### PR TITLE
make fees more finely adjustable

### DIFF
--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -16,17 +16,17 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     uint128 public constant MIN_PERSONAL_INVITE_FEE_DENOMINATOR = 20;
 
     /// Denominator to calculate fees paid in Token.sol. UINT256_MAX means no fees.
-    uint256 public tokenFeeDenominator;
+    FeeFactor public tokenFeeFactor;
     /// address the token fees have to be paid to
     address public tokenFeeCollector;
 
     /// Denominator to calculate fees paid in PublicFundraising.sol. UINT256_MAX means no fees.
-    uint256 public publicFundraisingFeeDenominator;
+    FeeFactor public publicFundraisingFeeFactor;
     /// address the public fundraising fees have to be paid to
     address public publicFundraisingFeeCollector;
 
     /// Denominator to calculate fees paid in PrivateOffer.sol. UINT256_MAX means no fees.
-    uint256 public privateOfferFeeDenominator;
+    FeeFactor public privateOfferFeeFactor;
     /// address the private offer fees have to be paid to
     address public privateOfferFeeCollector;
 
@@ -34,16 +34,12 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     Fees public proposedFees;
 
     /**
-     * @notice Fee denominators have been set to the following values: `tokenFeeDenominator`, `publicFundraisingFeeDenominator`, `privateOfferFeeDenominator`
-     * @param tokenFeeDenominator Defines the fee paid in Token.sol. UINT256_MAX means no fees.
-     * @param publicFundraisingFeeDenominator Defines the fee paid in PublicFundraising.sol. UINT256_MAX means no fees.
-     * @param privateOfferFeeDenominator Defines the fee paid in PrivateOffer.sol. UINT256_MAX means no fees.
+     * @notice Fee denominators have been set to the following values: `tokenFeeFactor`, `publicFundraisingFeeFactor`, `privateOfferFeeFactor`
+     * @param tokenFee Defines the fee paid in Token.sol. UINT256_MAX means no fees.
+     * @param publicFundraisingFee Defines the fee paid in PublicFundraising.sol. UINT256_MAX means no fees.
+     * @param privateOfferFee Defines the fee paid in PrivateOffer.sol. UINT256_MAX means no fees.
      */
-    event SetFeeDenominators(
-        uint256 tokenFeeDenominator,
-        uint256 publicFundraisingFeeDenominator,
-        uint256 privateOfferFeeDenominator
-    );
+    event SetFeeFactors(FeeFactor tokenFee, FeeFactor publicFundraisingFee, FeeFactor privateOfferFee);
 
     /**
      * @notice The fee collector has been changed to `newFeeCollector`
@@ -75,9 +71,9 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
         address _privateOfferFeeCollector
     ) {
         checkFeeLimits(_fees);
-        tokenFeeDenominator = _fees.tokenFeeDenominator;
-        publicFundraisingFeeDenominator = _fees.publicFundraisingFeeDenominator;
-        privateOfferFeeDenominator = _fees.privateOfferFeeDenominator;
+        tokenFeeFactor = _fees.tokenFeeFactor;
+        publicFundraisingFeeFactor = _fees.publicFundraisingFeeFactor;
+        privateOfferFeeFactor = _fees.privateOfferFeeFactor;
         require(_tokenFeeCollector != address(0), "Fee collector cannot be 0x0");
         tokenFeeCollector = _tokenFeeCollector;
         require(_publicFundraisingFeeCollector != address(0), "Fee collector cannot be 0x0");
@@ -96,9 +92,9 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
 
         // if at least one fee increases, enforce minimum delay
         if (
-            _fees.tokenFeeDenominator < tokenFeeDenominator ||
-            _fees.publicFundraisingFeeDenominator < publicFundraisingFeeDenominator ||
-            _fees.privateOfferFeeDenominator < privateOfferFeeDenominator
+            _isFractionAGreater(_fees.tokenFeeFactor, tokenFeeFactor) ||
+            _isFractionAGreater(_fees.publicFundraisingFeeFactor, publicFundraisingFeeFactor) ||
+            _isFractionAGreater(_fees.privateOfferFeeFactor, privateOfferFeeFactor)
         ) {
             require(_fees.time > block.timestamp + 12 weeks, "Fee change must be at least 12 weeks in the future");
         }
@@ -107,14 +103,23 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     }
 
     /**
+     * Compares two fractions and returns true if the first one is greater than the second one
+     * @param _a input fraction a
+     * @param _b input fraction b
+     */
+    function _isFractionAGreater(FeeFactor memory _a, FeeFactor memory _b) internal pure returns (bool) {
+        return _a.numerator * _b.denominator > _b.numerator * _a.denominator;
+    }
+
+    /**
      * @notice Executes a fee change that has been planned before
      */
     function executeFeeChange() external onlyOwner {
         require(block.timestamp >= proposedFees.time, "Fee change must be executed after the change time");
-        tokenFeeDenominator = proposedFees.tokenFeeDenominator;
-        publicFundraisingFeeDenominator = proposedFees.publicFundraisingFeeDenominator;
-        privateOfferFeeDenominator = proposedFees.privateOfferFeeDenominator;
-        emit SetFeeDenominators(tokenFeeDenominator, publicFundraisingFeeDenominator, privateOfferFeeDenominator);
+        tokenFeeFactor = proposedFees.tokenFeeFactor;
+        publicFundraisingFeeFactor = proposedFees.publicFundraisingFeeFactor;
+        privateOfferFeeFactor = proposedFees.privateOfferFeeFactor;
+        emit SetFeeFactors(tokenFeeFactor, publicFundraisingFeeFactor, privateOfferFeeFactor);
         delete proposedFees;
     }
 
