### PR TITLE
Feature/extend fee settings

### DIFF
--- a/contracts/ContinuousFundraising.sol
+++ b/contracts/ContinuousFundraising.sol
@@ -137,10 +137,10 @@ contract ContinuousFundraising is ERC2771Context, Ownable2Step, Pausable, Reentr
         // rounding up to the next whole number. Investor is charged up to one currency bit more in case of a fractional currency bit.
         uint256 currencyAmount = Math.ceilDiv(_amount * tokenPrice, 10 ** token.decimals());
 
-        IFeeSettingsV1 feeSettings = token.feeSettings();
+        IFeeSettingsV2 feeSettings = token.feeSettings();
         uint256 fee = feeSettings.continuousFundraisingFee(currencyAmount);
         if (fee != 0) {
-            currency.safeTransferFrom(_msgSender(), feeSettings.feeCollector(), fee);
+            currency.safeTransferFrom(_msgSender(), feeSettings.continuousFundraisingFeeCollector(), fee);
         }
 
         currency.safeTransferFrom(_msgSender(), currencyReceiver, currencyAmount - fee);

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -11,7 +11,9 @@ import "./interfaces/IFeeSettings.sol";
  * @notice The FeeSettings contract is used to manage fees paid to the tokenize.it platfom
  */
 contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
-    uint128 public constant MAX_FEE_DENOMINATOR = 20;
+    uint128 public constant MIN_TOKEN_FEE_DENOMINATOR = 20;
+    uint128 public constant MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR = 10;
+    uint128 public constant MIN_PERSONAL_INVITE_FEE_DENOMINATOR = 20;
 
     /// Denominator to calculate fees paid in Token.sol. UINT256_MAX means no fees.
     uint256 public tokenFeeDenominator;
@@ -140,15 +142,15 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
      */
     function checkFeeLimits(Fees memory _fees) internal pure {
         require(
-            _fees.tokenFeeDenominator >= MAX_FEE_DENOMINATOR,
+            _fees.tokenFeeDenominator >= MIN_TOKEN_FEE_DENOMINATOR,
             "Fee must be equal or less 5% (denominator must be >= 20)"
         );
         require(
-            _fees.continuousFundraisingFeeDenominator >= MAX_FEE_DENOMINATOR,
-            "Fee must be equal or less 5% (denominator must be >= 20)"
+            _fees.continuousFundraisingFeeDenominator >= MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR,
+            "ContinuousFundraising fee must be equal or less 10% (denominator must be >= 10)"
         );
         require(
-            _fees.personalInviteFeeDenominator >= MAX_FEE_DENOMINATOR,
+            _fees.personalInviteFeeDenominator >= MIN_PERSONAL_INVITE_FEE_DENOMINATOR,
             "Fee must be equal or less 5% (denominator must be >= 20)"
         );
     }

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -202,7 +202,8 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
         bytes4 interfaceId
     ) public view virtual override(ERC165, IFeeSettingsV1, IFeeSettingsV2) returns (bool) {
         return
-            interfaceId == type(IFeeSettingsV1).interfaceId || // we implement IFeeSettingsV1
+            interfaceId == type(IFeeSettingsV1).interfaceId || // we implement IFeeSettingsV1 for backwards compatibility
+            interfaceId == type(IFeeSettingsV2).interfaceId || // we implement IFeeSettingsV2
             ERC165.supportsInterface(interfaceId); // default implementation that enables further querying
     }
 

