### PR TITLE
introduce higher fee ceiling for ContinuousFundraising

### DIFF
--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -11,6 +11,10 @@ import "./interfaces/IFeeSettings.sol";
  * @notice The FeeSettings contract is used to manage fees paid to the tokenize.it platfom
  */
 contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV1 {
+    uint128 public constant MIN_TOKEN_FEE_DENOMINATOR = 20;
+    uint128 public constant MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR = 10;
+    uint128 public constant MIN_PERSONAL_INVITE_FEE_DENOMINATOR = 20;
+
     /// Denominator to calculate fees paid in Token.sol. UINT256_MAX means no fees.
     uint256 public tokenFeeDenominator;
     /// Denominator to calculate fees paid in ContinuousFundraising.sol. UINT256_MAX means no fees.
@@ -107,12 +111,18 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV1 {
      * @param _fees The fees to check
      */
     function checkFeeLimits(Fees memory _fees) internal pure {
-        require(_fees.tokenFeeDenominator >= 20, "Fee must be equal or less 5% (denominator must be >= 20)");
         require(
-            _fees.continuousFundraisingFeeDenominator >= 20,
+            _fees.tokenFeeDenominator >= MIN_TOKEN_FEE_DENOMINATOR,
             "Fee must be equal or less 5% (denominator must be >= 20)"
         );
-        require(_fees.personalInviteFeeDenominator >= 20, "Fee must be equal or less 5% (denominator must be >= 20)");
+        require(
+            _fees.continuousFundraisingFeeDenominator >= MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR,
+            "ContinuousFundraising fee must be equal or less 10% (denominator must be >= 10)"
+        );
+        require(
+            _fees.personalInviteFeeDenominator >= MIN_PERSONAL_INVITE_FEE_DENOMINATOR,
+            "Fee must be equal or less 5% (denominator must be >= 20)"
+        );
     }
 
     /**


### PR DESCRIPTION
This change is needed in a backwards-compatible way, in order to charge more than 5% of the payment for continuous fundraising