### PR TITLE
Feature/clone with upgradeable

### DIFF
--- a/contracts/CloneFactory.sol
+++ b/contracts/CloneFactory.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.17;
+
+import "@openzeppelin/contracts/proxy/Clones.sol";
+
+abstract contract CloneFactory {
+    event NewClone(address clone);
+
+    /// The address of the implementation to clone
+    address immutable implementation;
+
+    constructor(address _implementation) {
+        require(_implementation != address(0), "CloneFactory: implementation can not be zero");
+        implementation = _implementation;
+    }
+
+    /**
+     * @notice Predicts the address of a clone that will be created
+     * @param salt The salt used to deterministically generate the clone address
+     * @return The address of the clone that will be created
+     * @dev This function does not check if the clone has already been created
+     */
+    function predictCloneAddress(bytes32 salt) public view returns (address) {
+        return Clones.predictDeterministicAddress(implementation, salt);
+    }
+}

--- a/contracts/PersonalInvite.sol
+++ b/contracts/PersonalInvite.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.17;
 
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./Token.sol";
 
 /**

--- a/contracts/TokenCloneFactory.sol
+++ b/contracts/TokenCloneFactory.sol
@@ -11,6 +11,7 @@ contract TokenCloneFactory is CloneFactory {
 
     function createTokenClone(
         bytes32 salt,
+        address _trustedForwarder,
         IFeeSettingsV1 _feeSettings,
         address _admin,
         AllowList _allowList,
@@ -19,7 +20,9 @@ contract TokenCloneFactory is CloneFactory {
         string memory _symbol
     ) external returns (address) {
         address clone = Clones.cloneDeterministic(implementation, salt);
-        Token(clone).initialize(_feeSettings, _admin, _allowList, _requirements, _name, _symbol);
+        Token cloneToken = Token(clone);
+        require(cloneToken.isTrustedForwarder(_trustedForwarder), "TokenCloneFactory: Unexpected trustedForwarder");
+        cloneToken.initialize(_feeSettings, _admin, _allowList, _requirements, _name, _symbol);
         emit NewClone(clone);
         return clone;
     }

--- a/contracts/TokenCloneFactory.sol
+++ b/contracts/TokenCloneFactory.sol
@@ -10,7 +10,6 @@ contract TokenCloneFactory is CloneFactory {
     constructor(address _implementation) CloneFactory(_implementation) {}
 
     function createTokenClone(
-        bytes32 salt,
         address _trustedForwarder,
         IFeeSettingsV1 _feeSettings,
         address _admin,
@@ -19,11 +18,29 @@ contract TokenCloneFactory is CloneFactory {
         string memory _name,
         string memory _symbol
     ) external returns (address) {
+        bytes32 salt = keccak256(
+            abi.encodePacked(_trustedForwarder, _feeSettings, _admin, _allowList, _requirements, _name, _symbol)
+        );
         address clone = Clones.cloneDeterministic(implementation, salt);
         Token cloneToken = Token(clone);
         require(cloneToken.isTrustedForwarder(_trustedForwarder), "TokenCloneFactory: Unexpected trustedForwarder");
         cloneToken.initialize(_feeSettings, _admin, _allowList, _requirements, _name, _symbol);
         emit NewClone(clone);
         return clone;
+    }
+
+    function predictCloneAddress(
+        address _trustedForwarder,
+        IFeeSettingsV1 _feeSettings,
+        address _admin,
+        AllowList _allowList,
+        uint256 _requirements,
+        string memory _name,
+        string memory _symbol
+    ) external view returns (address) {
+        bytes32 salt = keccak256(
+            abi.encodePacked(_trustedForwarder, _feeSettings, _admin, _allowList, _requirements, _name, _symbol)
+        );
+        return Clones.predictDeterministicAddress(implementation, salt);
     }
 }

--- a/contracts/TokenCloneFactory.sol
+++ b/contracts/TokenCloneFactory.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.17;
+
+import "./Token.sol";
+import "./CloneFactory.sol";
+import "@openzeppelin/contracts/proxy/Clones.sol";
+
+contract TokenCloneFactory is CloneFactory {
+    constructor(address _implementation) CloneFactory(_implementation) {}
+
+    function createTokenClone(
+        bytes32 salt,
+        IFeeSettingsV1 _feeSettings,
+        address _admin,
+        AllowList _allowList,
+        uint256 _requirements,
+        string memory _name,
+        string memory _symbol
+    ) external returns (address) {
+        address clone = Clones.cloneDeterministic(implementation, salt);
+        Token(clone).initialize(_feeSettings, _admin, _allowList, _requirements, _name, _symbol);
+        emit NewClone(clone);
+        return clone;
+    }
+}

--- a/contracts/TokenCloneFactory.sol
+++ b/contracts/TokenCloneFactory.sol
@@ -10,6 +10,7 @@ contract TokenCloneFactory is CloneFactory {
     constructor(address _implementation) CloneFactory(_implementation) {}
 
     function createTokenClone(
+        bytes32 _rawSalt,
         address _trustedForwarder,
         IFeeSettingsV1 _feeSettings,
         address _admin,
@@ -19,7 +20,16 @@ contract TokenCloneFactory is CloneFactory {
         string memory _symbol
     ) external returns (address) {
         bytes32 salt = keccak256(
-            abi.encodePacked(_trustedForwarder, _feeSettings, _admin, _allowList, _requirements, _name, _symbol)
+            abi.encodePacked(
+                _rawSalt,
+                _trustedForwarder,
+                _feeSettings,
+                _admin,
+                _allowList,
+                _requirements,
+                _name,
+                _symbol
+            )
         );
         address clone = Clones.cloneDeterministic(implementation, salt);
         Token cloneToken = Token(clone);
@@ -30,6 +40,7 @@ contract TokenCloneFactory is CloneFactory {
     }
 
     function predictCloneAddress(
+        bytes32 _rawSalt,
         address _trustedForwarder,
         IFeeSettingsV1 _feeSettings,
         address _admin,
@@ -39,7 +50,16 @@ contract TokenCloneFactory is CloneFactory {
         string memory _symbol
     ) external view returns (address) {
         bytes32 salt = keccak256(
-            abi.encodePacked(_trustedForwarder, _feeSettings, _admin, _allowList, _requirements, _name, _symbol)
+            abi.encodePacked(
+                _rawSalt,
+                _trustedForwarder,
+                _feeSettings,
+                _admin,
+                _allowList,
+                _requirements,
+                _name,
+                _symbol
+            )
         );
         return Clones.predictDeterministicAddress(implementation, salt);
     }

--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
   },
   "dependencies": {
     "@opengsn/contracts": "2.2.5",
-    "@openzeppelin/contracts": "4.9.1"
+    "@openzeppelin/contracts": "4.9.1",
+    "@openzeppelin/contracts-upgradeable": "4.9.3"
   },
   "scripts": {
     "prepack": "yarn npmignore --auto && yarn test && yarn build ",

--- a/script/DeployCompany.sol
+++ b/script/DeployCompany.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.17;
 // taken from https://moveseventyeight.com/deploy-your-first-nft-contract-with-foundry#heading-prepare-a-basic-deployment-script
 
 import "../lib/forge-std/src/Script.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "../contracts/FeeSettings.sol";
 import "../contracts/AllowList.sol";
 import "../contracts/PersonalInviteFactory.sol";

--- a/test/ContinuousFundraising.t.sol
+++ b/test/ContinuousFundraising.t.sol
@@ -51,7 +51,7 @@ contract ContinuousFundraisingTest is Test {
         address tokenLogicContract = address(new Token(trustedForwarder));
         tokenCloneFactory = new TokenCloneFactory(tokenLogicContract);
         token = Token(
-            tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, list, 0x0, "TESTTOKEN", "TEST")
+            tokenCloneFactory.createTokenClone(0, trustedForwarder, feeSettings, admin, list, 0x0, "TESTTOKEN", "TEST")
         );
 
         // set up currency
@@ -178,6 +178,7 @@ contract ContinuousFundraisingTest is Test {
         list = new AllowList();
         Token _token = Token(
             tokenCloneFactory.createTokenClone(
+                0,
                 trustedForwarder,
                 feeSettings,
                 admin,

--- a/test/ContinuousFundraisingERC2771.t.sol
+++ b/test/ContinuousFundraisingERC2771.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../lib/forge-std/src/Test.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/ContinuousFundraising.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/FakePaymentToken.sol";
@@ -65,7 +65,10 @@ contract ContinuousFundraisingTest is Test {
         Fees memory fees = Fees(tokenFeeDenominator, paymentTokenFeeDenominator, paymentTokenFeeDenominator, 0);
         feeSettings = new FeeSettings(fees, admin);
 
-        token = new Token(trustedForwarder, feeSettings, admin, list, 0x0, "TESTTOKEN", "TEST");
+        Token implementation = new Token(trustedForwarder);
+        TokenCloneFactory factory = new TokenCloneFactory(address(implementation));
+        token = Token(factory.createTokenClone(trustedForwarder, feeSettings, admin, list, 0x0, "TESTTOKEN", "TEST"));
+
         ERC2771helper = new ERC2771Helper();
 
         buyer = vm.addr(buyerPrivateKey);

--- a/test/ContinuousFundraisingERC2771.t.sol
+++ b/test/ContinuousFundraisingERC2771.t.sol
@@ -67,7 +67,9 @@ contract ContinuousFundraisingTest is Test {
 
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory factory = new TokenCloneFactory(address(implementation));
-        token = Token(factory.createTokenClone(trustedForwarder, feeSettings, admin, list, 0x0, "TESTTOKEN", "TEST"));
+        token = Token(
+            factory.createTokenClone(0, trustedForwarder, feeSettings, admin, list, 0x0, "TESTTOKEN", "TEST")
+        );
 
         ERC2771helper = new ERC2771Helper();
 

--- a/test/ContinuousFundraisingIntegration.t.sol
+++ b/test/ContinuousFundraisingIntegration.t.sol
@@ -43,7 +43,7 @@ contract ContinuousFundraisingTest is Test {
         feeSettings = new FeeSettings(fees, platformAdmin);
         vm.prank(platformAdmin);
         token = Token(
-            factory.createTokenClone(trustedForwarder, feeSettings, companyOwner, list, 0x0, "TESTTOKEN", "TEST")
+            factory.createTokenClone(0, trustedForwarder, feeSettings, companyOwner, list, 0x0, "TESTTOKEN", "TEST")
         );
 
         // set up currency
@@ -119,7 +119,7 @@ contract ContinuousFundraisingTest is Test {
 
         list = new AllowList();
         Token _token = Token(
-            factory.createTokenClone(trustedForwarder, feeSettings, companyOwner, list, 0x0, "FEETESTTOKEN", "TEST")
+            factory.createTokenClone(0, trustedForwarder, feeSettings, companyOwner, list, 0x0, "FEETESTTOKEN", "TEST")
         );
 
         vm.prank(paymentTokenProvider);
@@ -223,6 +223,7 @@ contract ContinuousFundraisingTest is Test {
             list = new AllowList();
             Token _token = Token(
                 factory.createTokenClone(
+                    0,
                     trustedForwarder,
                     feeSettings,
                     companyOwner,

--- a/test/ContinuousFundraisingIntegration.t.sol
+++ b/test/ContinuousFundraisingIntegration.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../lib/forge-std/src/Test.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/ContinuousFundraising.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/FakePaymentToken.sol";
@@ -13,6 +13,8 @@ contract ContinuousFundraisingTest is Test {
     AllowList list;
     FeeSettings feeSettings;
 
+    Token implementation = new Token(trustedForwarder);
+    TokenCloneFactory factory = new TokenCloneFactory(address(implementation));
     Token token;
     FakePaymentToken paymentToken;
 
@@ -40,7 +42,9 @@ contract ContinuousFundraisingTest is Test {
         vm.prank(platformAdmin);
         feeSettings = new FeeSettings(fees, platformAdmin);
         vm.prank(platformAdmin);
-        token = new Token(trustedForwarder, feeSettings, companyOwner, list, 0x0, "TESTTOKEN", "TEST");
+        token = Token(
+            factory.createTokenClone(trustedForwarder, feeSettings, companyOwner, list, 0x0, "TESTTOKEN", "TEST")
+        );
 
         // set up currency
         vm.prank(paymentTokenProvider);
@@ -114,7 +118,10 @@ contract ContinuousFundraisingTest is Test {
         uint256 _paymentTokenAmount = 1000 * 10 ** _paymentTokenDecimals;
 
         list = new AllowList();
-        Token _token = new Token(trustedForwarder, feeSettings, platformAdmin, list, 0x0, "TESTTOKEN", "TEST");
+        Token _token = Token(
+            factory.createTokenClone(trustedForwarder, feeSettings, companyOwner, list, 0x0, "FEETESTTOKEN", "TEST")
+        );
+
         vm.prank(paymentTokenProvider);
         _paymentToken = new FakePaymentToken(_paymentTokenAmount, _paymentTokenDecimals);
         vm.prank(companyOwner);
@@ -133,7 +140,7 @@ contract ContinuousFundraisingTest is Test {
         // allow invite contract to mint
         bytes32 roleMintAllower = token.MINTALLOWER_ROLE();
 
-        vm.prank(platformAdmin);
+        vm.prank(companyOwner);
         _token.grantRole(roleMintAllower, mintAllower);
         vm.prank(mintAllower);
         _token.increaseMintingAllowance(address(_raise), _maxMintAmount);
@@ -214,7 +221,18 @@ contract ContinuousFundraisingTest is Test {
             uint256 _paymentTokenAmount = 1000 * 10 ** _paymentTokenDecimals;
 
             list = new AllowList();
-            Token _token = new Token(trustedForwarder, feeSettings, platformAdmin, list, 0x0, "TESTTOKEN", "TEST");
+            Token _token = Token(
+                factory.createTokenClone(
+                    trustedForwarder,
+                    feeSettings,
+                    companyOwner,
+                    list,
+                    0x0,
+                    "DECIMALSTESTTOKEN",
+                    "TEST"
+                )
+            );
+
             vm.prank(paymentTokenProvider);
             _paymentToken = new FakePaymentToken(_paymentTokenAmount, _paymentTokenDecimals);
             vm.prank(companyOwner);
@@ -232,7 +250,7 @@ contract ContinuousFundraisingTest is Test {
             // allow invite contract to mint
             bytes32 roleMintAllower = token.MINTALLOWER_ROLE();
 
-            vm.prank(platformAdmin);
+            vm.prank(companyOwner);
             _token.grantRole(roleMintAllower, mintAllower);
             vm.prank(mintAllower);
             _token.increaseMintingAllowance(address(_raise), _maxMintAmount);

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../lib/forge-std/src/Test.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/ERC2771Helper.sol";
@@ -89,7 +89,19 @@ contract TokenERC2771Test is Test {
         uint256 _tokenMintAmount = 1000 * 10 ** 18;
 
         // deploy company token
-        token = new Token(address(_forwarder), feeSettings, companyAdmin, allowList, 0x0, "TESTTOKEN", "TEST");
+        Token implementation = new Token(address(_forwarder));
+        TokenCloneFactory factory = new TokenCloneFactory(address(implementation));
+        token = Token(
+            factory.createTokenClone(
+                address(_forwarder),
+                feeSettings,
+                companyAdmin,
+                allowList,
+                0x0,
+                "TESTTOKEN",
+                "TEST"
+            )
+        );
 
         // deploy fundraising
         paymentToken = new FakePaymentToken(6 * 10 ** 18, 18);

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -93,6 +93,7 @@ contract TokenERC2771Test is Test {
         TokenCloneFactory factory = new TokenCloneFactory(address(implementation));
         token = Token(
             factory.createTokenClone(
+                0,
                 address(_forwarder),
                 feeSettings,
                 companyAdmin,

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.13;
 import "../lib/forge-std/src/Test.sol";
 //import "../lib/forge-std/stdlib.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/ContinuousFundraising.sol";
 import "../contracts/PersonalInvite.sol";
 import "../contracts/PersonalInviteFactory.sol";
@@ -62,7 +62,12 @@ contract MainnetCurrencies is Test {
         Fees memory fees = Fees(100, 100, 100, 0);
         feeSettings = new FeeSettings(fees, admin);
 
-        token = new Token(trustedForwarder, feeSettings, admin, list, 0x0, "TESTTOKEN", "TEST");
+        Token implementation = new Token(trustedForwarder);
+        TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
+        token = Token(
+            tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, list, 0x0, "TESTTOKEN", "TEST")
+        );
+
         factory = new PersonalInviteFactory();
         currencyCost = (amountOfTokenToBuy * price) / 10 ** token.decimals();
         currencyAmount = currencyCost * 2;
@@ -187,7 +192,7 @@ contract MainnetCurrencies is Test {
             price,
             expiration,
             _currency,
-            token
+            IERC20(address(token))
         );
 
         // grant mint allowance to invite
@@ -215,7 +220,7 @@ contract MainnetCurrencies is Test {
             price,
             expiration,
             _currency,
-            token
+            IERC20(address(token))
         );
 
         // check situation after deployment

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -65,7 +65,7 @@ contract MainnetCurrencies is Test {
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
         token = Token(
-            tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, list, 0x0, "TESTTOKEN", "TEST")
+            tokenCloneFactory.createTokenClone(0, trustedForwarder, feeSettings, admin, list, 0x0, "TESTTOKEN", "TEST")
         );
 
         factory = new PersonalInviteFactory();

--- a/test/PersonalInvite.t.sol
+++ b/test/PersonalInvite.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../lib/forge-std/src/Test.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/PersonalInvite.sol";
 import "../contracts/PersonalInviteFactory.sol";
 import "../contracts/FeeSettings.sol";
@@ -49,7 +49,12 @@ contract PersonalInviteTest is Test {
         Fees memory fees = Fees(100, 100, 100, 0);
         feeSettings = new FeeSettings(fees, admin);
 
-        token = new Token(trustedForwarder, feeSettings, admin, list, requirements, "token", "TOK");
+        Token implementation = new Token(trustedForwarder);
+        TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
+        token = Token(
+            tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, list, requirements, "token", "TOK")
+        );
+
         vm.prank(paymentTokenProvider);
         currency = new FakePaymentToken(0, 18);
     }
@@ -76,7 +81,7 @@ contract PersonalInviteTest is Test {
             price,
             expiration,
             currency,
-            token
+            IERC20(address(token))
         );
 
         uint256 tokenDecimals = token.decimals();
@@ -123,7 +128,7 @@ contract PersonalInviteTest is Test {
             price,
             expiration,
             currency,
-            token
+            IERC20(address(token))
         );
 
         console.log(
@@ -189,7 +194,7 @@ contract PersonalInviteTest is Test {
             _nominalPrice,
             expiration,
             currency,
-            token
+            IERC20(address(token))
         );
 
         // set fees to 0, otherwise extra tokens are minted which causes an overflow
@@ -243,7 +248,7 @@ contract PersonalInviteTest is Test {
             _nominalPrice,
             expiration,
             currency,
-            token
+            IERC20(address(token))
         );
 
         console.log(
@@ -327,7 +332,7 @@ contract PersonalInviteTest is Test {
             _nominalPrice,
             expiration,
             currency,
-            token
+            IERC20(address(token))
         );
 
         vm.startPrank(admin);
@@ -354,7 +359,7 @@ contract PersonalInviteTest is Test {
             _nominalPrice,
             expiration,
             currency,
-            token
+            IERC20(address(token))
         );
     }
 
@@ -388,7 +393,7 @@ contract PersonalInviteTest is Test {
             price,
             expiration,
             currency,
-            token
+            IERC20(address(token))
         );
 
         vm.prank(admin);
@@ -423,7 +428,7 @@ contract PersonalInviteTest is Test {
             price,
             expiration,
             currency,
-            token
+            IERC20(address(token))
         );
 
         console.log(

--- a/test/PersonalInvite.t.sol
+++ b/test/PersonalInvite.t.sol
@@ -52,7 +52,16 @@ contract PersonalInviteTest is Test {
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
         token = Token(
-            tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, list, requirements, "token", "TOK")
+            tokenCloneFactory.createTokenClone(
+                0,
+                trustedForwarder,
+                feeSettings,
+                admin,
+                list,
+                requirements,
+                "token",
+                "TOK"
+            )
         );
 
         vm.prank(paymentTokenProvider);

--- a/test/PersonalInviteFactory.t.sol
+++ b/test/PersonalInviteFactory.t.sol
@@ -40,10 +40,10 @@ contract PersonalInviteFactoryTest is Test {
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
         token = Token(
-            tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, list, 0x0, "token", "TOK")
+            tokenCloneFactory.createTokenClone(0, trustedForwarder, feeSettings, admin, list, 0x0, "token", "TOK")
         );
         currency = Token(
-            tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, list, 0x0, "currency", "CUR")
+            tokenCloneFactory.createTokenClone(0, trustedForwarder, feeSettings, admin, list, 0x0, "currency", "CUR")
         );
     }
 

--- a/test/PersonalInviteFactory.t.sol
+++ b/test/PersonalInviteFactory.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../lib/forge-std/src/Test.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/PersonalInvite.sol";
 import "../contracts/PersonalInviteFactory.sol";
 import "../contracts/FeeSettings.sol";
@@ -31,40 +31,20 @@ contract PersonalInviteFactoryTest is Test {
 
     uint256 public constant price = 10000000;
 
-    // function calcAddress(bytes memory bytecode, uint salt, address sender) public pure returns (address) {
-    //     bytes32 saltBytes = bytes32(salt);
-    //     bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), sender, saltBytes, keccak256(bytecode)));
-    //     return address(uint160(uint256(hash)));
-    // }
-
-    // function testCalcAddressWithExample() public view {
-    //     // example taken from https://docs.ethers.io/v5/api/utils/address/#utils-getCreate2Address
-    //     address sender = 0x8ba1f109551bD432803012645Ac136ddd64DBA72;
-    //     uint salt = 0x7c5ea36004851c764c44143b1dcb59679b11c9a68e5f41497f6cf3d480715331;
-    //     string memory hexString = "0x6394198df16000526103ff60206004601c335afa6040516060f3";
-    //     bytes memory bytecode = bytes(hexString);
-
-    //     address actual = calcAddress(bytecode, salt, sender);
-    //     address expected = 0x533ae9d683B10C02EbDb05471642F85230071FC3;
-
-    //     console.log("bytecode: %s", string(bytecode));
-
-    //     console.log("actual: %s", actual);
-    //     console.log("expected: %s", expected);
-    //     //assertEq(actual, expected);
-
-    //     // TODO: figure out why this fails
-
-    // }
-
     function setUp() public {
         factory = new PersonalInviteFactory();
         list = new AllowList();
         Fees memory fees = Fees(100, 100, 100, 0);
         feeSettings = new FeeSettings(fees, admin);
 
-        token = new Token(trustedForwarder, feeSettings, admin, list, 0x0, "token", "TOK");
-        currency = new Token(trustedForwarder, feeSettings, admin, list, 0x0, "currency", "CUR");
+        Token implementation = new Token(trustedForwarder);
+        TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
+        token = Token(
+            tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, list, 0x0, "token", "TOK")
+        );
+        currency = Token(
+            tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, list, 0x0, "currency", "CUR")
+        );
     }
 
     function testDeployContract(uint256 rawSalt) public {
@@ -83,8 +63,8 @@ contract PersonalInviteFactoryTest is Test {
             amount,
             price,
             expiration,
-            currency,
-            token
+            IERC20(address(currency)),
+            IERC20(address(token))
         );
 
         // make sure no contract lives here yet
@@ -107,7 +87,17 @@ contract PersonalInviteFactoryTest is Test {
 
         vm.expectEmit(true, true, true, true, address(factory));
         emit Deploy(expectedAddress);
-        factory.deploy(salt, buyer, buyer, receiver, amount, price, expiration, currency, token);
+        factory.deploy(
+            salt,
+            buyer,
+            buyer,
+            receiver,
+            amount,
+            price,
+            expiration,
+            IERC20(address(currency)),
+            IERC20(address(token))
+        );
 
         // make sure contract lives here now
         assembly {

--- a/test/PersonalInviteTimeLock.t.sol
+++ b/test/PersonalInviteTimeLock.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../lib/forge-std/src/Test.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/PersonalInvite.sol";
 import "../contracts/PersonalInviteFactory.sol";
 import "../contracts/VestingWalletFactory.sol";
@@ -44,7 +44,12 @@ contract PersonalInviteTimeLockTest is Test {
         Fees memory fees = Fees(100, 100, 100, 0);
         feeSettings = new FeeSettings(fees, admin);
 
-        token = new Token(trustedForwarder, feeSettings, admin, list, requirements, "token", "TOK");
+        Token implementation = new Token(trustedForwarder);
+        TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
+        token = Token(
+            tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, list, requirements, "token", "TOK")
+        );
+
         vm.prank(paymentTokenProvider);
         currency = new FakePaymentToken(0, 18);
     }
@@ -141,7 +146,7 @@ contract PersonalInviteTimeLockTest is Test {
             price,
             expiration,
             currency,
-            token
+            IERC20(address(token))
         );
 
         vm.prank(admin);
@@ -185,7 +190,7 @@ contract PersonalInviteTimeLockTest is Test {
             price,
             expiration,
             currency,
-            token
+            IERC20(address(token))
         );
 
         assertEq(inviteAddress, expectedInviteAddress, "deployed contract address is not correct");

--- a/test/PersonalInviteTimeLock.t.sol
+++ b/test/PersonalInviteTimeLock.t.sol
@@ -47,7 +47,16 @@ contract PersonalInviteTimeLockTest is Test {
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
         token = Token(
-            tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, list, requirements, "token", "TOK")
+            tokenCloneFactory.createTokenClone(
+                0,
+                trustedForwarder,
+                feeSettings,
+                admin,
+                list,
+                requirements,
+                "token",
+                "TOK"
+            )
         );
 
         vm.prank(paymentTokenProvider);

--- a/test/SetUpExampleCompany.t.sol
+++ b/test/SetUpExampleCompany.t.sol
@@ -137,6 +137,7 @@ contract CompanySetUpTest is Test {
         vm.startPrank(platformHotWallet);
         token = Token(
             tokenCloneFactory.createTokenClone(
+                0,
                 address(forwarder),
                 feeSettings,
                 companyAdmin,

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../lib/forge-std/src/Test.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/FeeSettings.sol";
 
 contract tokenTest is Test {
@@ -10,6 +10,9 @@ contract tokenTest is Test {
     event MintingAllowanceChanged(address indexed minter, uint256 newAllowance);
 
     Token token;
+    Token implementation = new Token(trustedForwarder);
+    TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
+
     AllowList allowList;
     FeeSettings feeSettings;
     address public constant trustedForwarder = 0x9109709EcFA91A80626FF3989D68f67F5B1dD129;
@@ -29,7 +32,17 @@ contract tokenTest is Test {
         vm.prank(feeSettingsOwner);
         Fees memory fees = Fees(100, 100, 100, 0);
         feeSettings = new FeeSettings(fees, admin);
-        token = new Token(trustedForwarder, feeSettings, admin, allowList, 0x0, "testToken", "TEST");
+        token = Token(
+            tokenCloneFactory.createTokenClone(
+                trustedForwarder,
+                feeSettings,
+                admin,
+                allowList,
+                0x0,
+                "testToken",
+                "TEST"
+            )
+        );
 
         // set up roles
         vm.startPrank(admin);
@@ -61,19 +74,35 @@ contract tokenTest is Test {
     function testAllowList0() public {
         AllowList _noList = AllowList(address(0));
         vm.expectRevert("AllowList must not be zero address");
-        new Token(trustedForwarder, feeSettings, admin, _noList, 0x0, "testToken", "TEST");
+        tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, _noList, 0x0, "testToken", "TEST");
     }
 
     function testFeeSettings0() public {
         FeeSettings _noFeeSettings = FeeSettings(address(0));
         console.log("fee settings address:", address(_noFeeSettings));
         vm.expectRevert();
-        new Token(trustedForwarder, _noFeeSettings, admin, allowList, 0x0, "testToken", "TEST");
+        tokenCloneFactory.createTokenClone(
+            trustedForwarder,
+            _noFeeSettings,
+            admin,
+            allowList,
+            0x0,
+            "testToken",
+            "TEST"
+        );
     }
 
     function testFeeSettingsNoERC165() public {
         vm.expectRevert();
-        new Token(trustedForwarder, FeeSettings(address(allowList)), admin, allowList, 0x0, "testToken", "TEST");
+        tokenCloneFactory.createTokenClone(
+            trustedForwarder,
+            FeeSettings(address(allowList)),
+            admin,
+            allowList,
+            0x0,
+            "testToken",
+            "TEST"
+        );
     }
 
     function testFailAdmin() public {
@@ -1001,7 +1030,17 @@ contract tokenTest is Test {
     }
 
     function testDeployerDoesNotGetRole() public {
-        Token localToken = new Token(trustedForwarder, feeSettings, admin, allowList, 0x0, "testToken", "TEST");
+        Token localToken = Token(
+            tokenCloneFactory.createTokenClone(
+                trustedForwarder,
+                feeSettings,
+                admin,
+                allowList,
+                0x0,
+                "testTokenRole",
+                "TEST"
+            )
+        );
         address deployer = msg.sender;
         assertFalse(localToken.hasRole(localToken.REQUIREMENT_ROLE(), deployer));
         assertFalse(localToken.hasRole(localToken.MINTALLOWER_ROLE(), deployer));

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -34,6 +34,7 @@ contract tokenTest is Test {
         feeSettings = new FeeSettings(fees, admin);
         token = Token(
             tokenCloneFactory.createTokenClone(
+                0,
                 trustedForwarder,
                 feeSettings,
                 admin,
@@ -74,7 +75,7 @@ contract tokenTest is Test {
     function testAllowList0() public {
         AllowList _noList = AllowList(address(0));
         vm.expectRevert("AllowList must not be zero address");
-        tokenCloneFactory.createTokenClone(trustedForwarder, feeSettings, admin, _noList, 0x0, "testToken", "TEST");
+        tokenCloneFactory.createTokenClone(0, trustedForwarder, feeSettings, admin, _noList, 0x0, "testToken", "TEST");
     }
 
     function testFeeSettings0() public {
@@ -82,6 +83,7 @@ contract tokenTest is Test {
         console.log("fee settings address:", address(_noFeeSettings));
         vm.expectRevert();
         tokenCloneFactory.createTokenClone(
+            0,
             trustedForwarder,
             _noFeeSettings,
             admin,
@@ -95,6 +97,7 @@ contract tokenTest is Test {
     function testFeeSettingsNoERC165() public {
         vm.expectRevert();
         tokenCloneFactory.createTokenClone(
+            0,
             trustedForwarder,
             FeeSettings(address(allowList)),
             admin,
@@ -1032,6 +1035,7 @@ contract tokenTest is Test {
     function testDeployerDoesNotGetRole() public {
         Token localToken = Token(
             tokenCloneFactory.createTokenClone(
+                0,
                 trustedForwarder,
                 feeSettings,
                 admin,

--- a/test/TokenCloneFactory.t.sol
+++ b/test/TokenCloneFactory.t.sol
@@ -41,6 +41,7 @@ contract tokenTest is Test {
     }
 
     function testAddressPrediction(
+        bytes32 _salt,
         address _admin,
         AllowList _allowList,
         uint256 _requirements,
@@ -52,10 +53,11 @@ contract tokenTest is Test {
         vm.assume(address(_allowList) != address(0));
 
         bytes32 salt = keccak256(
-            abi.encodePacked(trustedForwarder, feeSettings, _admin, _allowList, _requirements, _name, _symbol)
+            abi.encodePacked(_salt, trustedForwarder, feeSettings, _admin, _allowList, _requirements, _name, _symbol)
         );
         address expected1 = factory.predictCloneAddress(salt);
         address expected2 = factory.predictCloneAddress(
+            _salt,
             trustedForwarder,
             feeSettings,
             _admin,
@@ -67,6 +69,7 @@ contract tokenTest is Test {
         assertEq(expected1, expected2, "address prediction with salt and params not equal");
 
         address actual = factory.createTokenClone(
+            _salt,
             trustedForwarder,
             feeSettings,
             _admin,
@@ -76,6 +79,42 @@ contract tokenTest is Test {
             _symbol
         );
         assertEq(expected1, actual, "address prediction failed");
+    }
+
+    function testSecondDeploymentFails(
+        bytes32 _salt,
+        address _admin,
+        AllowList _allowList,
+        uint256 _requirements,
+        string memory _name,
+        string memory _symbol
+    ) public {
+        vm.assume(trustedForwarder != address(0));
+        vm.assume(_admin != address(0));
+        vm.assume(address(_allowList) != address(0));
+
+        address clone = factory.createTokenClone(
+            _salt,
+            trustedForwarder,
+            feeSettings,
+            _admin,
+            _allowList,
+            _requirements,
+            _name,
+            _symbol
+        );
+
+        vm.expectRevert("create2 failed");
+        factory.createTokenClone(
+            _salt,
+            trustedForwarder,
+            feeSettings,
+            _admin,
+            _allowList,
+            _requirements,
+            _name,
+            _symbol
+        );
     }
 
     function testInitialization(
@@ -97,6 +136,7 @@ contract tokenTest is Test {
 
         Token clone = Token(
             factory.createTokenClone(
+                0,
                 trustedForwarder,
                 _feeSettings,
                 _admin,
@@ -156,6 +196,7 @@ contract tokenTest is Test {
 
         Token _token = Token(
             factory.createTokenClone(
+                0,
                 trustedForwarder,
                 _feeSettings,
                 _admin,
@@ -200,6 +241,7 @@ contract tokenTest is Test {
 
         Token _token = Token(
             factory.createTokenClone(
+                0,
                 trustedForwarder,
                 _feeSettings,
                 admin,
@@ -253,6 +295,7 @@ contract tokenTest is Test {
 
         Token clone = Token(
             factory.createTokenClone(
+                0,
                 trustedForwarder,
                 feeSettings,
                 _admin,

--- a/test/TokenCloneFactory.t.sol
+++ b/test/TokenCloneFactory.t.sol
@@ -104,7 +104,7 @@ contract tokenTest is Test {
             _symbol
         );
 
-        vm.expectRevert("create2 failed");
+        vm.expectRevert("ERC1167: create2 failed");
         factory.createTokenClone(
             _salt,
             trustedForwarder,

--- a/test/TokenCloneFactory.t.sol
+++ b/test/TokenCloneFactory.t.sol
@@ -313,8 +313,9 @@ contract tokenTest is Test {
         assertEq(clone.balanceOf(_tokenSpender), 0);
 
         // spend tokens
-        vm.prank(_tokenSpender);
+        vm.startPrank(_tokenSpender);
         clone.transferFrom(tokenOwner, _tokenSpender, _tokenPermitAmount);
+        vm.stopPrank();
 
         // check token balances after transfer
         assertEq(clone.balanceOf(tokenOwner), 0);

--- a/test/TokenCloneFactory.t.sol
+++ b/test/TokenCloneFactory.t.sol
@@ -40,23 +40,45 @@ contract tokenTest is Test {
         factory = new TokenCloneFactory(address(implementation));
     }
 
-    function testAddressPrediction(bytes32 salt) public {
-        address expected = factory.predictCloneAddress(salt);
-        address actual = factory.createTokenClone(
-            salt,
+    function testAddressPrediction(
+        address _admin,
+        AllowList _allowList,
+        uint256 _requirements,
+        string memory _name,
+        string memory _symbol
+    ) public {
+        vm.assume(trustedForwarder != address(0));
+        vm.assume(_admin != address(0));
+        vm.assume(address(_allowList) != address(0));
+
+        bytes32 salt = keccak256(
+            abi.encodePacked(trustedForwarder, feeSettings, _admin, _allowList, _requirements, _name, _symbol)
+        );
+        address expected1 = factory.predictCloneAddress(salt);
+        address expected2 = factory.predictCloneAddress(
             trustedForwarder,
             feeSettings,
-            admin,
-            allowList,
-            requirements,
-            "testToken",
-            "TEST"
+            _admin,
+            _allowList,
+            _requirements,
+            _name,
+            _symbol
         );
-        assertEq(expected, actual, "address prediction failed");
+        assertEq(expected1, expected2, "address prediction with salt and params not equal");
+
+        address actual = factory.createTokenClone(
+            trustedForwarder,
+            feeSettings,
+            _admin,
+            _allowList,
+            _requirements,
+            _name,
+            _symbol
+        );
+        assertEq(expected1, actual, "address prediction failed");
     }
 
     function testInitialization(
-        bytes32 salt,
         string memory name,
         string memory symbol,
         address _admin,
@@ -75,7 +97,6 @@ contract tokenTest is Test {
 
         Token clone = Token(
             factory.createTokenClone(
-                salt,
                 trustedForwarder,
                 _feeSettings,
                 _admin,
@@ -135,7 +156,6 @@ contract tokenTest is Test {
 
         Token _token = Token(
             factory.createTokenClone(
-                0,
                 trustedForwarder,
                 _feeSettings,
                 _admin,
@@ -180,7 +200,6 @@ contract tokenTest is Test {
 
         Token _token = Token(
             factory.createTokenClone(
-                0,
                 trustedForwarder,
                 _feeSettings,
                 admin,
@@ -213,7 +232,6 @@ contract tokenTest is Test {
     }
 
     function testPermitWithClone(
-        bytes32 salt,
         string memory name,
         string memory symbol,
         address _admin,
@@ -235,7 +253,6 @@ contract tokenTest is Test {
 
         Token clone = Token(
             factory.createTokenClone(
-                salt,
                 trustedForwarder,
                 feeSettings,
                 _admin,

--- a/test/TokenCloneFactory.t.sol
+++ b/test/TokenCloneFactory.t.sol
@@ -93,7 +93,7 @@ contract tokenTest is Test {
         vm.assume(_admin != address(0));
         vm.assume(address(_allowList) != address(0));
 
-        address clone = factory.createTokenClone(
+        factory.createTokenClone(
             _salt,
             trustedForwarder,
             feeSettings,

--- a/test/TokenCloneFactory.t.sol
+++ b/test/TokenCloneFactory.t.sol
@@ -1,0 +1,306 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.13;
+
+import "../lib/forge-std/src/Test.sol";
+import "../contracts/TokenCloneFactory.sol";
+import "../contracts/FeeSettings.sol";
+import "./resources/ERC2771Helper.sol";
+
+contract tokenTest is Test {
+    using ECDSA for bytes32;
+
+    Token implementation;
+    AllowList allowList;
+    FeeSettings feeSettings;
+    TokenCloneFactory factory;
+    address public constant trustedForwarder = 0x9109709EcFA91A80626FF3989D68f67F5B1dD129;
+    address public constant admin = 0x0109709eCFa91a80626FF3989D68f67f5b1dD120;
+    address public constant requirer = 0x1109709ecFA91a80626ff3989D68f67F5B1Dd121;
+    address public constant mintAllower = 0x2109709EcFa91a80626Ff3989d68F67F5B1Dd122;
+    address public constant minter = 0x3109709ECfA91A80626fF3989D68f67F5B1Dd123;
+    address public constant burner = 0x4109709eCFa91A80626ff3989d68F67f5b1DD124;
+    address public constant transfererAdmin = 0x5109709EcFA91a80626ff3989d68f67F5B1dD125;
+    address public constant transferer = 0x6109709EcFA91A80626FF3989d68f67F5b1dd126;
+    address public constant pauser = 0x7109709eCfa91A80626Ff3989D68f67f5b1dD127;
+    address public constant feeSettingsAndAllowListOwner = 0x8109709ecfa91a80626fF3989d68f67F5B1dD128;
+
+    uint256 requirements = 0;
+
+    event RequirementsChanged(uint256 newRequirements);
+
+    function setUp() public {
+        vm.startPrank(feeSettingsAndAllowListOwner);
+        allowList = new AllowList();
+        Fees memory fees = Fees(100, 100, 100, 0);
+        feeSettings = new FeeSettings(fees, feeSettingsAndAllowListOwner);
+        vm.stopPrank();
+
+        implementation = new Token(trustedForwarder);
+
+        factory = new TokenCloneFactory(address(implementation));
+    }
+
+    function testAddressPrediction(bytes32 salt) public {
+        address expected = factory.predictCloneAddress(salt);
+        address actual = factory.createTokenClone(
+            salt,
+            trustedForwarder,
+            feeSettings,
+            admin,
+            allowList,
+            requirements,
+            "testToken",
+            "TEST"
+        );
+        assertEq(expected, actual, "address prediction failed");
+    }
+
+    function testInitialization(
+        bytes32 salt,
+        string memory name,
+        string memory symbol,
+        address _admin,
+        address _allowList,
+        uint256 _requirements
+    ) public {
+        vm.assume(_admin != address(0));
+        vm.assume(_allowList != address(0));
+        vm.assume(keccak256(abi.encodePacked(name)) != keccak256(abi.encodePacked("")));
+        vm.assume(keccak256(abi.encodePacked(symbol)) != keccak256(abi.encodePacked("")));
+
+        console.log("name: %s", name);
+        console.log("symbol: %s", symbol);
+
+        FeeSettings _feeSettings = new FeeSettings(Fees(100, 100, 100, 0), feeSettingsAndAllowListOwner);
+
+        Token clone = Token(
+            factory.createTokenClone(
+                salt,
+                trustedForwarder,
+                _feeSettings,
+                _admin,
+                AllowList(_allowList),
+                _requirements,
+                name,
+                symbol
+            )
+        );
+
+        // test constructor arguments are used
+        assertEq(clone.name(), name, "name not set");
+        assertEq(clone.symbol(), symbol, "symbol not set");
+        assertTrue(clone.hasRole(clone.DEFAULT_ADMIN_ROLE(), _admin), "admin not set");
+        assertEq(address(clone.allowList()), _allowList, "allowList not set");
+        assertEq(clone.requirements(), _requirements, "requirements not set");
+        assertEq(address(clone.feeSettings()), address(_feeSettings), "feeSettings not set");
+
+        // check trustedForwarder is set
+        assertTrue(clone.isTrustedForwarder(trustedForwarder), "trustedForwarder not set");
+
+        // test roles are assigned
+        assertTrue(clone.hasRole(clone.REQUIREMENT_ROLE(), _admin), "requirer not set");
+        assertTrue(clone.hasRole(clone.MINTALLOWER_ROLE(), _admin), "mintAllower not set");
+        assertTrue(clone.hasRole(clone.BURNER_ROLE(), _admin), "burner not set");
+        assertTrue(clone.hasRole(clone.TRANSFERERADMIN_ROLE(), _admin), "transfererAdmin not set");
+        assertTrue(clone.hasRole(clone.PAUSER_ROLE(), _admin), "pauser not set");
+
+        // test EIP712 Domain Separator is set correctly
+        string memory domainSeparatorName;
+        string memory domainSeparatorVersion;
+        uint256 domainSeparatorChainId;
+        address domainSeparatorAddress;
+
+        (, domainSeparatorName, domainSeparatorVersion, domainSeparatorChainId, domainSeparatorAddress, , ) = clone
+            .eip712Domain();
+
+        assertEq(domainSeparatorName, name, "domainSeparatorName not set");
+        assertEq(domainSeparatorVersion, "1", "domainSeparatorVersion not set");
+        assertEq(domainSeparatorChainId, block.chainid, "domainSeparatorChainId not set");
+        assertEq(domainSeparatorAddress, address(clone), "domainSeparatorAddress not set");
+
+        // test contract can not be initialized again
+        vm.expectRevert("Initializable: contract is already initialized");
+        clone.initialize(feeSettings, admin, allowList, requirements, "testToken", "TEST");
+    }
+
+    /*
+        pausing and unpausing
+    */
+    function testPausing(address _admin, address rando) public {
+        vm.assume(_admin != address(0));
+        vm.assume(rando != address(0));
+        vm.assume(rando != _admin);
+
+        FeeSettings _feeSettings = new FeeSettings(Fees(100, 100, 100, 0), feeSettingsAndAllowListOwner);
+
+        Token _token = Token(
+            factory.createTokenClone(
+                0,
+                trustedForwarder,
+                _feeSettings,
+                _admin,
+                AllowList(address(3)),
+                0,
+                "TestToken",
+                "TST"
+            )
+        );
+
+        vm.prank(rando);
+        vm.expectRevert();
+        _token.pause();
+
+        vm.prank(rando);
+        vm.expectRevert();
+        _token.unpause();
+
+        assertFalse(_token.paused());
+        vm.prank(_admin);
+        _token.pause();
+        assertTrue(_token.paused());
+
+        // can't transfer when paused
+        vm.prank(rando);
+        vm.expectRevert("Pausable: paused");
+        _token.transfer(_admin, 1);
+
+        vm.prank(_admin);
+        _token.unpause();
+        assertFalse(_token.paused());
+    }
+
+    /*
+        granting role
+    */
+    function testGrantRole(address newPauser) public {
+        vm.assume(newPauser != address(0));
+        vm.assume(newPauser != admin);
+
+        FeeSettings _feeSettings = new FeeSettings(Fees(100, 100, 100, 0), feeSettingsAndAllowListOwner);
+
+        Token _token = Token(
+            factory.createTokenClone(
+                0,
+                trustedForwarder,
+                _feeSettings,
+                admin,
+                AllowList(address(3)),
+                0,
+                "TestToken",
+                "TST"
+            )
+        );
+
+        bytes32 pauserRole = _token.PAUSER_ROLE();
+
+        assertFalse(_token.hasRole(pauserRole, newPauser));
+
+        vm.expectRevert();
+        vm.prank(newPauser);
+        _token.pause();
+
+        vm.prank(admin);
+        _token.grantRole(pauserRole, newPauser);
+
+        assertTrue(_token.hasRole(pauserRole, newPauser));
+
+        assertFalse(_token.paused());
+
+        vm.prank(newPauser);
+        _token.pause();
+
+        assertTrue(_token.paused());
+    }
+
+    function testPermitWithClone(
+        bytes32 salt,
+        string memory name,
+        string memory symbol,
+        address _admin,
+        uint256 _tokenPermitAmount,
+        uint256 _tokenOwnerPrivateKey,
+        address _tokenSpender,
+        address _relayer
+    ) public {
+        vm.assume(_relayer != address(0));
+        vm.assume(_tokenSpender != address(0));
+        vm.assume(_tokenSpender != feeSettingsAndAllowListOwner);
+        vm.assume(bytes(name).length > 0);
+        vm.assume(bytes(symbol).length > 0);
+        vm.assume(_tokenPermitAmount < (type(uint256).max / 10) * 9); // leave room for fees
+        vm.assume(
+            _tokenOwnerPrivateKey < 115792089237316195423570985008687907852837564279074904382605163141518161494337
+        );
+        vm.assume(_tokenOwnerPrivateKey > 0);
+
+        Token clone = Token(
+            factory.createTokenClone(
+                salt,
+                trustedForwarder,
+                feeSettings,
+                _admin,
+                AllowList(allowList),
+                requirements,
+                name,
+                symbol
+            )
+        );
+
+        address tokenOwner = vm.addr(_tokenOwnerPrivateKey);
+        vm.assume(tokenOwner != address(0));
+        vm.assume(tokenOwner != feeSettingsAndAllowListOwner);
+        vm.assume(_tokenSpender != tokenOwner);
+        vm.assume(_relayer != tokenOwner);
+
+        // permit spender to spend holder's tokens
+        //uint256 nonce = clone.nonces(tokenOwner);
+        uint256 deadline = block.timestamp + 1000;
+        bytes32 permitTypehash = keccak256(
+            "Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)"
+        );
+        bytes32 structHash = keccak256(
+            abi.encode(
+                permitTypehash,
+                tokenOwner,
+                _tokenSpender,
+                _tokenPermitAmount,
+                clone.nonces(tokenOwner),
+                block.timestamp + 1000
+            )
+        );
+
+        //bytes32 hash = ECDSA.toTypedDataHash(clone.DOMAIN_SEPARATOR(), structHash);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(
+            _tokenOwnerPrivateKey,
+            ECDSA.toTypedDataHash(clone.DOMAIN_SEPARATOR(), structHash)
+        );
+
+        // check allowance
+        assertEq(clone.allowance(tokenOwner, _tokenSpender), 0);
+
+        // call permit with a wallet that is not tokenOwner
+        vm.prank(_relayer);
+        clone.permit(tokenOwner, _tokenSpender, _tokenPermitAmount, deadline, v, r, s);
+
+        // check allowance
+        assertEq(clone.allowance(tokenOwner, _tokenSpender), _tokenPermitAmount);
+
+        // mint tokens to tokenOwner
+        vm.startPrank(_admin);
+        clone.mint(tokenOwner, _tokenPermitAmount);
+        vm.stopPrank();
+
+        // check token balances before transfer
+        assertEq(clone.balanceOf(tokenOwner), _tokenPermitAmount);
+        assertEq(clone.balanceOf(_tokenSpender), 0);
+
+        // spend tokens
+        vm.prank(_tokenSpender);
+        clone.transferFrom(tokenOwner, _tokenSpender, _tokenPermitAmount);
+
+        // check token balances after transfer
+        assertEq(clone.balanceOf(tokenOwner), 0);
+        assertEq(clone.balanceOf(_tokenSpender), _tokenPermitAmount);
+    }
+}