--- a/contracts/PersonalInvite.sol
+++ b/contracts/PersonalInvite.sol
@@ -79,10 +79,10 @@ contract PersonalInvite {
         // rounding up to the next whole number. Investor is charged up to one currency bit more in case of a fractional currency bit.
         uint256 currencyAmount = Math.ceilDiv(_tokenAmount * _tokenPrice, 10 ** _token.decimals());
 
-        IFeeSettingsV1 feeSettings = _token.feeSettings();
+        IFeeSettingsV2 feeSettings = _token.feeSettings();
         uint256 fee = feeSettings.personalInviteFee(currencyAmount);
         if (fee != 0) {
-            _currency.safeTransferFrom(_currencyPayer, feeSettings.feeCollector(), fee);
+            _currency.safeTransferFrom(_currencyPayer, feeSettings.personalInviteFeeCollector(), fee);
         }
         _currency.safeTransferFrom(_currencyPayer, _currencyReceiver, (currencyAmount - fee));
 

--- a/contracts/TokenCloneFactory.sol
+++ b/contracts/TokenCloneFactory.sol
@@ -12,7 +12,7 @@ contract TokenCloneFactory is CloneFactory {
     function createTokenClone(
         bytes32 _rawSalt,
         address _trustedForwarder,
-        IFeeSettingsV1 _feeSettings,
+        IFeeSettingsV2 _feeSettings,
         address _admin,
         AllowList _allowList,
         uint256 _requirements,

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -17,6 +17,24 @@ interface IFeeSettingsV1 {
     function supportsInterface(bytes4) external view returns (bool); //because we inherit from ERC165
 }
 
+interface IFeeSettingsV2 {
+    function tokenFee(uint256) external view returns (uint256);
+
+    function tokenFeeCollector() external view returns (address);
+
+    function continuousFundraisingFee(uint256) external view returns (uint256);
+
+    function continuousFundraisingFeeCollector() external view returns (address);
+
+    function personalInviteFee(uint256) external view returns (uint256);
+
+    function personalInviteFeeCollector() external view returns (address);
+
+    function owner() external view returns (address);
+
+    function supportsInterface(bytes4) external view returns (bool); //because we inherit from ERC165
+}
+
 struct Fees {
     uint256 tokenFeeDenominator;
     uint256 continuousFundraisingFeeDenominator;

--- a/script/DeployPlatform.s.sol
+++ b/script/DeployPlatform.s.sol
@@ -30,7 +30,7 @@ contract DeployPlatform is Script {
 
         console.log("Deploying FeeSettings contract...");
         Fees memory fees = Fees(100, 100, 100, 0);
-        FeeSettings feeSettings = new FeeSettings(fees, platformColdWallet);
+        FeeSettings feeSettings = new FeeSettings(fees, platformColdWallet, platformColdWallet, platformColdWallet);
         console.log("FeeSettings deployed at: ", address(feeSettings));
         feeSettings.transferOwnership(platformColdWallet);
         console.log("Started ownership transfer to: ", platformColdWallet);

--- a/test/ContinuousFundraising.t.sol
+++ b/test/ContinuousFundraising.t.sol
@@ -18,7 +18,7 @@ contract ContinuousFundraisingTest is Test {
 
     ContinuousFundraising raise;
     AllowList list;
-    IFeeSettingsV1 feeSettings;
+    IFeeSettingsV2 feeSettings;
 
     TokenCloneFactory tokenCloneFactory;
     Token token;
@@ -257,12 +257,13 @@ contract ContinuousFundraisingTest is Test {
             "receiver has payment tokens"
         );
         assertTrue(
-            paymentToken.balanceOf(token.feeSettings().feeCollector()) ==
+            paymentToken.balanceOf(token.feeSettings().continuousFundraisingFeeCollector()) ==
                 localFeeSettings.continuousFundraisingFee(costInPaymentToken),
             "fee collector has collected fee in payment tokens"
         );
         assertTrue(
-            token.balanceOf(token.feeSettings().feeCollector()) == localFeeSettings.tokenFee(tokenBuyAmount),
+            token.balanceOf(token.feeSettings().continuousFundraisingFeeCollector()) ==
+                localFeeSettings.tokenFee(tokenBuyAmount),
             "fee collector has collected fee in tokens"
         );
         assertTrue(raise.tokensSold() == tokenBuyAmount, "raise has sold tokens");
@@ -478,7 +479,7 @@ contract ContinuousFundraisingTest is Test {
             "receiver received payment tokens"
         );
         assertEq(
-            token.balanceOf(token.feeSettings().feeCollector()),
+            token.balanceOf(token.feeSettings().continuousFundraisingFeeCollector()),
             tokenFee,
             "fee collector has collected fee in tokens"
         );

--- a/test/ContinuousFundraising.t.sol
+++ b/test/ContinuousFundraising.t.sol
@@ -45,7 +45,7 @@ contract ContinuousFundraisingTest is Test {
     function setUp() public {
         list = new AllowList();
         Fees memory fees = Fees(100, 100, 100, 100);
-        feeSettings = new FeeSettings(fees, admin);
+        feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/ContinuousFundraisingERC2771.t.sol
+++ b/test/ContinuousFundraisingERC2771.t.sol
@@ -63,7 +63,7 @@ contract ContinuousFundraisingTest is Test {
     function setUp() public {
         list = new AllowList();
         Fees memory fees = Fees(tokenFeeDenominator, paymentTokenFeeDenominator, paymentTokenFeeDenominator, 0);
-        feeSettings = new FeeSettings(fees, admin);
+        feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory factory = new TokenCloneFactory(address(implementation));

--- a/test/ContinuousFundraisingIntegration.t.sol
+++ b/test/ContinuousFundraisingIntegration.t.sol
@@ -40,7 +40,7 @@ contract ContinuousFundraisingTest is Test {
         list = new AllowList();
         Fees memory fees = Fees(100, 100, 100, 100);
         vm.prank(platformAdmin);
-        feeSettings = new FeeSettings(fees, platformAdmin);
+        feeSettings = new FeeSettings(fees, platformAdmin, platformAdmin, platformAdmin);
         vm.prank(platformAdmin);
         token = Token(
             factory.createTokenClone(0, trustedForwarder, feeSettings, companyOwner, list, 0x0, "TESTTOKEN", "TEST")

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -74,7 +74,7 @@ contract TokenERC2771Test is Test {
             0
         );
         vm.prank(platformAdmin);
-        feeSettings = new FeeSettings(fees, feeCollector);
+        feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
 
         // deploy helper functions (only for testing with foundry)
         ERC2771helper = new ERC2771Helper();

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -463,8 +463,21 @@ contract FeeSettingsTest is Test {
         );
     }
 
+    function testIFeeSettingsV2IsAvailable() public {
+        FeeSettings _feeSettings;
+        Fees memory fees = Fees(100, 100, 100, 0);
+        _feeSettings = new FeeSettings(fees, admin, admin, admin);
+
+        assertEq(
+            _feeSettings.supportsInterface(type(IFeeSettingsV2).interfaceId),
+            true,
+            "IFeeSettingsV1 not supported"
+        );
+    }
+
     function testNonsenseInterfacesAreNotAvailable(bytes4 _nonsenseInterface) public {
         vm.assume(_nonsenseInterface != type(IFeeSettingsV1).interfaceId);
+        vm.assume(_nonsenseInterface != type(IFeeSettingsV2).interfaceId);
         vm.assume(_nonsenseInterface != 0x01ffc9a7);
         FeeSettings _feeSettings;
         Fees memory fees = Fees(100, 100, 100, 0);

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -36,7 +36,7 @@ contract FeeSettingsTest is Test {
     uint256 public constant price = 10000000;
 
     function testEnforceFeeDenominatorRangeInConstructor(uint8 fee) public {
-        vm.assume(!feeInValidRange(fee));
+        vm.assume(!tokenOrPersonalInviteFeeInValidRange(fee));
         Fees memory _fees;
 
         console.log("Testing token fee");
@@ -46,8 +46,13 @@ contract FeeSettingsTest is Test {
 
         console.log("Testing ContinuousFundraising fee");
         _fees = Fees(30, fee, 100, 0);
-        vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
-        new FeeSettings(_fees, admin, admin, admin);
+        if (fee < 10) {
+            vm.expectRevert("ContinuousFundraising fee must be equal or less 10% (denominator must be >= 10)");
+            new FeeSettings(_fees, admin, admin, admin);
+        } else {
+            // this should not revert, as the fee is in valid range for continuous fundraising
+            new FeeSettings(_fees, admin, admin, admin);
+        }
 
         console.log("Testing PersonalInvite fee");
         _fees = Fees(30, 40, fee, 0);
@@ -56,7 +61,7 @@ contract FeeSettingsTest is Test {
     }
 
     function testEnforceTokenFeeDenominatorRangeInFeeChanger(uint8 fee) public {
-        vm.assume(!feeInValidRange(fee));
+        vm.assume(!tokenOrPersonalInviteFeeInValidRange(fee));
         Fees memory fees = Fees(100, 100, 100, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
@@ -71,7 +76,7 @@ contract FeeSettingsTest is Test {
     }
 
     function testEnforceContinuousFundraisingFeeDenominatorRangeInFeeChanger(uint8 fee) public {
-        vm.assume(!feeInValidRange(fee));
+        vm.assume(fee < 10);
         Fees memory fees = Fees(100, 100, 100, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
@@ -81,12 +86,12 @@ contract FeeSettingsTest is Test {
             personalInviteFeeDenominator: 100,
             time: block.timestamp + 7884001
         });
-        vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
+        vm.expectRevert("ContinuousFundraising fee must be equal or less 10% (denominator must be >= 10)");
         _feeSettings.planFeeChange(feeChange);
     }
 
     function testEnforcePersonalInviteFeeDenominatorRangeInFeeChanger(uint8 fee) public {
-        vm.assume(!feeInValidRange(fee));
+        vm.assume(!tokenOrPersonalInviteFeeInValidRange(fee));
         Fees memory fees = Fees(100, 100, 100, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
@@ -141,8 +146,8 @@ contract FeeSettingsTest is Test {
 
     function testExecuteFeeChangeTooEarly(uint delayAnnounced, uint256 tokenFee, uint256 investmentFee) public {
         vm.assume(delayAnnounced > 12 weeks && delayAnnounced < 1000000000000);
-        vm.assume(feeInValidRange(tokenFee));
-        vm.assume(feeInValidRange(investmentFee));
+        vm.assume(tokenOrPersonalInviteFeeInValidRange(tokenFee));
+        vm.assume(tokenOrPersonalInviteFeeInValidRange(investmentFee));
 
         Fees memory fees = Fees(50, 50, 50, 0);
         vm.prank(admin);
@@ -170,9 +175,9 @@ contract FeeSettingsTest is Test {
         uint256 personalInviteFee
     ) public {
         vm.assume(delayAnnounced > 12 weeks && delayAnnounced < 100000000000);
-        vm.assume(feeInValidRange(tokenFee));
-        vm.assume(feeInValidRange(fundraisingFee));
-        vm.assume(feeInValidRange(personalInviteFee));
+        vm.assume(tokenOrPersonalInviteFeeInValidRange(tokenFee));
+        vm.assume(tokenOrPersonalInviteFeeInValidRange(fundraisingFee));
+        vm.assume(tokenOrPersonalInviteFeeInValidRange(personalInviteFee));
         Fees memory fees = Fees(50, 50, 50, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
@@ -288,8 +293,8 @@ contract FeeSettingsTest is Test {
     }
 
     function testSetFeeInConstructor(uint8 tokenFee, uint8 investmentFee) public {
-        vm.assume(feeInValidRange(tokenFee));
-        vm.assume(feeInValidRange(investmentFee));
+        vm.assume(tokenOrPersonalInviteFeeInValidRange(tokenFee));
+        vm.assume(tokenOrPersonalInviteFeeInValidRange(investmentFee));
         FeeSettings _feeSettings;
         Fees memory fees = Fees(tokenFee, investmentFee, investmentFee, 0);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
@@ -350,7 +355,7 @@ contract FeeSettingsTest is Test {
         assertEq(_feeSettings.personalInviteFeeCollector(), newPersonalInviteFeeCollector);
     }
 
-    function feeInValidRange(uint256 fee) internal pure returns (bool) {
+    function tokenOrPersonalInviteFeeInValidRange(uint256 fee) internal pure returns (bool) {
         return fee >= 20;
     }
 

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -11,7 +11,11 @@ contract FeeSettingsTest is Test {
         uint256 continuousFundraisingFeeDenominator,
         uint256 personalInviteFeeDenominator
     );
-    event FeeCollectorChanged(address indexed newFeeCollector);
+    event FeeCollectorsChanged(
+        address indexed newTokenFeeCollector,
+        address indexed newContinuousFundraisingFeeCollector,
+        address indexed newPersonalInviteFeeCollector
+    );
     event ChangeProposed(Fees proposal);
 
     FeeSettings feeSettings;
@@ -38,23 +42,23 @@ contract FeeSettingsTest is Test {
         console.log("Testing token fee");
         _fees = Fees(fee, 30, 100, 0);
         vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
-        new FeeSettings(_fees, admin);
+        new FeeSettings(_fees, admin, admin, admin);
 
         console.log("Testing ContinuousFundraising fee");
         _fees = Fees(30, fee, 100, 0);
         vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
-        new FeeSettings(_fees, admin);
+        new FeeSettings(_fees, admin, admin, admin);
 
         console.log("Testing PersonalInvite fee");
         _fees = Fees(30, 40, fee, 0);
         vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
-        new FeeSettings(_fees, admin);
+        new FeeSettings(_fees, admin, admin, admin);
     }
 
     function testEnforceTokenFeeDenominatorRangeInFeeChanger(uint8 fee) public {
         vm.assume(!feeInValidRange(fee));
         Fees memory fees = Fees(100, 100, 100, 0);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees({
             tokenFeeDenominator: fee,
@@ -69,7 +73,7 @@ contract FeeSettingsTest is Test {
     function testEnforceContinuousFundraisingFeeDenominatorRangeInFeeChanger(uint8 fee) public {
         vm.assume(!feeInValidRange(fee));
         Fees memory fees = Fees(100, 100, 100, 0);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees({
             tokenFeeDenominator: 100,
@@ -84,7 +88,7 @@ contract FeeSettingsTest is Test {
     function testEnforcePersonalInviteFeeDenominatorRangeInFeeChanger(uint8 fee) public {
         vm.assume(!feeInValidRange(fee));
         Fees memory fees = Fees(100, 100, 100, 0);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees({
             tokenFeeDenominator: 100,
@@ -102,7 +106,7 @@ contract FeeSettingsTest is Test {
         vm.assume(newDenominator < startDenominator);
         Fees memory fees = Fees(startDenominator, startDenominator, startDenominator, 0);
         vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees({
             tokenFeeDenominator: newDenominator,
@@ -142,7 +146,7 @@ contract FeeSettingsTest is Test {
 
         Fees memory fees = Fees(50, 50, 50, 0);
         vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees({
             tokenFeeDenominator: tokenFee,
@@ -171,7 +175,7 @@ contract FeeSettingsTest is Test {
         vm.assume(feeInValidRange(personalInviteFee));
         Fees memory fees = Fees(50, 50, 50, 0);
         vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees({
             tokenFeeDenominator: tokenFee,
@@ -198,7 +202,7 @@ contract FeeSettingsTest is Test {
     function testSetFeeTo0Immediately() public {
         Fees memory fees = Fees(50, 20, 30, 0);
         vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees({
             tokenFeeDenominator: UINT256_MAX,
@@ -228,7 +232,7 @@ contract FeeSettingsTest is Test {
     function testSetFeeToXFrom0Immediately() public {
         Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
         vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees({
             tokenFeeDenominator: 20,
@@ -256,7 +260,7 @@ contract FeeSettingsTest is Test {
         vm.assume(personalReductor >= 30);
         Fees memory fees = Fees(50, 20, 30, 0);
         vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees({
             tokenFeeDenominator: tokenReductor,
@@ -288,7 +292,7 @@ contract FeeSettingsTest is Test {
         vm.assume(feeInValidRange(investmentFee));
         FeeSettings _feeSettings;
         Fees memory fees = Fees(tokenFee, investmentFee, investmentFee, 0);
-        _feeSettings = new FeeSettings(fees, admin);
+        _feeSettings = new FeeSettings(fees, admin, admin, admin);
         assertEq(_feeSettings.tokenFeeDenominator(), tokenFee, "Token fee mismatch");
         assertEq(_feeSettings.continuousFundraisingFeeDenominator(), investmentFee, "Investment fee mismatch");
     }
@@ -297,30 +301,53 @@ contract FeeSettingsTest is Test {
         vm.expectRevert("Fee collector cannot be 0x0");
         FeeSettings _feeSettings;
         Fees memory fees = Fees(100, 100, 100, 0);
-        _feeSettings = new FeeSettings(fees, address(0));
+        _feeSettings = new FeeSettings(fees, address(0), address(0), address(0));
     }
 
     function testFeeCollector0FailsInSetter() public {
         FeeSettings _feeSettings;
         Fees memory fees = Fees(100, 100, 100, 0);
         vm.prank(admin);
-        _feeSettings = new FeeSettings(fees, admin);
+        _feeSettings = new FeeSettings(fees, admin, admin, admin);
         vm.expectRevert("Fee collector cannot be 0x0");
         vm.prank(admin);
-        _feeSettings.setFeeCollector(address(0));
+        _feeSettings.setFeeCollectors(address(0), address(1), address(2));
+        vm.expectRevert("Fee collector cannot be 0x0");
+        vm.prank(admin);
+        _feeSettings.setFeeCollectors(address(2), address(0), address(1));
+        vm.expectRevert("Fee collector cannot be 0x0");
+        vm.prank(admin);
+        _feeSettings.setFeeCollectors(address(1), address(2), address(0));
     }
 
-    function testUpdateFeeCollector(address newCollector) public {
-        vm.assume(newCollector != address(0));
+    function testUpdateFeeCollectors(
+        address newTokenFeeCollector,
+        address newContinuousFundraisingFeeCollector,
+        address newPersonalInviteFeeCollector
+    ) public {
+        vm.assume(newTokenFeeCollector != address(0));
+        vm.assume(newContinuousFundraisingFeeCollector != address(0));
+        vm.assume(newPersonalInviteFeeCollector != address(0));
         FeeSettings _feeSettings;
         Fees memory fees = Fees(100, 100, 100, 0);
         vm.prank(admin);
-        _feeSettings = new FeeSettings(fees, admin);
+        _feeSettings = new FeeSettings(fees, admin, admin, admin);
         vm.expectEmit(true, true, true, true, address(_feeSettings));
-        emit FeeCollectorChanged(newCollector);
+        emit FeeCollectorsChanged(
+            newTokenFeeCollector,
+            newContinuousFundraisingFeeCollector,
+            newPersonalInviteFeeCollector
+        );
         vm.prank(admin);
-        _feeSettings.setFeeCollector(newCollector);
-        assertEq(_feeSettings.feeCollector(), newCollector);
+        _feeSettings.setFeeCollectors(
+            newTokenFeeCollector,
+            newContinuousFundraisingFeeCollector,
+            newPersonalInviteFeeCollector
+        );
+        assertEq(_feeSettings.feeCollector(), newTokenFeeCollector); // IFeeSettingsV1
+        assertEq(_feeSettings.tokenFeeCollector(), newTokenFeeCollector);
+        assertEq(_feeSettings.continuousFundraisingFeeCollector(), newContinuousFundraisingFeeCollector);
+        assertEq(_feeSettings.personalInviteFeeCollector(), newPersonalInviteFeeCollector);
     }
 
     function feeInValidRange(uint256 fee) internal pure returns (bool) {
@@ -343,7 +370,7 @@ contract FeeSettingsTest is Test {
             personalInviteFeeDenominator,
             0
         );
-        FeeSettings _feeSettings = new FeeSettings(_fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
         assertEq(
@@ -372,7 +399,7 @@ contract FeeSettingsTest is Test {
         // only token fee is 0
 
         Fees memory _fees = Fees(UINT256_MAX, continuousFundraisingFeeDenominator, personalInviteFeeDenominator, 0);
-        FeeSettings _feeSettings = new FeeSettings(_fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), 0, "Token fee mismatch");
         assertEq(
@@ -389,7 +416,7 @@ contract FeeSettingsTest is Test {
         // only continuous fundraising fee is 0
 
         _fees = Fees(tokenFeeDenominator, UINT256_MAX, personalInviteFeeDenominator, 0);
-        _feeSettings = new FeeSettings(_fees, admin);
+        _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
         assertEq(_feeSettings.continuousFundraisingFee(amount), 0, "Investment fee mismatch");
@@ -402,7 +429,7 @@ contract FeeSettingsTest is Test {
         // only personal invite fee is 0
 
         _fees = Fees(tokenFeeDenominator, continuousFundraisingFeeDenominator, UINT256_MAX, 0);
-        _feeSettings = new FeeSettings(_fees, admin);
+        _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
         assertEq(
@@ -416,7 +443,7 @@ contract FeeSettingsTest is Test {
     function testERC165IsAvailable() public {
         FeeSettings _feeSettings;
         Fees memory fees = Fees(100, 100, 100, 0);
-        _feeSettings = new FeeSettings(fees, admin);
+        _feeSettings = new FeeSettings(fees, admin, admin, admin);
         assertEq(
             _feeSettings.supportsInterface(0x01ffc9a7), // type(IERC165).interfaceId
             true,
@@ -427,7 +454,7 @@ contract FeeSettingsTest is Test {
     function testIFeeSettingsV1IsAvailable() public {
         FeeSettings _feeSettings;
         Fees memory fees = Fees(100, 100, 100, 0);
-        _feeSettings = new FeeSettings(fees, admin);
+        _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         assertEq(
             _feeSettings.supportsInterface(type(IFeeSettingsV1).interfaceId),
@@ -441,7 +468,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_nonsenseInterface != 0x01ffc9a7);
         FeeSettings _feeSettings;
         Fees memory fees = Fees(100, 100, 100, 0);
-        _feeSettings = new FeeSettings(fees, admin);
+        _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         assertEq(_feeSettings.supportsInterface(0x01ffc9b7), false, "This interface should not be supported");
     }
@@ -463,7 +490,7 @@ contract FeeSettingsTest is Test {
         // only token fee is 0
 
         Fees memory _fees = Fees(UINT256_MAX, continuousFundraisingFeeDenominator, personalInviteFeeDenominator, 0);
-        FeeSettings _feeSettings = new FeeSettings(_fees, admin);
+        FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), 1, "Token fee mismatch");
         assertEq(
@@ -480,7 +507,7 @@ contract FeeSettingsTest is Test {
         // only continuous fundraising fee is 0
 
         _fees = Fees(tokenFeeDenominator, UINT256_MAX, personalInviteFeeDenominator, 0);
-        _feeSettings = new FeeSettings(_fees, admin);
+        _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
         assertEq(_feeSettings.continuousFundraisingFee(amount), 1, "Investment fee mismatch");
@@ -493,7 +520,7 @@ contract FeeSettingsTest is Test {
         // only personal invite fee is 0
 
         _fees = Fees(tokenFeeDenominator, continuousFundraisingFeeDenominator, UINT256_MAX, 0);
-        _feeSettings = new FeeSettings(_fees, admin);
+        _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
         assertEq(

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -60,7 +60,7 @@ contract MainnetCurrencies is Test {
     function setUp() public {
         list = new AllowList();
         Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = new FeeSettings(fees, admin);
+        feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -234,7 +234,7 @@ contract MainnetCurrencies is Test {
             "receiver should have received currency"
         );
         assertEq(
-            _currency.balanceOf(token.feeSettings().feeCollector()),
+            _currency.balanceOf(token.feeSettings().continuousFundraisingFeeCollector()),
             token.feeSettings().continuousFundraisingFee(currencyCost),
             "fee receiver should have received currency"
         );

--- a/test/PersonalInvite.t.sol
+++ b/test/PersonalInvite.t.sol
@@ -382,7 +382,10 @@ contract PersonalInviteTest is Test {
     }
 
     function testAcceptWithDifferentTokenReceiver(uint256 rawSalt) public {
-        console.log("feeCollector currency balance: %s", currency.balanceOf(token.feeSettings().feeCollector()));
+        console.log(
+            "feeCollector currency balance: %s",
+            currency.balanceOf(token.feeSettings().personalInviteFeeCollector())
+        );
 
         //uint rawSalt = 0;
         bytes32 salt = bytes32(rawSalt);
@@ -416,7 +419,10 @@ contract PersonalInviteTest is Test {
 
         // make sure balances are as expected before deployment
 
-        console.log("feeCollector currency balance: %s", currency.balanceOf(token.feeSettings().feeCollector()));
+        console.log(
+            "feeCollector currency balance: %s",
+            currency.balanceOf(token.feeSettings().personalInviteFeeCollector())
+        );
 
         assertEq(currency.balanceOf(currencyPayer), currencyAmount);
         assertEq(currency.balanceOf(currencyReceiver), 0);
@@ -425,7 +431,7 @@ contract PersonalInviteTest is Test {
 
         console.log(
             "feeCollector currency balance before deployment: %s",
-            currency.balanceOf(token.feeSettings().feeCollector())
+            currency.balanceOf(token.feeSettings().personalInviteFeeCollector())
         );
 
         address inviteAddress = factory.deploy(
@@ -442,7 +448,7 @@ contract PersonalInviteTest is Test {
 
         console.log(
             "feeCollector currency balance after deployment: %s",
-            currency.balanceOf(token.feeSettings().feeCollector())
+            currency.balanceOf(token.feeSettings().personalInviteFeeCollector())
         );
 
         assertEq(inviteAddress, expectedAddress, "deployed contract address is not correct");
@@ -462,16 +468,22 @@ contract PersonalInviteTest is Test {
             currencyAmount - token.feeSettings().personalInviteFee(currencyAmount)
         );
 
-        console.log("feeCollector currency balance: %s", currency.balanceOf(token.feeSettings().feeCollector()));
+        console.log(
+            "feeCollector currency balance: %s",
+            currency.balanceOf(token.feeSettings().personalInviteFeeCollector())
+        );
 
         assertEq(
-            currency.balanceOf(token.feeSettings().feeCollector()),
+            currency.balanceOf(token.feeSettings().personalInviteFeeCollector()),
             token.feeSettings().personalInviteFee(currencyAmount),
             "feeCollector currency balance is not correct"
         );
 
         assertEq(token.balanceOf(tokenReceiver), tokenAmount);
 
-        assertEq(token.balanceOf(token.feeSettings().feeCollector()), token.feeSettings().tokenFee(tokenAmount));
+        assertEq(
+            token.balanceOf(token.feeSettings().personalInviteFeeCollector()),
+            token.feeSettings().tokenFee(tokenAmount)
+        );
     }
 }

--- a/test/PersonalInvite.t.sol
+++ b/test/PersonalInvite.t.sol
@@ -47,7 +47,7 @@ contract PersonalInviteTest is Test {
         list.set(tokenReceiver, requirements);
 
         Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = new FeeSettings(fees, admin);
+        feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));

--- a/test/PersonalInviteFactory.t.sol
+++ b/test/PersonalInviteFactory.t.sol
@@ -35,7 +35,7 @@ contract PersonalInviteFactoryTest is Test {
         factory = new PersonalInviteFactory();
         list = new AllowList();
         Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = new FeeSettings(fees, admin);
+        feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));

--- a/test/PersonalInviteTimeLock.t.sol
+++ b/test/PersonalInviteTimeLock.t.sol
@@ -42,7 +42,7 @@ contract PersonalInviteTimeLockTest is Test {
         list.set(tokenReceiver, requirements);
 
         Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = new FeeSettings(fees, admin);
+        feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));

--- a/test/PersonalInviteTimeLock.t.sol
+++ b/test/PersonalInviteTimeLock.t.sol
@@ -169,8 +169,6 @@ contract PersonalInviteTimeLockTest is Test {
 
         // make sure balances are as expected before deployment
 
-        console.log("feeCollector currency balance: %s", currency.balanceOf(token.feeSettings().feeCollector()));
-
         assertEq(currency.balanceOf(currencyPayer), currencyAmount, "currencyPayer wrong balance before deployment");
         assertEq(currency.balanceOf(currencyReceiver), 0, "currencyReceiver wrong balance before deployment");
         assertEq(currency.balanceOf(expectedTimeLockAddress), 0, "timeLock wrong currency balance before deployment");
@@ -178,7 +176,7 @@ contract PersonalInviteTimeLockTest is Test {
 
         console.log(
             "feeCollector currency balance before deployment: %s",
-            currency.balanceOf(token.feeSettings().feeCollector())
+            currency.balanceOf(token.feeSettings().personalInviteFeeCollector())
         );
 
         // create vesting wallet as token receiver
@@ -217,7 +215,7 @@ contract PersonalInviteTimeLockTest is Test {
         );
 
         assertEq(
-            currency.balanceOf(token.feeSettings().feeCollector()),
+            currency.balanceOf(token.feeSettings().personalInviteFeeCollector()),
             token.feeSettings().personalInviteFee(currencyAmount),
             "feeCollector currency balance is not correct"
         );
@@ -225,7 +223,7 @@ contract PersonalInviteTimeLockTest is Test {
         assertEq(token.balanceOf(address(timeLock)), tokenAmount, "timeLock wrong token balance after deployment");
 
         assertEq(
-            token.balanceOf(token.feeSettings().feeCollector()),
+            token.balanceOf(token.feeSettings().personalInviteFeeCollector()),
             token.feeSettings().tokenFee(tokenAmount),
             "feeCollector token balance is not correct"
         );

--- a/test/SetUpExampleCompany.t.sol
+++ b/test/SetUpExampleCompany.t.sol
@@ -102,7 +102,7 @@ contract CompanySetUpTest is Test {
         // set up FeeSettings
         Fees memory fees = Fees(tokenFeeDenominator, paymentTokenFeeDenominator, paymentTokenFeeDenominator, 0);
         vm.prank(platformAdmin);
-        feeSettings = new FeeSettings(fees, platformFeeCollector);
+        feeSettings = new FeeSettings(fees, platformFeeCollector, platformFeeCollector, platformFeeCollector);
 
         // set up AllowList
         vm.prank(platformAdmin);

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -31,7 +31,7 @@ contract tokenTest is Test {
         allowList = new AllowList();
         vm.prank(feeSettingsOwner);
         Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = new FeeSettings(fees, admin);
+        feeSettings = new FeeSettings(fees, admin, admin, admin);
         token = Token(
             tokenCloneFactory.createTokenClone(
                 0,

--- a/test/TokenCloneFactory.t.sol
+++ b/test/TokenCloneFactory.t.sol
@@ -6,7 +6,7 @@ import "../contracts/TokenCloneFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/ERC2771Helper.sol";
 
-contract tokenTest is Test {
+contract tokenCloneFactoryTest is Test {
     using ECDSA for bytes32;
 
     Token implementation;
@@ -53,6 +53,11 @@ contract tokenTest is Test {
         string memory _name,
         string memory _symbol
     ) public {
+        console.log("IFeeSettingsV2 interface id: ");
+        console.logBytes4(type(IFeeSettingsV2).interfaceId);
+
+        console.log("Supports interface: ", feeSettings.supportsInterface(type(IFeeSettingsV2).interfaceId));
+
         vm.assume(trustedForwarder != address(0));
         vm.assume(_admin != address(0));
         vm.assume(address(_allowList) != address(0));

--- a/test/TokenCloneFactory.t.sol
+++ b/test/TokenCloneFactory.t.sol
@@ -32,7 +32,12 @@ contract tokenTest is Test {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
         Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = new FeeSettings(fees, feeSettingsAndAllowListOwner);
+        feeSettings = new FeeSettings(
+            fees,
+            feeSettingsAndAllowListOwner,
+            feeSettingsAndAllowListOwner,
+            feeSettingsAndAllowListOwner
+        );
         vm.stopPrank();
 
         implementation = new Token(trustedForwarder);
@@ -132,7 +137,12 @@ contract tokenTest is Test {
         console.log("name: %s", name);
         console.log("symbol: %s", symbol);
 
-        FeeSettings _feeSettings = new FeeSettings(Fees(100, 100, 100, 0), feeSettingsAndAllowListOwner);
+        FeeSettings _feeSettings = new FeeSettings(
+            Fees(100, 100, 100, 0),
+            feeSettingsAndAllowListOwner,
+            feeSettingsAndAllowListOwner,
+            feeSettingsAndAllowListOwner
+        );
 
         Token clone = Token(
             factory.createTokenClone(
@@ -192,7 +202,12 @@ contract tokenTest is Test {
         vm.assume(rando != address(0));
         vm.assume(rando != _admin);
 
-        FeeSettings _feeSettings = new FeeSettings(Fees(100, 100, 100, 0), feeSettingsAndAllowListOwner);
+        FeeSettings _feeSettings = new FeeSettings(
+            Fees(100, 100, 100, 0),
+            feeSettingsAndAllowListOwner,
+            feeSettingsAndAllowListOwner,
+            feeSettingsAndAllowListOwner
+        );
 
         Token _token = Token(
             factory.createTokenClone(
@@ -237,7 +252,12 @@ contract tokenTest is Test {
         vm.assume(newPauser != address(0));
         vm.assume(newPauser != admin);
 
-        FeeSettings _feeSettings = new FeeSettings(Fees(100, 100, 100, 0), feeSettingsAndAllowListOwner);
+        FeeSettings _feeSettings = new FeeSettings(
+            Fees(100, 100, 100, 0),
+            feeSettingsAndAllowListOwner,
+            feeSettingsAndAllowListOwner,
+            feeSettingsAndAllowListOwner
+        );
 
         Token _token = Token(
             factory.createTokenClone(

--- a/test/TokenERC2612.t.sol
+++ b/test/TokenERC2612.t.sol
@@ -71,7 +71,7 @@ contract TokenERC2612Test is Test {
             0
         );
         vm.prank(platformAdmin);
-        feeSettings = new FeeSettings(fees, feeCollector);
+        feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
 
         // deploy forwarder
         Forwarder forwarder = new Forwarder();

--- a/test/TokenERC2771.t.sol
+++ b/test/TokenERC2771.t.sol
@@ -69,7 +69,7 @@ contract TokenERC2771Test is Test {
             0
         );
         vm.prank(platformAdmin);
-        feeSettings = new FeeSettings(fees, feeCollector);
+        feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
 
         // deploy helper functions (only for testing with foundry)
         ERC2771helper = new ERC2771Helper();

--- a/test/TokenGasConsumption.t.sol
+++ b/test/TokenGasConsumption.t.sol
@@ -28,7 +28,12 @@ contract tokenTest is Test {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
         Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = new FeeSettings(fees, feeSettingsAndAllowListOwner);
+        feeSettings = new FeeSettings(
+            fees,
+            feeSettingsAndAllowListOwner,
+            feeSettingsAndAllowListOwner,
+            feeSettingsAndAllowListOwner
+        );
 
         address tokenHolder = address(this);
 

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -32,7 +32,7 @@ contract tokenTest is Test {
         allowList = new AllowList();
         vm.prank(feeSettingsOwner);
         Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = new FeeSettings(fees, admin);
+        feeSettings = new FeeSettings(fees, admin, admin, admin);
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
         token = Token(
@@ -88,7 +88,7 @@ contract tokenTest is Test {
     function testSuggestNewFeeSettingsWrongCaller(address wrongUpdater) public {
         vm.assume(wrongUpdater != feeSettings.owner());
         Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
-        FeeSettings newFeeSettings = new FeeSettings(fees, pauser);
+        FeeSettings newFeeSettings = new FeeSettings(fees, pauser, pauser, pauser);
         vm.prank(wrongUpdater);
         vm.expectRevert("Only fee settings owner can suggest fee settings update");
         token.suggestNewFeeSettings(newFeeSettings);
@@ -96,7 +96,7 @@ contract tokenTest is Test {
 
     function testSuggestNewFeeSettingsFeeCollector() public {
         Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
-        FeeSettings newFeeSettings = new FeeSettings(fees, pauser);
+        FeeSettings newFeeSettings = new FeeSettings(fees, pauser, pauser, pauser);
         vm.prank(feeSettings.feeCollector());
         vm.expectRevert("Only fee settings owner can suggest fee settings update");
         token.suggestNewFeeSettings(newFeeSettings);
@@ -111,7 +111,7 @@ contract tokenTest is Test {
     function testSuggestNewFeeSettings(address newCollector) public {
         vm.assume(newCollector != address(0));
         Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
-        FeeSettings newFeeSettings = new FeeSettings(fees, newCollector);
+        FeeSettings newFeeSettings = new FeeSettings(fees, newCollector, newCollector, newCollector);
         FeeSettings oldFeeSettings = FeeSettings(address(token.feeSettings()));
         uint oldInvestmentFeeDenominator = oldFeeSettings.continuousFundraisingFeeDenominator();
         uint oldTokenFeeDenominator = oldFeeSettings.tokenFeeDenominator();
@@ -140,7 +140,7 @@ contract tokenTest is Test {
     function testAcceptNewFeeSettings(address newCollector) public {
         vm.assume(newCollector != address(0));
         Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
-        FeeSettings newFeeSettings = new FeeSettings(fees, newCollector);
+        FeeSettings newFeeSettings = new FeeSettings(fees, newCollector, newCollector, newCollector);
         FeeSettings oldFeeSettings = FeeSettings(address(token.feeSettings()));
         uint oldInvestmentFeeDenominator = oldFeeSettings.continuousFundraisingFeeDenominator();
         uint oldTokenFeeDenominator = oldFeeSettings.tokenFeeDenominator();
@@ -168,7 +168,12 @@ contract tokenTest is Test {
     function testAcceptFeeCollectorInsteadOfFeeSettings(address newFeeSettingsPretendAddress) public {
         vm.assume(newFeeSettingsPretendAddress != address(0));
         Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
-        FeeSettings newFeeSettings = new FeeSettings(fees, newFeeSettingsPretendAddress);
+        FeeSettings newFeeSettings = new FeeSettings(
+            fees,
+            newFeeSettingsPretendAddress,
+            newFeeSettingsPretendAddress,
+            newFeeSettingsPretendAddress
+        );
         vm.assume(newFeeSettingsPretendAddress != address(newFeeSettings));
 
         vm.prank(feeSettings.owner());
@@ -183,8 +188,18 @@ contract tokenTest is Test {
 
     function testAcceptWrongFeeSettings() public {
         Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
-        FeeSettings realNewFeeSettings = new FeeSettings(fees, feeSettings.feeCollector());
-        FeeSettings fakeNewFeeSettings = new FeeSettings(fees, feeSettings.feeCollector());
+        FeeSettings realNewFeeSettings = new FeeSettings(
+            fees,
+            feeSettings.feeCollector(),
+            feeSettings.feeCollector(),
+            feeSettings.feeCollector()
+        );
+        FeeSettings fakeNewFeeSettings = new FeeSettings(
+            fees,
+            feeSettings.feeCollector(),
+            feeSettings.feeCollector(),
+            feeSettings.feeCollector()
+        );
 
         assertTrue(
             address(fakeNewFeeSettings) != address(realNewFeeSettings),

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -312,12 +312,12 @@ contract tokenTest is Test {
         FeeSettings[] memory feeSettingsArray = new FeeSettings[](3);
         feeSettingsArray[0] = new FeeSettingsFailERC165Check0(fees, feeSettings.feeCollector());
         feeSettingsArray[1] = new FeeSettingsFailERC165Check1(fees, feeSettings.feeCollector());
-        feeSettingsArray[2] = new FeeSettingsFailIFeeSettingsV1Check(fees, feeSettings.feeCollector());
+        feeSettingsArray[2] = new FeeSettingsFailIFeeSettingsV2Check(fees, feeSettings.feeCollector());
 
         vm.startPrank(feeSettings.owner());
         // cycle through the fake contracts and make sure each one triggers a revert
         for (uint i = 0; i < feeSettingsArray.length; i++) {
-            vm.expectRevert("FeeSettings must implement IFeeSettingsV1");
+            vm.expectRevert("FeeSettings must implement IFeeSettingsV2");
             token.suggestNewFeeSettings(feeSettingsArray[i]);
         }
         vm.stopPrank();

--- a/test/resources/WrongFeeSettings.sol
+++ b/test/resources/WrongFeeSettings.sol
@@ -8,7 +8,10 @@ import "../../contracts/FeeSettings.sol";
     fake currency to test the main contract with
 */
 contract FeeSettingsFailERC165Check0 is FeeSettings {
-    constructor(Fees memory _fees, address _feeCollector) FeeSettings(_fees, _feeCollector) {}
+    constructor(
+        Fees memory _fees,
+        address _feeCollector
+    ) FeeSettings(_fees, _feeCollector, _feeCollector, _feeCollector) {}
 
     function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
         if (interfaceId == 0x01ffc9a7) {
@@ -20,7 +23,10 @@ contract FeeSettingsFailERC165Check0 is FeeSettings {
 }
 
 contract FeeSettingsFailERC165Check1 is FeeSettings {
-    constructor(Fees memory _fees, address _feeCollector) FeeSettings(_fees, _feeCollector) {}
+    constructor(
+        Fees memory _fees,
+        address _feeCollector
+    ) FeeSettings(_fees, _feeCollector, _feeCollector, _feeCollector) {}
 
     function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
         if (interfaceId == 0x01ffc9a7) {
@@ -33,7 +39,10 @@ contract FeeSettingsFailERC165Check1 is FeeSettings {
 }
 
 contract FeeSettingsFailIFeeSettingsV1Check is FeeSettings {
-    constructor(Fees memory _fees, address _feeCollector) FeeSettings(_fees, _feeCollector) {}
+    constructor(
+        Fees memory _fees,
+        address _feeCollector
+    ) FeeSettings(_fees, _feeCollector, _feeCollector, _feeCollector) {}
 
     function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
         if (interfaceId == 0x01ffc9a7) {

--- a/test/resources/WrongFeeSettings.sol
+++ b/test/resources/WrongFeeSettings.sol
@@ -38,7 +38,7 @@ contract FeeSettingsFailERC165Check1 is FeeSettings {
     }
 }
 
-contract FeeSettingsFailIFeeSettingsV1Check is FeeSettings {
+contract FeeSettingsFailIFeeSettingsV2Check is FeeSettings {
     constructor(
         Fees memory _fees,
         address _feeCollector
@@ -49,7 +49,7 @@ contract FeeSettingsFailIFeeSettingsV1Check is FeeSettings {
             return true; // signal that we support ERC165
         } else if (interfaceId == 0xffffffff) {
             return false; // signal that we support ERC165
-        } else if (interfaceId == type(IFeeSettingsV1).interfaceId) {
+        } else if (interfaceId == type(IFeeSettingsV2).interfaceId) {
             return false; // signal that we don't support IFeeSettingsV1
         }
         return FeeSettings.supportsInterface(interfaceId);


### PR DESCRIPTION
# Changes
## Introduce 2 new feeCollectors to `FeeSettings`:
- `continuousFundraisingFeeCollector`
- `personalInviteFeeCollector`
- `feeCollector` is now `tokenFeeCollector`, but for compatibility `feeCollector()` still works.

This required an update from `IFeeSettingsV1` to `IFeeSettingsV2`. Currently, `FeeSettings` implements both.

## Introduce a higher fee ceiling for ContinuousFundraising
max fee is now 10% for ContinuousFundraising, see [decision](https://corpusventures.slack.com/archives/C02P9SN9W4T/p1695730014568399)