### PR TITLE
Add stateless PersonalInvite contract, that is deployed using CREATE2

### DIFF
--- a/contracts/PersonalInviteCreate2.sol
+++ b/contracts/PersonalInviteCreate2.sol
@@ -21,7 +21,7 @@ contract PersonalInvite {
 
     event Deal(address indexed buyer, uint amount, uint tokenPrice, IERC20 currency, MintableERC20 indexed token);
 
-    constructor(address payable _buyer, address payable _receiver, uint _amount, uint _tokenPrice, uint _expiration, IERC20 _currency, MintableERC20 _token) {
+    constructor(address _buyer, address _receiver, uint _amount, uint _tokenPrice, uint _expiration, IERC20 _currency, MintableERC20 _token) {
         
         require(_buyer != address(0), "_buyer can not be zero address");
         require(_receiver != address(0), "_receiver can not be zero address");


### PR DESCRIPTION
Since we can know the address to which this contract will be deployed to, we can set this address as minter in the token contract, and the investor can give the contract the necessary allowance.

The investor accepts the deal (hence the `deal` function isn't needed anymore) by deploying the contract.
The execution of the deal happens in the constructor, therefore we don't need any state variables, which makes it very cheap gas-wise.
Additionally, the investor gets more privacy, as only accepted deals are on-chain and offers aren't.