@@ -142,15 +147,17 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
      */
     function checkFeeLimits(Fees memory _fees) internal pure {
         require(
-            _fees.tokenFeeDenominator >= MIN_TOKEN_FEE_DENOMINATOR,
+            _fees.tokenFeeFactor.denominator / _fees.tokenFeeFactor.numerator >= MIN_TOKEN_FEE_DENOMINATOR,
             "Fee must be equal or less 5% (denominator must be >= 20)"
         );
         require(
-            _fees.publicFundraisingFeeDenominator >= MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR,
+            _fees.publicFundraisingFeeFactor.denominator / _fees.publicFundraisingFeeFactor.numerator >=
+                MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR,
             "PublicFundraising fee must be equal or less 10% (denominator must be >= 10)"
         );
         require(
-            _fees.privateOfferFeeDenominator >= MIN_PERSONAL_INVITE_FEE_DENOMINATOR,
+            _fees.privateOfferFeeFactor.denominator / _fees.privateOfferFeeFactor.numerator >=
+                MIN_PERSONAL_INVITE_FEE_DENOMINATOR,
             "Fee must be equal or less 5% (denominator must be >= 20)"
         );
     }
@@ -160,7 +167,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
      * @dev will wrongly return 1 if denominator and amount are both uint256 max
      */
     function tokenFee(uint256 _tokenAmount) external view override(IFeeSettingsV1, IFeeSettingsV2) returns (uint256) {
-        return _tokenAmount / tokenFeeDenominator;
+        return (_tokenAmount * tokenFeeFactor.numerator) / tokenFeeFactor.denominator;
     }
 
     /**
@@ -172,7 +179,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     function publicFundraisingFee(
         uint256 _currencyAmount
     ) external view override(IFeeSettingsV1, IFeeSettingsV2) returns (uint256) {
-        return _currencyAmount / publicFundraisingFeeDenominator;
+        return (_currencyAmount * publicFundraisingFeeFactor.numerator) / publicFundraisingFeeFactor.denominator;
     }
 
     /**
@@ -184,7 +191,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     function privateOfferFee(
         uint256 _currencyAmount
     ) external view override(IFeeSettingsV1, IFeeSettingsV2) returns (uint256) {
-        return _currencyAmount / privateOfferFeeDenominator;
+        return (_currencyAmount * privateOfferFeeFactor.denominator) / privateOfferFeeFactor.denominator;
     }
 
     /**

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -35,9 +35,20 @@ interface IFeeSettingsV2 {
     function supportsInterface(bytes4) external view returns (bool); //because we inherit from ERC165
 }
 
+/**
+ * @title FeeFactor struct
+ * @notice FeeFactor is a struct used to represent a fee factor, split into a numerator and a denominator
+ * @dev The fee factor is calculated as `numerator / denominator`
+ * @dev As fees over 100% don't make sense, the denominator will almost always be greater than or equal to the numerator
+ */
+struct FeeFactor {
+    uint128 numerator;
+    uint128 denominator;
+}
+
 struct Fees {
-    uint256 tokenFeeDenominator;
-    uint256 publicFundraisingFeeDenominator;
-    uint256 privateOfferFeeDenominator;
+    FeeFactor tokenFeeFactor;
+    FeeFactor publicFundraisingFeeFactor;
+    FeeFactor privateOfferFeeFactor;
     uint256 time;
 }