--- a/test/TokenERC2612.t.sol
+++ b/test/TokenERC2612.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../lib/forge-std/src/Test.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/FakePaymentToken.sol";
 import "@opengsn/contracts/src/forwarder/Forwarder.sol"; // chose specific version to avoid import error: yarn add @opengsn/contracts@2.2.5
@@ -14,6 +14,8 @@ contract TokenERC2612Test is Test {
     FeeSettings feeSettings;
 
     Token token;
+    Token implementation;
+    TokenCloneFactory tokenCloneFactory;
     FakePaymentToken paymentToken;
     //Forwarder trustedForwarder;
 
@@ -74,8 +76,21 @@ contract TokenERC2612Test is Test {
         // deploy forwarder
         Forwarder forwarder = new Forwarder();
 
+        implementation = new Token(address(forwarder));
+        tokenCloneFactory = new TokenCloneFactory(address(implementation));
+
         // deploy company token
-        token = new Token(address(forwarder), feeSettings, companyAdmin, allowList, 0x0, "TESTTOKEN", "TEST");
+        token = Token(
+            tokenCloneFactory.createTokenClone(
+                address(forwarder),
+                feeSettings,
+                companyAdmin,
+                allowList,
+                0x0,
+                "TESTTOKEN",
+                "TEST"
+            )
+        );
 
         // mint tokens for holder
         vm.startPrank(companyAdmin);

--- a/test/TokenERC2612.t.sol
+++ b/test/TokenERC2612.t.sol
@@ -82,6 +82,7 @@ contract TokenERC2612Test is Test {
         // deploy company token
         token = Token(
             tokenCloneFactory.createTokenClone(
+                0,
                 address(forwarder),
                 feeSettings,
                 companyAdmin,

--- a/test/TokenERC2771.t.sol
+++ b/test/TokenERC2771.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../lib/forge-std/src/Test.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/ERC2771Helper.sol";
@@ -76,8 +76,22 @@ contract TokenERC2771Test is Test {
     }
 
     function setUpTokenWithForwarder(Forwarder forwarder) public {
+        // this is part of the platform setup, but we need it here to use the correct forwarder
+        Token implementation = new Token(address(forwarder));
+        TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
+
         // deploy company token
-        token = new Token(address(forwarder), feeSettings, companyAdmin, allowList, 0x0, "TESTTOKEN", "TEST");
+        token = Token(
+            tokenCloneFactory.createTokenClone(
+                address(forwarder),
+                feeSettings,
+                companyAdmin,
+                allowList,
+                0x0,
+                "TESTTOKEN",
+                "TEST"
+            )
+        );
 
         // register domainSeparator with forwarder
         domainSeparator = ERC2771helper.registerDomain(

--- a/test/TokenERC2771.t.sol
+++ b/test/TokenERC2771.t.sol
@@ -83,6 +83,7 @@ contract TokenERC2771Test is Test {
         // deploy company token
         token = Token(
             tokenCloneFactory.createTokenClone(
+                0,
                 address(forwarder),
                 feeSettings,
                 companyAdmin,

--- a/test/TokenGasConsumption.t.sol
+++ b/test/TokenGasConsumption.t.sol
@@ -43,6 +43,7 @@ contract tokenTest is Test {
 
         token = Token(
             tokenCloneFactory.createTokenClone(
+                0,
                 trustedForwarder,
                 feeSettings,
                 admin,

--- a/test/TokenGasConsumption.t.sol
+++ b/test/TokenGasConsumption.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../lib/forge-std/src/Test.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/FeeSettings.sol";
 
 contract tokenTest is Test {
@@ -38,7 +38,20 @@ contract tokenTest is Test {
 
         vm.stopPrank();
 
-        token = new Token(trustedForwarder, feeSettings, admin, allowList, requirements, "testToken", "TEST");
+        Token implementation = new Token(trustedForwarder);
+        TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
+
+        token = Token(
+            tokenCloneFactory.createTokenClone(
+                trustedForwarder,
+                feeSettings,
+                admin,
+                allowList,
+                requirements,
+                "testToken",
+                "TEST"
+            )
+        );
         console.log(msg.sender);
 
         // set up roles

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../lib/forge-std/src/Test.sol";
-import "../contracts/Token.sol";
+import "../contracts/TokenCloneFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/WrongFeeSettings.sol";
 
@@ -33,7 +33,19 @@ contract tokenTest is Test {
         vm.prank(feeSettingsOwner);
         Fees memory fees = Fees(100, 100, 100, 0);
         feeSettings = new FeeSettings(fees, admin);
-        token = new Token(trustedForwarder, feeSettings, admin, allowList, 0x0, "testToken", "TEST");
+        Token implementation = new Token(trustedForwarder);
+        TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
+        token = Token(
+            tokenCloneFactory.createTokenClone(
+                trustedForwarder,
+                feeSettings,
+                admin,
+                allowList,
+                0x0,
+                "testToken",
+                "TEST"
+            )
+        );
         console.log(msg.sender);
 
         // set up roles

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -37,6 +37,7 @@ contract tokenTest is Test {
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
         token = Token(
             tokenCloneFactory.createTokenClone(
+                0,
                 trustedForwarder,
                 feeSettings,
                 admin,

--- a/test/resources/FakePaymentToken.sol
+++ b/test/resources/FakePaymentToken.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../../lib/forge-std/src/Test.sol";
+import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";
 import "../../contracts/Token.sol";
 
 /*

--- a/test/resources/MaliciousPaymentToken.sol
+++ b/test/resources/MaliciousPaymentToken.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import "../../lib/forge-std/src/Test.sol";
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "../../contracts/Token.sol";
 import "../../contracts/ContinuousFundraising.sol";
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -833,6 +833,11 @@
   dependencies:
     "@openzeppelin/contracts" "^4.2.0"
 
+"@openzeppelin/contracts-upgradeable@4.9.3":
+  version "4.9.3"
+  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.3.tgz#ff17a80fb945f5102571f8efecb5ce5915cc4811"
+  integrity sha512-jjaHAVRMrE4UuZNfDwjlLGDxTHWIOwTJS2ldnc278a0gevfXfPr8hxKEVBGFBE96kl2G3VHDZhUimw/+G3TG2A==
+
 "@openzeppelin/contracts@4.9.1":
   version "4.9.1"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-4.9.1.tgz#afa804d2c68398704b0175acc94d91a54f203645"


### PR DESCRIPTION
cloning contracts using the upgradeable openzeppelin package

We abandon the dual deployment possibilities of using a contract without cloning, too. This means a functioning token contract can no longer be created without a clone factory, which can not be created without a token logic contract.

The clones are created with deterministic addresses. All parameters of the token are considered in the deployment, so any parameter change will result in a different token address. Additionally, a salt can be provided, which will also influence token address. Vanity addresses would be possible ;)

Address prediction can be done through 2 functions:
```
function predictCloneAddress(
        bytes32 _rawSalt,
        address _trustedForwarder,
        IFeeSettingsV1 _feeSettings,
        address _admin,
        AllowList _allowList,
        uint256 _requirements,
        string memory _name,
        string memory _symbol
    )
```
```
predictCloneAddress(bytes32 salt)
```
The second does not leak any information about the planned token, but requires conversion from parameters to `salt` on the client side.