--- a/script/DeployPlatform.s.sol
+++ b/script/DeployPlatform.s.sol
@@ -29,7 +29,8 @@ contract DeployPlatform is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         console.log("Deploying FeeSettings contract...");
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         FeeSettings feeSettings = new FeeSettings(fees, platformColdWallet, platformColdWallet, platformColdWallet);
         console.log("FeeSettings deployed at: ", address(feeSettings));
         feeSettings.transferOwnership(platformColdWallet);

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -52,9 +52,9 @@ contract TokenERC2771Test is Test {
     address public constant platformAdmin = 0x3109709ECfA91A80626fF3989D68f67F5B1Dd123;
     address public constant feeCollector = 0x0109709eCFa91a80626FF3989D68f67f5b1dD120;
 
-    uint256 public constant tokenFeeDenominator = 100;
-    uint256 public constant publicFundraisingFeeDenominator = 50;
-    uint256 public constant privateOfferFeeDenominator = 70;
+    uint128 public constant tokenFeeDenominator = 100;
+    uint128 public constant publicFundraisingFeeDenominator = 50;
+    uint128 public constant privateOfferFeeDenominator = 70;
 
     bytes32 domainSeparator;
     bytes32 requestType;
@@ -69,7 +69,12 @@ contract TokenERC2771Test is Test {
         allowList = new AllowList();
 
         // deploy fee settings
-        Fees memory fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory fees = Fees(
+            FeeFactor(1, tokenFeeDenominator),
+            FeeFactor(1, publicFundraisingFeeDenominator),
+            FeeFactor(1, privateOfferFeeDenominator),
+            0
+        );
         vm.prank(platformAdmin);
         feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
 

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -35,17 +35,22 @@ contract FeeSettingsTest is Test {
 
     uint256 public constant price = 10000000;
 
+    FeeFactor feeOnePercent = FeeFactor(1, 100);
+
     function testEnforceFeeDenominatorRangeInConstructor(uint8 fee) public {
-        vm.assume(!tokenOrPrivateOfferFeeInValidRange(fee));
+        vm.assume(!tokenOrPrivateOfferFeeInValidRange(1, fee));
         Fees memory _fees;
 
+        FeeFactor memory feeThreePercent = FeeFactor(3, 100);
+        FeeFactor memory feeVariable = FeeFactor(1, fee);
+
         console.log("Testing token fee");
-        _fees = Fees(fee, 30, 100, 0);
+        _fees = Fees(feeVariable, feeThreePercent, feeOnePercent, 0);
         vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
         new FeeSettings(_fees, admin, admin, admin);
 
         console.log("Testing PublicFundraising fee");
-        _fees = Fees(30, fee, 100, 0);
+        _fees = Fees(feeThreePercent, feeVariable, feeOnePercent, 0);
         if (fee < 10) {
             vm.expectRevert("PublicFundraising fee must be equal or less 10% (denominator must be >= 10)");
             new FeeSettings(_fees, admin, admin, admin);
@@ -55,110 +60,89 @@ contract FeeSettingsTest is Test {
         }
 
         console.log("Testing PrivateOffer fee");
-        _fees = Fees(30, 40, fee, 0);
+        _fees = Fees(feeThreePercent, feeOnePercent, feeVariable, 0);
         vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
         new FeeSettings(_fees, admin, admin, admin);
     }
 
-    function testEnforceTokenFeeDenominatorRangeInFeeChanger(uint8 fee) public {
-        vm.assume(!tokenOrPrivateOfferFeeInValidRange(fee));
-        Fees memory fees = Fees(100, 100, 100, 0);
+    function testEnforceTokenFeeDenominatorRangeInFeeChanger(uint128 fee) public {
+        vm.assume(!tokenOrPrivateOfferFeeInValidRange(1, fee));
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: fee,
-            publicFundraisingFeeDenominator: 100,
-            privateOfferFeeDenominator: 100,
-            time: block.timestamp + 7884001
-        });
+        Fees memory feeChange = Fees(FeeFactor(1, fee), feeOnePercent, feeOnePercent, block.timestamp + 7884001);
         vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
         _feeSettings.planFeeChange(feeChange);
     }
 
     function testEnforcePublicFundraisingFeeDenominatorRangeInFeeChanger(uint8 fee) public {
         vm.assume(fee < 10);
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: 100,
-            publicFundraisingFeeDenominator: fee,
-            privateOfferFeeDenominator: 100,
-            time: block.timestamp + 7884001
-        });
+        Fees memory feeChange = Fees(feeOnePercent, FeeFactor(1, fee), feeOnePercent, block.timestamp + 7884001);
+
         vm.expectRevert("PublicFundraising fee must be equal or less 10% (denominator must be >= 10)");
         _feeSettings.planFeeChange(feeChange);
     }
 
     function testEnforcePrivateOfferFeeDenominatorRangeInFeeChanger(uint8 fee) public {
-        vm.assume(!tokenOrPrivateOfferFeeInValidRange(fee));
-        Fees memory fees = Fees(100, 100, 100, 0);
+        vm.assume(!tokenOrPrivateOfferFeeInValidRange(1, fee));
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: 100,
-            publicFundraisingFeeDenominator: 100,
-            privateOfferFeeDenominator: fee,
-            time: block.timestamp + 7884001
-        });
+        Fees memory feeChange = Fees(feeOnePercent, feeOnePercent, FeeFactor(1, fee), block.timestamp + 7884001);
+
         vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
         _feeSettings.planFeeChange(feeChange);
     }
 
-    function testEnforceFeeChangeDelayOnIncrease(uint delay, uint startDenominator, uint newDenominator) public {
+    function testEnforceFeeChangeDelayOnIncrease(uint delay, uint128 startDenominator, uint128 newDenominator) public {
         vm.assume(delay <= 12 weeks);
         vm.assume(startDenominator >= 20 && newDenominator >= 20);
         vm.assume(newDenominator < startDenominator);
-        Fees memory fees = Fees(startDenominator, startDenominator, startDenominator, 0);
+        FeeFactor memory startFactor = FeeFactor(1, startDenominator);
+        FeeFactor memory newFactor = FeeFactor(1, newDenominator);
+        Fees memory fees = Fees(startFactor, startFactor, startFactor, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: newDenominator,
-            publicFundraisingFeeDenominator: UINT256_MAX,
-            privateOfferFeeDenominator: UINT256_MAX,
-            time: block.timestamp + delay
-        });
+        Fees memory feeChange = Fees(newFactor, startFactor, startFactor, block.timestamp + delay);
         vm.prank(admin);
         vm.expectRevert("Fee change must be at least 12 weeks in the future");
         _feeSettings.planFeeChange(feeChange);
 
-        feeChange = Fees({
-            tokenFeeDenominator: UINT256_MAX,
-            publicFundraisingFeeDenominator: newDenominator,
-            privateOfferFeeDenominator: UINT256_MAX,
-            time: block.timestamp + delay
-        });
+        feeChange = Fees(startFactor, newFactor, startFactor, block.timestamp + delay);
+
         vm.prank(admin);
         vm.expectRevert("Fee change must be at least 12 weeks in the future");
         _feeSettings.planFeeChange(feeChange);
 
-        feeChange = Fees({
-            tokenFeeDenominator: UINT256_MAX,
-            publicFundraisingFeeDenominator: UINT256_MAX,
-            privateOfferFeeDenominator: newDenominator,
-            time: block.timestamp + delay
-        });
+        feeChange = Fees(startFactor, startFactor, newFactor, block.timestamp + delay);
         vm.prank(admin);
         vm.expectRevert("Fee change must be at least 12 weeks in the future");
         _feeSettings.planFeeChange(feeChange);
     }
 
-    function testExecuteFeeChangeTooEarly(uint delayAnnounced, uint256 tokenFee, uint256 investmentFee) public {
+    function testExecuteFeeChangeTooEarly(uint delayAnnounced, uint128 tokenFee, uint128 investmentFee) public {
         vm.assume(delayAnnounced > 12 weeks && delayAnnounced < 1000000000000);
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFee));
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(investmentFee));
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(1, tokenFee));
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(1, investmentFee));
 
-        Fees memory fees = Fees(50, 50, 50, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 50);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: tokenFee,
-            publicFundraisingFeeDenominator: investmentFee,
-            privateOfferFeeDenominator: 100,
-            time: block.timestamp + delayAnnounced
-        });
+        Fees memory feeChange = Fees(
+            FeeFactor(1, tokenFee),
+            FeeFactor(1, investmentFee),
+            FeeFactor(1, 100),
+            block.timestamp + delayAnnounced
+        );
         vm.prank(admin);
         _feeSettings.planFeeChange(feeChange);
 
@@ -170,24 +154,26 @@ contract FeeSettingsTest is Test {
 
     function testExecuteFeeChangeProperly(
         uint delayAnnounced,
-        uint256 tokenFee,
-        uint256 fundraisingFee,
-        uint256 privateOfferFee
+        uint128 tokenFee,
+        uint128 fundraisingFee,
+        uint128 privateOfferFee
     ) public {
         vm.assume(delayAnnounced > 12 weeks && delayAnnounced < 100000000000);
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFee));
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(fundraisingFee));
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(privateOfferFee));
-        Fees memory fees = Fees(50, 50, 50, 0);
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(1, tokenFee));
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(1, fundraisingFee));
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(1, privateOfferFee));
+        FeeFactor memory feeFactor = FeeFactor(1, 50);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: tokenFee,
-            publicFundraisingFeeDenominator: fundraisingFee,
-            privateOfferFeeDenominator: privateOfferFee,
-            time: block.timestamp + delayAnnounced
-        });
+        Fees memory feeChange = Fees(
+            FeeFactor(1, tokenFee),
+            FeeFactor(1, fundraisingFee),
+            FeeFactor(1, privateOfferFee),
+            block.timestamp + delayAnnounced
+        );
+
         vm.prank(admin);
         vm.expectEmit(true, true, true, true, address(_feeSettings));
         emit ChangeProposed(feeChange);
@@ -199,26 +185,29 @@ contract FeeSettingsTest is Test {
         emit SetFeeDenominators(tokenFee, fundraisingFee, privateOfferFee);
         _feeSettings.executeFeeChange();
 
-        assertEq(_feeSettings.tokenFeeDenominator(), tokenFee);
-        assertEq(_feeSettings.publicFundraisingFeeDenominator(), fundraisingFee);
-        //assertEq(_feeSettings.change, 0);
+        (, uint128 currentTokenFeeDenominator) = _feeSettings.tokenFeeFactor();
+        assertEq(currentTokenFeeDenominator, tokenFee);
+        (, uint128 currentPublicFundraisingFeeDenominator) = _feeSettings.publicFundraisingFeeFactor();
+        assertEq(currentPublicFundraisingFeeDenominator, fundraisingFee);
+        (, uint128 currentPrivateOfferFeeDenominator) = _feeSettings.privateOfferFeeFactor();
+        assertEq(currentPrivateOfferFeeDenominator, privateOfferFee);
     }
 
     function testSetFeeTo0Immediately() public {
-        Fees memory fees = Fees(50, 20, 30, 0);
+        Fees memory fees = Fees(FeeFactor(1, 50), FeeFactor(1, 20), FeeFactor(1, 30), 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: UINT256_MAX,
-            publicFundraisingFeeDenominator: UINT256_MAX,
-            privateOfferFeeDenominator: UINT256_MAX,
-            time: 0
-        });
-
-        assertEq(_feeSettings.tokenFeeDenominator(), 50);
-        assertEq(_feeSettings.publicFundraisingFeeDenominator(), 20);
-        assertEq(_feeSettings.privateOfferFeeDenominator(), 30);
+        Fees memory feeChange = Fees(FeeFactor(0, 1), FeeFactor(0, 1), FeeFactor(0, 1), 0);
+        (uint128 numerator, uint128 denominator) = _feeSettings.tokenFeeFactor();
+        assertEq(numerator, 1, "Token fee numerator mismatch");
+        assertEq(denominator, 50, "Token fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.publicFundraisingFeeFactor();
+        assertEq(numerator, 1, "Public fundraising fee numerator mismatch");
+        assertEq(denominator, 20, "Public fundraising fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.privateOfferFeeFactor();
+        assertEq(numerator, 1, "Private offer fee numerator mismatch");
+        assertEq(denominator, 30, "Private offer fee denominator mismatch");
 
         vm.prank(admin);
         _feeSettings.planFeeChange(feeChange);
@@ -227,28 +216,34 @@ contract FeeSettingsTest is Test {
         //vm.warp(block.timestamp + delayAnnounced + 1);
         _feeSettings.executeFeeChange();
 
-        assertEq(_feeSettings.tokenFeeDenominator(), UINT256_MAX);
-        assertEq(_feeSettings.publicFundraisingFeeDenominator(), UINT256_MAX);
-        assertEq(_feeSettings.privateOfferFeeDenominator(), UINT256_MAX);
-
-        //assertEq(_feeSettings.change, 0);
+        (numerator, denominator) = _feeSettings.tokenFeeFactor();
+        assertEq(numerator, 0, "Token fee numerator mismatch");
+        assertEq(denominator, 1, "Token fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.publicFundraisingFeeFactor();
+        assertEq(numerator, 0, "Public fundraising fee numerator mismatch");
+        assertEq(denominator, 1, "Public fundraising fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.privateOfferFeeFactor();
+        assertEq(numerator, 0, "Private offer fee numerator mismatch");
+        assertEq(denominator, 1, "Private offer fee denominator mismatch");
     }
 
     function testSetFeeToXFrom0Immediately() public {
-        Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
+        Fees memory fees = Fees(FeeFactor(0, 1), FeeFactor(0, 1), FeeFactor(0, 1), 0);
+
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: 20,
-            publicFundraisingFeeDenominator: 30,
-            privateOfferFeeDenominator: 50,
-            time: 0
-        });
+        Fees memory feeChange = Fees(FeeFactor(1, 50), FeeFactor(1, 20), FeeFactor(1, 30), 0);
 
-        assertEq(_feeSettings.tokenFeeDenominator(), UINT256_MAX);
-        assertEq(_feeSettings.publicFundraisingFeeDenominator(), UINT256_MAX);
-        assertEq(_feeSettings.privateOfferFeeDenominator(), UINT256_MAX);
+        (uint128 numerator, uint128 denominator) = _feeSettings.tokenFeeFactor();
+        assertEq(numerator, 0, "Token fee numerator mismatch");
+        assertEq(denominator, 1, "Token fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.publicFundraisingFeeFactor();
+        assertEq(numerator, 0, "Public fundraising fee numerator mismatch");
+        assertEq(denominator, 1, "Public fundraising fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.privateOfferFeeFactor();
+        assertEq(numerator, 0, "Private offer fee numerator mismatch");
+        assertEq(denominator, 1, "Private offer fee denominator mismatch");
 
         vm.prank(admin);
         vm.expectRevert("Fee change must be at least 12 weeks in the future");
@@ -256,27 +251,33 @@ contract FeeSettingsTest is Test {
     }
 
     function testReduceFeeImmediately(
-        uint256 tokenReductor,
-        uint256 continuousReductor,
-        uint256 personalReductor
+        uint128 tokenReductor,
+        uint128 continuousReductor,
+        uint128 personalReductor
     ) public {
         vm.assume(tokenReductor >= 50);
         vm.assume(continuousReductor >= 20);
         vm.assume(personalReductor >= 30);
-        Fees memory fees = Fees(50, 20, 30, 0);
+        Fees memory fees = Fees(FeeFactor(1, 50), FeeFactor(1, 20), FeeFactor(1, 30), 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: tokenReductor,
-            publicFundraisingFeeDenominator: continuousReductor,
-            privateOfferFeeDenominator: personalReductor,
-            time: 0
-        });
+        Fees memory feeChange = Fees(
+            FeeFactor(1, tokenReductor),
+            FeeFactor(1, continuousReductor),
+            FeeFactor(1, personalReductor),
+            0
+        );
 
-        assertEq(_feeSettings.tokenFeeDenominator(), 50);
-        assertEq(_feeSettings.publicFundraisingFeeDenominator(), 20);
-        assertEq(_feeSettings.privateOfferFeeDenominator(), 30);
+        (uint128 numerator, uint128 denominator) = _feeSettings.tokenFeeFactor();
+        assertEq(numerator, 1, "Token fee numerator mismatch");
+        assertEq(denominator, 50, "Token fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.publicFundraisingFeeFactor();
+        assertEq(numerator, 1, "Public fundraising fee numerator mismatch");
+        assertEq(denominator, 20, "Public fundraising fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.privateOfferFeeFactor();
+        assertEq(numerator, 1, "Private offer fee numerator mismatch");
+        assertEq(denominator, 30, "Private offer fee denominator mismatch");
 
         vm.prank(admin);
         _feeSettings.planFeeChange(feeChange);
@@ -285,33 +286,60 @@ contract FeeSettingsTest is Test {
         //vm.warp(block.timestamp + delayAnnounced + 1);
         _feeSettings.executeFeeChange();
 
-        assertEq(_feeSettings.tokenFeeDenominator(), tokenReductor);
-        assertEq(_feeSettings.publicFundraisingFeeDenominator(), continuousReductor);
-        assertEq(_feeSettings.privateOfferFeeDenominator(), personalReductor);
-
-        //assertEq(_feeSettings.change, 0);
+        (numerator, denominator) = _feeSettings.tokenFeeFactor();
+        assertEq(numerator, 1, "Token fee numerator mismatch");
+        assertEq(denominator, tokenReductor, "Token fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.publicFundraisingFeeFactor();
+        assertEq(numerator, 1, "Public fundraising fee numerator mismatch");
+        assertEq(denominator, continuousReductor, "Public fundraising fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.privateOfferFeeFactor();
+        assertEq(numerator, 1, "Private offer fee numerator mismatch");
+        assertEq(denominator, personalReductor, "Private offer fee denominator mismatch");
     }
 
-    function testSetFeeInConstructor(uint8 tokenFee, uint8 investmentFee) public {
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFee));
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(investmentFee));
+    function testSetFeeInConstructor(
+        uint128 tokenNumerator,
+        uint128 tokenDenominator,
+        uint128 publicNumerator,
+        uint128 publicDenominator,
+        uint128 privateNumerator,
+        uint128 privateDenominator
+    ) public {
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenNumerator, tokenDenominator));
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(publicNumerator, publicDenominator));
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(privateNumerator, privateDenominator));
+
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(tokenFee, investmentFee, investmentFee, 0);
+        Fees memory fees = Fees(
+            FeeFactor(tokenNumerator, tokenDenominator),
+            FeeFactor(publicNumerator, publicDenominator),
+            FeeFactor(privateNumerator, privateDenominator),
+            0
+        );
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
-        assertEq(_feeSettings.tokenFeeDenominator(), tokenFee, "Token fee mismatch");
-        assertEq(_feeSettings.publicFundraisingFeeDenominator(), investmentFee, "Investment fee mismatch");
+        (uint128 numerator, uint128 denominator) = _feeSettings.tokenFeeFactor();
+        assertEq(numerator, tokenNumerator, "Token fee numerator mismatch");
+        assertEq(denominator, tokenDenominator, "Token fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.publicFundraisingFeeFactor();
+        assertEq(numerator, publicNumerator, "Public fundraising fee numerator mismatch");
+        assertEq(denominator, publicDenominator, "Public fundraising fee denominator mismatch");
+        (numerator, denominator) = _feeSettings.privateOfferFeeFactor();
+        assertEq(numerator, privateNumerator, "Private offer fee numerator mismatch");
+        assertEq(denominator, privateDenominator, "Private offer fee denominator mismatch");
     }
 
     function testFeeCollector0FailsInConstructor() public {
         vm.expectRevert("Fee collector cannot be 0x0");
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         _feeSettings = new FeeSettings(fees, address(0), address(0), address(0));
     }
 
     function testFeeCollector0FailsInSetter() public {
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         vm.prank(admin);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
         vm.expectRevert("Fee collector cannot be 0x0");
@@ -334,7 +362,8 @@ contract FeeSettingsTest is Test {
         vm.assume(newPublicFundraisingFeeCollector != address(0));
         vm.assume(newPrivateOfferFeeCollector != address(0));
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         vm.prank(admin);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
         vm.expectEmit(true, true, true, true, address(_feeSettings));
@@ -351,21 +380,26 @@ contract FeeSettingsTest is Test {
         assertEq(_feeSettings.privateOfferFeeCollector(), newPrivateOfferFeeCollector);
     }
 
-    function tokenOrPrivateOfferFeeInValidRange(uint256 fee) internal pure returns (bool) {
-        return fee >= 20;
+    function tokenOrPrivateOfferFeeInValidRange(uint128 numerator, uint128 denominator) internal pure returns (bool) {
+        return denominator / numerator >= 20;
     }
 
     function testCalculateProperFees(
-        uint256 tokenFeeDenominator,
-        uint256 publicFundraisingFeeDenominator,
-        uint256 privateOfferFeeDenominator,
+        uint128 tokenFeeDenominator,
+        uint128 publicFundraisingFeeDenominator,
+        uint128 privateOfferFeeDenominator,
         uint256 amount
     ) public {
         vm.assume(tokenFeeDenominator >= 20 && tokenFeeDenominator < UINT256_MAX);
         vm.assume(publicFundraisingFeeDenominator >= 20 && publicFundraisingFeeDenominator < UINT256_MAX);
         vm.assume(privateOfferFeeDenominator >= 20 && privateOfferFeeDenominator < UINT256_MAX);
 
-        Fees memory _fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory _fees = Fees(
+            FeeFactor(1, tokenFeeDenominator),
+            FeeFactor(1, publicFundraisingFeeDenominator),
+            FeeFactor(1, privateOfferFeeDenominator),
+            0
+        );
         FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
@@ -382,9 +416,9 @@ contract FeeSettingsTest is Test {
     }
 
     function testCalculate0FeesForAmountLessThanUINT256_MAX(
-        uint256 tokenFeeDenominator,
-        uint256 publicFundraisingFeeDenominator,
-        uint256 privateOfferFeeDenominator,
+        uint128 tokenFeeDenominator,
+        uint128 publicFundraisingFeeDenominator,
+        uint128 privateOfferFeeDenominator,
         uint256 amount
     ) public {
         vm.assume(tokenFeeDenominator >= 20 && tokenFeeDenominator < UINT256_MAX);
@@ -394,7 +428,12 @@ contract FeeSettingsTest is Test {
 
         // only token fee is 0
 
-        Fees memory _fees = Fees(UINT256_MAX, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory _fees = Fees(
+            FeeFactor(0, 1),
+            FeeFactor(1, publicFundraisingFeeDenominator),
+            FeeFactor(1, privateOfferFeeDenominator),
+            0
+        );
         FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), 0, "Token fee mismatch");
@@ -411,7 +450,7 @@ contract FeeSettingsTest is Test {
 
         // only public fundraising fee is 0
 
-        _fees = Fees(tokenFeeDenominator, UINT256_MAX, privateOfferFeeDenominator, 0);
+        _fees = Fees(FeeFactor(1, tokenFeeDenominator), FeeFactor(0, 1), FeeFactor(1, privateOfferFeeDenominator), 0);
         _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
@@ -424,7 +463,12 @@ contract FeeSettingsTest is Test {
 
         // only private offer fee is 0
 
-        _fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, UINT256_MAX, 0);
+        _fees = Fees(
+            FeeFactor(1, tokenFeeDenominator),
+            FeeFactor(1, publicFundraisingFeeDenominator),
+            FeeFactor(0, 1),
+            0
+        );
         _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
@@ -438,7 +482,8 @@ contract FeeSettingsTest is Test {
 
     function testERC165IsAvailable() public {
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
         assertEq(
             _feeSettings.supportsInterface(0x01ffc9a7), // type(IERC165).interfaceId
@@ -449,7 +494,8 @@ contract FeeSettingsTest is Test {
 
     function testIFeeSettingsV1IsAvailable() public {
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         assertEq(
@@ -461,7 +507,8 @@ contract FeeSettingsTest is Test {
 
     function testIFeeSettingsV2IsAvailable() public {
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         assertEq(
@@ -476,7 +523,8 @@ contract FeeSettingsTest is Test {
         vm.assume(_nonsenseInterface != type(IFeeSettingsV2).interfaceId);
         vm.assume(_nonsenseInterface != 0x01ffc9a7);
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         assertEq(_feeSettings.supportsInterface(0x01ffc9b7), false, "This interface should not be supported");
@@ -487,9 +535,9 @@ contract FeeSettingsTest is Test {
      *      if denominator is UINT256_MAX and amount is UINT256_MAX, the result will be 1 instead of 0
      */
     function testCalculate0FeesForAmountUINT256_MAX(
-        uint256 tokenFeeDenominator,
-        uint256 publicFundraisingFeeDenominator,
-        uint256 privateOfferFeeDenominator
+        uint128 tokenFeeDenominator,
+        uint128 publicFundraisingFeeDenominator,
+        uint128 privateOfferFeeDenominator
     ) public {
         vm.assume(tokenFeeDenominator >= 20 && tokenFeeDenominator < UINT256_MAX);
         vm.assume(publicFundraisingFeeDenominator >= 20 && publicFundraisingFeeDenominator < UINT256_MAX);
@@ -498,7 +546,12 @@ contract FeeSettingsTest is Test {
 
         // only token fee is 0
 
-        Fees memory _fees = Fees(UINT256_MAX, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory _fees = Fees(
+            FeeFactor(0, 1),
+            FeeFactor(1, publicFundraisingFeeDenominator),
+            FeeFactor(1, privateOfferFeeDenominator),
+            0
+        );
         FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), 1, "Token fee mismatch");
@@ -515,7 +568,7 @@ contract FeeSettingsTest is Test {
 
         // only public fundraising fee is 0
 
-        _fees = Fees(tokenFeeDenominator, UINT256_MAX, privateOfferFeeDenominator, 0);
+        _fees = Fees(FeeFactor(1, tokenFeeDenominator), FeeFactor(0, 1), FeeFactor(1, privateOfferFeeDenominator), 0);
         _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
@@ -528,7 +581,12 @@ contract FeeSettingsTest is Test {
 
         // only private offer fee is 0
 
-        _fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, UINT256_MAX, 0);
+        _fees = Fees(
+            FeeFactor(1, tokenFeeDenominator),
+            FeeFactor(1, publicFundraisingFeeDenominator),
+            FeeFactor(0, 1),
+            0
+        );
         _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -61,7 +61,8 @@ contract MainnetCurrencies is Test {
 
     function setUp() public {
         list = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);
@@ -148,17 +149,17 @@ contract MainnetCurrencies is Test {
         assertEq(token.balanceOf(receiver), 0, "receiver has no tokens");
         assertEq(
             _currency.balanceOf(receiver),
-            _currencyCost - _currencyCost / FeeSettings(address(token.feeSettings())).publicFundraisingFeeDenominator(),
+            _currencyCost - FeeSettings(address(token.feeSettings())).publicFundraisingFee(_currencyCost),
             "receiver should have received currency"
         );
         assertEq(
             _currency.balanceOf(FeeSettings(address(token.feeSettings())).feeCollector()),
-            _currencyCost / FeeSettings(address(token.feeSettings())).publicFundraisingFeeDenominator(),
+            FeeSettings(address(token.feeSettings())).publicFundraisingFee(_currencyCost),
             "fee receiver should have received currency"
         );
         assertEq(
             token.balanceOf(FeeSettings(address(token.feeSettings())).feeCollector()),
-            amountOfTokenToBuy / FeeSettings(address(token.feeSettings())).publicFundraisingFeeDenominator(),
+            FeeSettings(address(token.feeSettings())).tokenFee(amountOfTokenToBuy),
             "fee receiver should have received tokens"
         );
         assertEq(_currency.balanceOf(buyer), _currencyAmount - _currencyCost, "buyer should have paid currency");

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -48,7 +48,8 @@ contract PrivateOfferTest is Test {
 
         list.set(tokenReceiver, requirements);
 
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         feeSettings = new FeeSettings(fees, wrongFeeReceiver, wrongFeeReceiver, admin);
 
         Token implementation = new Token(trustedForwarder);

--- a/test/PrivateOfferFactory.t.sol
+++ b/test/PrivateOfferFactory.t.sol
@@ -34,7 +34,8 @@ contract PrivateOfferFactoryTest is Test {
     function setUp() public {
         factory = new PrivateOfferFactory();
         list = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);

--- a/test/PrivateOfferTimeLock.t.sol
+++ b/test/PrivateOfferTimeLock.t.sol
@@ -41,7 +41,8 @@ contract PrivateOfferTimeLockTest is Test {
 
         list.set(tokenReceiver, requirements);
 
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);

--- a/test/PublicFundraisingCloneFactory.t.sol
+++ b/test/PublicFundraisingCloneFactory.t.sol
@@ -33,7 +33,8 @@ contract tokenTest is Test {
     function setUp() public {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         feeSettings = new FeeSettings(
             fees,
             feeSettingsAndAllowListOwner,

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -31,7 +31,8 @@ contract tokenTest is Test {
         vm.prank(admin);
         allowList = new AllowList();
         vm.prank(feeSettingsOwner);
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         feeSettings = new FeeSettings(fees, admin, admin, admin);
         token = Token(
             tokenCloneFactory.createTokenClone(

--- a/test/TokenCloneFactory.t.sol
+++ b/test/TokenCloneFactory.t.sol
@@ -31,7 +31,8 @@ contract tokenCloneFactoryTest is Test {
     function setUp() public {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         feeSettings = new FeeSettings(
             fees,
             feeSettingsAndAllowListOwner,

--- a/test/TokenERC2612.t.sol
+++ b/test/TokenERC2612.t.sol
@@ -64,7 +64,12 @@ contract TokenERC2612Test is Test {
         allowList = new AllowList();
 
         // deploy fee settings
-        Fees memory fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory fees = Fees(
+            FeeFactor(1, tokenFeeDenominator),
+            FeeFactor(1, publicFundraisingFeeDenominator),
+            FeeFactor(1, privateOfferFeeDenominator),
+            0
+        );
         vm.prank(platformAdmin);
         feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
 

--- a/test/TokenERC2771.t.sol
+++ b/test/TokenERC2771.t.sol
@@ -62,7 +62,12 @@ contract TokenERC2771Test is Test {
         allowList = new AllowList();
 
         // deploy fee settings
-        Fees memory fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory fees = Fees(
+            FeeFactor(1, tokenFeeDenominator),
+            FeeFactor(1, publicFundraisingFeeDenominator),
+            FeeFactor(1, privateOfferFeeDenominator),
+            0
+        );
         vm.prank(platformAdmin);
         feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
 

--- a/test/TokenGasConsumption.t.sol
+++ b/test/TokenGasConsumption.t.sol
@@ -27,7 +27,8 @@ contract tokenTest is Test {
     function setUp() public {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         feeSettings = new FeeSettings(
             fees,
             feeSettingsAndAllowListOwner,

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -31,7 +31,8 @@ contract tokenTest is Test {
         vm.prank(admin);
         allowList = new AllowList();
         vm.prank(feeSettingsOwner);
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeFactor memory feeFactor = FeeFactor(1, 100);
+        Fees memory fees = Fees(feeFactor, feeFactor, feeFactor, 0);
         feeSettings = new FeeSettings(fees, admin, admin, admin);
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));


### PR DESCRIPTION
make fees more finely adjustable by adding a numerator

Reducing storage further (below uint128) would not reduce gas cost because a struct always starts a new slot anyway.