### PR TITLE
Feature/fee settings numerator no struct

### DIFF
--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -95,8 +95,11 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
         address _privateOfferFeeCollector
     ) {
         checkFeeLimits(_fees);
+        tokenFeeNumerator = _fees.tokenFeeNumerator;
         tokenFeeDenominator = _fees.tokenFeeDenominator;
+        publicFundraisingFeeNumerator = _fees.publicFundraisingFeeNumerator;
         publicFundraisingFeeDenominator = _fees.publicFundraisingFeeDenominator;
+        privateOfferFeeNumerator = _fees.privateOfferFeeNumerator;
         privateOfferFeeDenominator = _fees.privateOfferFeeDenominator;
         require(_tokenFeeCollector != address(0), "Fee collector cannot be 0x0");
         tokenFeeCollector = _tokenFeeCollector;

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -56,7 +56,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
      * @param privateOfferFeeNumerator a in fraction a/b that defines the fee paid in currency for private offers: fee = amount * a / b
      * @param privateOfferFeeDenominator b in fraction a/b that defines the fee paid in currency for private offers: fee = amount * a / b
      */
-    event SetFeeDenominators(
+    event SetFee(
         uint32 tokenFeeNumerator,
         uint32 tokenFeeDenominator,
         uint32 publicFundraisingFeeNumerator,
@@ -155,7 +155,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
         publicFundraisingFeeDenominator = proposedFees.publicFundraisingFeeDenominator;
         privateOfferFeeNumerator = proposedFees.privateOfferFeeNumerator;
         privateOfferFeeDenominator = proposedFees.privateOfferFeeDenominator;
-        emit SetFeeDenominators(
+        emit SetFee(
             tokenFeeNumerator,
             tokenFeeDenominator,
             publicFundraisingFeeNumerator,
@@ -221,7 +221,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
                 MAX_CONTINUOUS_FUNDRAISING_FEE_NUMERATOR,
                 MAX_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR
             ),
-            "PublicFundraising fee must be equal or less 10% (denominator must be >= 10)"
+            "PublicFundraising fee must be equal or less 10%"
         );
         require(
             !_isFractionAGreater(
@@ -230,7 +230,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
                 MAX_PERSONAL_INVITE_FEE_NUMERATOR,
                 MAX_PERSONAL_INVITE_FEE_DENOMINATOR
             ),
-            "Fee must be equal or less 5% (denominator must be >= 20)"
+            "Fee must be equal or less 5%"
         );
     }
 

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -15,18 +15,26 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     uint128 public constant MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR = 10;
     uint128 public constant MIN_PERSONAL_INVITE_FEE_DENOMINATOR = 20;
 
-    /// Denominator to calculate fees paid in Token.sol. UINT256_MAX means no fees.
-    uint256 public tokenFeeDenominator;
+    /// Numerator to calculate fees paid in Token.sol.
+    uint32 public tokenFeeNumerator;
+    /// Denominator to calculate fees paid in Token.sol.
+    uint32 public tokenFeeDenominator;
+
+    /// Numerator to calculate fees paid in PublicFundraising.sol.
+    uint32 public publicFundraisingFeeNumerator;
+    /// Denominator to calculate fees paid in PublicFundraising.sol.
+    uint32 public publicFundraisingFeeDenominator;
+
+    /// Numerator to calculate fees paid in PrivateOffer.sol.
+    uint32 public privateOfferFeeNumerator;
+    /// Denominator to calculate fees paid in PrivateOffer.sol.
+    uint32 public privateOfferFeeDenominator;
+
     /// address the token fees have to be paid to
     address public tokenFeeCollector;
-
-    /// Denominator to calculate fees paid in PublicFundraising.sol. UINT256_MAX means no fees.
-    uint256 public publicFundraisingFeeDenominator;
     /// address the public fundraising fees have to be paid to
     address public publicFundraisingFeeCollector;
 
-    /// Denominator to calculate fees paid in PrivateOffer.sol. UINT256_MAX means no fees.
-    uint256 public privateOfferFeeDenominator;
     /// address the private offer fees have to be paid to
     address public privateOfferFeeCollector;
 
@@ -34,15 +42,21 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     Fees public proposedFees;
 
     /**
-     * @notice Fee denominators have been set to the following values: `tokenFeeDenominator`, `publicFundraisingFeeDenominator`, `privateOfferFeeDenominator`
-     * @param tokenFeeDenominator Defines the fee paid in Token.sol. UINT256_MAX means no fees.
-     * @param publicFundraisingFeeDenominator Defines the fee paid in PublicFundraising.sol. UINT256_MAX means no fees.
-     * @param privateOfferFeeDenominator Defines the fee paid in PrivateOffer.sol. UINT256_MAX means no fees.
+     * @notice Fee factors have been changed
+     * @param tokenFeeNumerator a in fraction a/b that defines the fee paid in Token: fee = amount * a / b
+     * @param tokenFeeDenominator b in fraction a/b that defines the fee paid in Token: fee = amount * a / b
+     * @param publicFundraisingFeeNumerator a in fraction a/b that defines the fee paid in currency for public fundraising: fee = amount * a / b
+     * @param publicFundraisingFeeDenominator b in fraction a/b that defines the fee paid in currency for public fundraising: fee = amount * a / b
+     * @param privateOfferFeeNumerator a in fraction a/b that defines the fee paid in currency for private offers: fee = amount * a / b
+     * @param privateOfferFeeDenominator b in fraction a/b that defines the fee paid in currency for private offers: fee = amount * a / b
      */
     event SetFeeDenominators(
-        uint256 tokenFeeDenominator,
-        uint256 publicFundraisingFeeDenominator,
-        uint256 privateOfferFeeDenominator
+        uint32 tokenFeeNumerator,
+        uint32 tokenFeeDenominator,
+        uint32 publicFundraisingFeeNumerator,
+        uint32 publicFundraisingFeeDenominator,
+        uint32 privateOfferFeeNumerator,
+        uint32 privateOfferFeeDenominator
     );
 
     /**

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -13,13 +13,13 @@ import "./interfaces/IFeeSettings.sol";
 contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     /// max token fee is 5%
     uint32 public constant MAX_TOKEN_FEE_NUMERATOR = 1;
-    uint32 public constant MIN_TOKEN_FEE_DENOMINATOR = 20;
+    uint32 public constant MAX_TOKEN_FEE_DENOMINATOR = 20;
     /// max public fundraising fee is 10%
     uint32 public constant MAX_CONTINUOUS_FUNDRAISING_FEE_NUMERATOR = 1;
-    uint32 public constant MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR = 10;
+    uint32 public constant MAX_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR = 10;
     /// max private offer fee is 5%
     uint32 public constant MAX_PERSONAL_INVITE_FEE_NUMERATOR = 1;
-    uint32 public constant MIN_PERSONAL_INVITE_FEE_DENOMINATOR = 20;
+    uint32 public constant MAX_PERSONAL_INVITE_FEE_DENOMINATOR = 20;
 
     /// Numerator to calculate fees paid in Token.sol.
     uint32 public tokenFeeNumerator;
@@ -119,9 +119,24 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
 
         // if at least one fee increases, enforce minimum delay
         if (
-            _fees.tokenFeeDenominator < tokenFeeDenominator ||
-            _fees.publicFundraisingFeeDenominator < publicFundraisingFeeDenominator ||
-            _fees.privateOfferFeeDenominator < privateOfferFeeDenominator
+            _isFractionAGreater(
+                _fees.tokenFeeNumerator,
+                _fees.tokenFeeDenominator,
+                tokenFeeNumerator,
+                tokenFeeDenominator
+            ) ||
+            _isFractionAGreater(
+                _fees.publicFundraisingFeeNumerator,
+                _fees.publicFundraisingFeeDenominator,
+                publicFundraisingFeeNumerator,
+                publicFundraisingFeeDenominator
+            ) ||
+            _isFractionAGreater(
+                _fees.privateOfferFeeNumerator,
+                _fees.privateOfferFeeDenominator,
+                privateOfferFeeNumerator,
+                privateOfferFeeDenominator
+            )
         ) {
             require(_fees.time > block.timestamp + 12 weeks, "Fee change must be at least 12 weeks in the future");
         }
@@ -195,7 +210,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
                 _fees.tokenFeeNumerator,
                 _fees.tokenFeeDenominator,
                 MAX_TOKEN_FEE_NUMERATOR,
-                MIN_TOKEN_FEE_DENOMINATOR
+                MAX_TOKEN_FEE_DENOMINATOR
             ),
             "Fee must be equal or less 5%"
         );
@@ -204,7 +219,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
                 _fees.publicFundraisingFeeNumerator,
                 _fees.publicFundraisingFeeDenominator,
                 MAX_CONTINUOUS_FUNDRAISING_FEE_NUMERATOR,
-                MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR
+                MAX_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR
             ),
             "PublicFundraising fee must be equal or less 10% (denominator must be >= 10)"
         );
@@ -213,7 +228,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
                 _fees.privateOfferFeeNumerator,
                 _fees.privateOfferFeeDenominator,
                 MAX_PERSONAL_INVITE_FEE_NUMERATOR,
-                MIN_PERSONAL_INVITE_FEE_DENOMINATOR
+                MAX_PERSONAL_INVITE_FEE_DENOMINATOR
             ),
             "Fee must be equal or less 5% (denominator must be >= 20)"
         );

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -11,9 +11,15 @@ import "./interfaces/IFeeSettings.sol";
  * @notice The FeeSettings contract is used to manage fees paid to the tokenize.it platfom
  */
 contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
-    uint128 public constant MIN_TOKEN_FEE_DENOMINATOR = 20;
-    uint128 public constant MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR = 10;
-    uint128 public constant MIN_PERSONAL_INVITE_FEE_DENOMINATOR = 20;
+    /// max token fee is 5%
+    uint32 public constant MAX_TOKEN_FEE_NUMERATOR = 1;
+    uint32 public constant MIN_TOKEN_FEE_DENOMINATOR = 20;
+    /// max public fundraising fee is 10%
+    uint32 public constant MAX_CONTINUOUS_FUNDRAISING_FEE_NUMERATOR = 1;
+    uint32 public constant MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR = 10;
+    /// max private offer fee is 5%
+    uint32 public constant MAX_PERSONAL_INVITE_FEE_NUMERATOR = 1;
+    uint32 public constant MIN_PERSONAL_INVITE_FEE_DENOMINATOR = 20;
 
     /// Numerator to calculate fees paid in Token.sol.
     uint32 public tokenFeeNumerator;
@@ -125,10 +131,20 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
      */
     function executeFeeChange() external onlyOwner {
         require(block.timestamp >= proposedFees.time, "Fee change must be executed after the change time");
+        tokenFeeNumerator = proposedFees.tokenFeeNumerator;
         tokenFeeDenominator = proposedFees.tokenFeeDenominator;
+        publicFundraisingFeeNumerator = proposedFees.publicFundraisingFeeNumerator;
         publicFundraisingFeeDenominator = proposedFees.publicFundraisingFeeDenominator;
+        privateOfferFeeNumerator = proposedFees.privateOfferFeeNumerator;
         privateOfferFeeDenominator = proposedFees.privateOfferFeeDenominator;
-        emit SetFeeDenominators(tokenFeeDenominator, publicFundraisingFeeDenominator, privateOfferFeeDenominator);
+        emit SetFeeDenominators(
+            tokenFeeNumerator,
+            tokenFeeDenominator,
+            publicFundraisingFeeNumerator,
+            publicFundraisingFeeDenominator,
+            privateOfferFeeNumerator,
+            privateOfferFeeDenominator
+        );
         delete proposedFees;
     }
 
@@ -151,20 +167,51 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     }
 
     /**
+     * Compares two fractions and returns true if the first one is greater than the second one
+     * @param aNumerator numerator in fraction aNumerator/aDenominator
+     * @param aDenominator denominator in fraction aNumerator/aDenominator
+     * @param bNumerator numerator in fraction bNumerator/bDenominator
+     * @param bDenominator denominator in fraction bNumerator/bDenominator
+     */
+    function _isFractionAGreater(
+        uint32 aNumerator,
+        uint32 aDenominator,
+        uint32 bNumerator,
+        uint32 bDenominator
+    ) internal pure returns (bool) {
+        return aNumerator * bDenominator > bNumerator * aDenominator;
+    }
+
+    /**
      * @notice Checks if the given fee settings are valid
      * @param _fees The fees to check
      */
     function checkFeeLimits(Fees memory _fees) internal pure {
         require(
-            _fees.tokenFeeDenominator >= MIN_TOKEN_FEE_DENOMINATOR,
-            "Fee must be equal or less 5% (denominator must be >= 20)"
+            !_isFractionAGreater(
+                _fees.tokenFeeNumerator,
+                _fees.tokenFeeDenominator,
+                MAX_TOKEN_FEE_NUMERATOR,
+                MIN_TOKEN_FEE_DENOMINATOR
+            ),
+            "Fee must be equal or less 5%"
         );
         require(
-            _fees.publicFundraisingFeeDenominator >= MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR,
+            !_isFractionAGreater(
+                _fees.publicFundraisingFeeNumerator,
+                _fees.publicFundraisingFeeDenominator,
+                MAX_CONTINUOUS_FUNDRAISING_FEE_NUMERATOR,
+                MIN_CONTINUOUS_FUNDRAISING_FEE_DENOMINATOR
+            ),
             "PublicFundraising fee must be equal or less 10% (denominator must be >= 10)"
         );
         require(
-            _fees.privateOfferFeeDenominator >= MIN_PERSONAL_INVITE_FEE_DENOMINATOR,
+            !_isFractionAGreater(
+                _fees.privateOfferFeeNumerator,
+                _fees.privateOfferFeeDenominator,
+                MAX_PERSONAL_INVITE_FEE_NUMERATOR,
+                MIN_PERSONAL_INVITE_FEE_DENOMINATOR
+            ),
             "Fee must be equal or less 5% (denominator must be >= 20)"
         );
     }
@@ -174,7 +221,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
      * @dev will wrongly return 1 if denominator and amount are both uint256 max
      */
     function tokenFee(uint256 _tokenAmount) external view override(IFeeSettingsV1, IFeeSettingsV2) returns (uint256) {
-        return _tokenAmount / tokenFeeDenominator;
+        return (_tokenAmount * tokenFeeNumerator) / tokenFeeDenominator;
     }
 
     /**
@@ -186,7 +233,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     function publicFundraisingFee(
         uint256 _currencyAmount
     ) external view override(IFeeSettingsV1, IFeeSettingsV2) returns (uint256) {
-        return _currencyAmount / publicFundraisingFeeDenominator;
+        return (_currencyAmount * publicFundraisingFeeNumerator) / publicFundraisingFeeDenominator;
     }
 
     /**
@@ -198,7 +245,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     function privateOfferFee(
         uint256 _currencyAmount
     ) external view override(IFeeSettingsV1, IFeeSettingsV2) returns (uint256) {
-        return _currencyAmount / privateOfferFeeDenominator;
+        return (_currencyAmount * privateOfferFeeNumerator) / privateOfferFeeDenominator;
     }
 
     /**

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -197,7 +197,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
         uint32 bNumerator,
         uint32 bDenominator
     ) internal pure returns (bool) {
-        return aNumerator * bDenominator > bNumerator * aDenominator;
+        return uint256(aNumerator) * bDenominator > uint256(bNumerator) * aDenominator;
     }
 
     /**

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -36,8 +36,11 @@ interface IFeeSettingsV2 {
 }
 
 struct Fees {
-    uint256 tokenFeeDenominator;
-    uint256 publicFundraisingFeeDenominator;
-    uint256 privateOfferFeeDenominator;
-    uint256 time;
+    uint32 tokenFeeNumerator;
+    uint32 tokenFeeDenominator;
+    uint32 publicFundraisingFeeNumerator;
+    uint32 publicFundraisingFeeDenominator;
+    uint32 privateOfferFeeNumerator;
+    uint32 privateOfferFeeDenominator;
+    uint64 time;
 }

--- a/script/DeployPlatform.s.sol
+++ b/script/DeployPlatform.s.sol
@@ -29,7 +29,7 @@ contract DeployPlatform is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         console.log("Deploying FeeSettings contract...");
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         FeeSettings feeSettings = new FeeSettings(fees, platformColdWallet, platformColdWallet, platformColdWallet);
         console.log("FeeSettings deployed at: ", address(feeSettings));
         feeSettings.transferOwnership(platformColdWallet);

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -52,9 +52,9 @@ contract TokenERC2771Test is Test {
     address public constant platformAdmin = 0x3109709ECfA91A80626fF3989D68f67F5B1Dd123;
     address public constant feeCollector = 0x0109709eCFa91a80626FF3989D68f67f5b1dD120;
 
-    uint256 public constant tokenFeeDenominator = 100;
-    uint256 public constant publicFundraisingFeeDenominator = 50;
-    uint256 public constant privateOfferFeeDenominator = 70;
+    uint32 public constant tokenFeeDenominator = 100;
+    uint32 public constant publicFundraisingFeeDenominator = 50;
+    uint32 public constant privateOfferFeeDenominator = 70;
 
     bytes32 domainSeparator;
     bytes32 requestType;
@@ -69,7 +69,15 @@ contract TokenERC2771Test is Test {
         allowList = new AllowList();
 
         // deploy fee settings
-        Fees memory fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory fees = Fees(
+            1,
+            tokenFeeDenominator,
+            1,
+            publicFundraisingFeeDenominator,
+            1,
+            privateOfferFeeDenominator,
+            0
+        );
         vm.prank(platformAdmin);
         feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
 

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -98,17 +98,17 @@ contract FeeSettingsTest is Test {
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees(1, newDenominator, 0, 1, 0, 1, uint64(block.timestamp + 7884001));
+        Fees memory feeChange = Fees(1, newDenominator, 0, 1, 0, 1, uint64(block.timestamp + delay));
         vm.prank(admin);
         vm.expectRevert("Fee change must be at least 12 weeks in the future");
         _feeSettings.planFeeChange(feeChange);
 
-        feeChange = Fees(0, 1, 1, newDenominator, 0, 1, uint64(block.timestamp + 7884001));
+        feeChange = Fees(0, 1, 1, newDenominator, 0, 1, uint64(block.timestamp + delay));
         vm.prank(admin);
         vm.expectRevert("Fee change must be at least 12 weeks in the future");
         _feeSettings.planFeeChange(feeChange);
 
-        feeChange = Fees(0, 1, 0, 1, 1, newDenominator, uint64(block.timestamp + 7884001));
+        feeChange = Fees(0, 1, 0, 1, 1, newDenominator, uint64(block.timestamp + delay));
         vm.prank(admin);
         vm.expectRevert("Fee change must be at least 12 weeks in the future");
         _feeSettings.planFeeChange(feeChange);
@@ -448,8 +448,9 @@ contract FeeSettingsTest is Test {
     }
 
     /**
-     * @dev the fee calculation is implemented to accept a wrong result in one case:
+     * @dev the fee calculation WAS implemented to accept a wrong result in one case:
      *      if denominator is UINT256_MAX and amount is UINT256_MAX, the result will be 1 instead of 0
+     *      This has now been fixed
      */
     function testCalculate0FeesForAmountUINT256_MAX(
         uint32 tokenFeeDenominator,
@@ -466,7 +467,7 @@ contract FeeSettingsTest is Test {
         Fees memory _fees = Fees(0, 1, 1, publicFundraisingFeeDenominator, 1, privateOfferFeeDenominator, 0);
         FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
-        assertEq(_feeSettings.tokenFee(amount), 1, "Token fee mismatch");
+        assertEq(_feeSettings.tokenFee(amount), 0, "Token fee mismatch");
         assertEq(
             _feeSettings.publicFundraisingFee(amount),
             amount / publicFundraisingFeeDenominator,
@@ -484,7 +485,7 @@ contract FeeSettingsTest is Test {
         _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
-        assertEq(_feeSettings.publicFundraisingFee(amount), 1, "Investment fee mismatch");
+        assertEq(_feeSettings.publicFundraisingFee(amount), 0, "Investment fee mismatch");
         assertEq(
             _feeSettings.privateOfferFee(amount),
             amount / privateOfferFeeDenominator,
@@ -502,6 +503,6 @@ contract FeeSettingsTest is Test {
             amount / publicFundraisingFeeDenominator,
             "Investment fee mismatch"
         );
-        assertEq(_feeSettings.privateOfferFee(amount), 1, "Private offer fee mismatch");
+        assertEq(_feeSettings.privateOfferFee(amount), 0, "Private offer fee mismatch");
     }
 }

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -38,18 +38,18 @@ contract FeeSettingsTest is Test {
 
     uint256 public constant price = 10000000;
 
-    function testEnforceFeeRangeInConstructor(uint8 fee) public {
-        vm.assume(!tokenOrPrivateOfferFeeInValidRange(fee));
+    function testEnforceFeeRangeInConstructor(uint32 numerator, uint32 denominator) public {
+        vm.assume(!tokenOrPrivateOfferFeeInValidRange(numerator, denominator));
         Fees memory _fees;
 
         console.log("Testing token fee");
-        _fees = Fees(1, fee, 1, 30, 1, 100, 0);
+        _fees = Fees(numerator, denominator, 1, 30, 1, 100, 0);
         vm.expectRevert("Fee must be equal or less 5%");
         new FeeSettings(_fees, admin, admin, admin);
 
         console.log("Testing PublicFundraising fee");
-        _fees = Fees(1, 30, 1, fee, 1, 100, 0);
-        if (fee < 10) {
+        _fees = Fees(1, 30, numerator, denominator, 1, 100, 0);
+        if (!publicFundraisingFeeInValidRange(numerator, denominator)) {
             vm.expectRevert("PublicFundraising fee must be equal or less 10%");
             new FeeSettings(_fees, admin, admin, admin);
         } else {
@@ -58,37 +58,37 @@ contract FeeSettingsTest is Test {
         }
 
         console.log("Testing PrivateOffer fee");
-        _fees = Fees(1, 30, 1, 40, 1, fee, 0);
+        _fees = Fees(1, 30, 1, 40, numerator, denominator, 0);
         vm.expectRevert("Fee must be equal or less 5%");
         new FeeSettings(_fees, admin, admin, admin);
     }
 
-    function testEnforceTokenFeeRangeInFeeChanger(uint8 fee) public {
-        vm.assume(!tokenOrPrivateOfferFeeInValidRange(fee));
+    function testEnforceTokenFeeRangeInFeeChanger(uint32 numerator, uint32 denominator) public {
+        vm.assume(!tokenOrPrivateOfferFeeInValidRange(numerator, denominator));
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees(1, fee, 1, 100, 1, 100, uint64(block.timestamp + 7884001));
+        Fees memory feeChange = Fees(numerator, denominator, 1, 100, 1, 100, uint64(block.timestamp + 7884001));
         vm.expectRevert("Fee must be equal or less 5%");
         _feeSettings.planFeeChange(feeChange);
     }
 
-    function testEnforcePublicFundraisingFeeRangeInFeeChanger(uint8 fee) public {
-        vm.assume(fee < 10);
+    function testEnforcePublicFundraisingFeeRangeInFeeChanger(uint32 numerator, uint32 denominator) public {
+        vm.assume(!publicFundraisingFeeInValidRange(numerator, denominator));
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees(1, 100, 1, fee, 1, 100, uint64(block.timestamp + 7884001));
+        Fees memory feeChange = Fees(1, 100, numerator, denominator, 1, 100, uint64(block.timestamp + 7884001));
         vm.expectRevert("PublicFundraising fee must be equal or less 10%");
         _feeSettings.planFeeChange(feeChange);
     }
 
-    function testEnforcePrivateOfferFeeRangeInFeeChanger(uint8 fee) public {
-        vm.assume(!tokenOrPrivateOfferFeeInValidRange(fee));
+    function testEnforcePrivateOfferFeeRangeInFeeChanger(uint32 numerator, uint32 denominator) public {
+        vm.assume(!tokenOrPrivateOfferFeeInValidRange(numerator, denominator));
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees(1, 100, 1, 100, 1, fee, uint64(block.timestamp + 7884001));
+        Fees memory feeChange = Fees(1, 100, 1, 100, numerator, denominator, uint64(block.timestamp + 7884001));
         vm.expectRevert("Fee must be equal or less 5%");
         _feeSettings.planFeeChange(feeChange);
     }
@@ -119,8 +119,8 @@ contract FeeSettingsTest is Test {
 
     function testExecuteFeeChangeTooEarly(uint delayAnnounced, uint32 tokenFee, uint32 investmentFee) public {
         vm.assume(delayAnnounced > 12 weeks && delayAnnounced < 1000000000000);
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFee));
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(investmentFee));
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(1, tokenFee));
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(1, investmentFee));
 
         Fees memory fees = Fees(1, 50, 1, 50, 1, 50, 0);
         vm.prank(admin);
@@ -146,25 +146,29 @@ contract FeeSettingsTest is Test {
 
     function testExecuteFeeChangeProperly(
         uint delayAnnounced,
-        uint32 tokenFee,
-        uint32 fundraisingFee,
-        uint32 privateOfferFee
+        uint32 tokenFeeDenominator,
+        uint32 publicFundraisingFeeDenominator,
+        uint32 privateOfferFeeDenominator
     ) public {
+        uint32 tokenFeeNumerator = 2;
+        uint32 publicFundraisingFeeNumerator = 3;
+        uint32 privateOfferFeeNumerator = 4;
         vm.assume(delayAnnounced > 12 weeks && delayAnnounced < 100000000000);
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFee));
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(fundraisingFee));
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(privateOfferFee));
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFeeNumerator, tokenFeeDenominator));
+        vm.assume(publicFundraisingFeeInValidRange(publicFundraisingFeeNumerator, publicFundraisingFeeDenominator));
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(privateOfferFeeNumerator, privateOfferFeeDenominator));
+
         Fees memory fees = Fees(1, 50, 1, 50, 1, 50, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees(
-            1,
-            tokenFee,
-            1,
-            fundraisingFee,
-            1,
-            privateOfferFee,
+            tokenFeeNumerator,
+            tokenFeeDenominator,
+            publicFundraisingFeeNumerator,
+            publicFundraisingFeeDenominator,
+            privateOfferFeeNumerator,
+            privateOfferFeeDenominator,
             uint64(block.timestamp + delayAnnounced)
         );
         vm.prank(admin);
@@ -175,12 +179,22 @@ contract FeeSettingsTest is Test {
         vm.prank(admin);
         vm.warp(uint64(block.timestamp + delayAnnounced) + 1);
         vm.expectEmit(true, true, true, true, address(_feeSettings));
-        emit SetFee(1, tokenFee, 1, fundraisingFee, 1, privateOfferFee);
+        emit SetFee(
+            tokenFeeNumerator,
+            tokenFeeDenominator,
+            publicFundraisingFeeNumerator,
+            publicFundraisingFeeDenominator,
+            privateOfferFeeNumerator,
+            privateOfferFeeDenominator
+        );
         _feeSettings.executeFeeChange();
 
-        assertEq(_feeSettings.tokenFeeDenominator(), tokenFee);
-        assertEq(_feeSettings.publicFundraisingFeeDenominator(), fundraisingFee);
-        //assertEq(_feeSettings.change, 0);
+        assertEq(_feeSettings.tokenFeeNumerator(), tokenFeeNumerator);
+        assertEq(_feeSettings.tokenFeeDenominator(), tokenFeeDenominator);
+        assertEq(_feeSettings.publicFundraisingFeeNumerator(), publicFundraisingFeeNumerator);
+        assertEq(_feeSettings.publicFundraisingFeeDenominator(), publicFundraisingFeeDenominator);
+        assertEq(_feeSettings.privateOfferFeeNumerator(), privateOfferFeeNumerator);
+        assertEq(_feeSettings.privateOfferFeeDenominator(), privateOfferFeeDenominator);
     }
 
     function testSetFeeTo0Immediately() public {
@@ -261,14 +275,50 @@ contract FeeSettingsTest is Test {
         //assertEq(_feeSettings.change, 0);
     }
 
-    function testSetFeeInConstructor(uint8 tokenFee, uint8 investmentFee) public {
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFee));
-        vm.assume(tokenOrPrivateOfferFeeInValidRange(investmentFee));
+    function testSetFeeInConstructor(
+        uint32 tokenFeeNumerator,
+        uint32 tokenFeeDenominator,
+        uint32 publicFundraisingFeeNumerator,
+        uint32 publicFundraisingFeeDenominator,
+        uint32 privateOfferFeeNumerator,
+        uint32 privateOfferFeeDenominator
+    ) public {
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFeeNumerator, tokenFeeDenominator));
+        vm.assume(tokenOrPrivateOfferFeeInValidRange(privateOfferFeeNumerator, privateOfferFeeDenominator));
+        vm.assume(publicFundraisingFeeInValidRange(publicFundraisingFeeNumerator, publicFundraisingFeeDenominator));
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(1, tokenFee, 1, investmentFee, 1, investmentFee, 0);
+        Fees memory fees = Fees(
+            tokenFeeNumerator,
+            tokenFeeDenominator,
+            publicFundraisingFeeNumerator,
+            publicFundraisingFeeDenominator,
+            privateOfferFeeNumerator,
+            privateOfferFeeDenominator,
+            0
+        );
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
-        assertEq(_feeSettings.tokenFeeDenominator(), tokenFee, "Token fee mismatch");
-        assertEq(_feeSettings.publicFundraisingFeeDenominator(), investmentFee, "Investment fee mismatch");
+        assertEq(_feeSettings.tokenFeeNumerator(), tokenFeeNumerator, "Token fee numerator mismatch");
+        assertEq(_feeSettings.tokenFeeDenominator(), tokenFeeDenominator, "Token fee denominator mismatch");
+        assertEq(
+            _feeSettings.publicFundraisingFeeNumerator(),
+            publicFundraisingFeeNumerator,
+            "PublicFundraising fee numerator mismatch"
+        );
+        assertEq(
+            _feeSettings.publicFundraisingFeeDenominator(),
+            publicFundraisingFeeDenominator,
+            "PublicFundraising fee denominator mismatch"
+        );
+        assertEq(
+            _feeSettings.privateOfferFeeNumerator(),
+            privateOfferFeeNumerator,
+            "PrivateOffer fee numerator mismatch"
+        );
+        assertEq(
+            _feeSettings.privateOfferFeeDenominator(),
+            privateOfferFeeDenominator,
+            "PrivateOffer fee denominator mismatch"
+        );
     }
 
     function testFeeCollector0FailsInConstructor() public {
@@ -320,8 +370,12 @@ contract FeeSettingsTest is Test {
         assertEq(_feeSettings.privateOfferFeeCollector(), newPrivateOfferFeeCollector);
     }
 
-    function tokenOrPrivateOfferFeeInValidRange(uint256 fee) internal pure returns (bool) {
-        return fee >= 20;
+    function tokenOrPrivateOfferFeeInValidRange(uint32 numerator, uint32 denominator) internal pure returns (bool) {
+        return uint256(numerator) * 20 <= denominator;
+    }
+
+    function publicFundraisingFeeInValidRange(uint32 numerator, uint32 denominator) internal pure returns (bool) {
+        return uint256(numerator) * 10 <= denominator;
     }
 
     function testCalculateProperFees(

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -7,9 +7,9 @@ import "../contracts/FeeSettings.sol";
 
 contract FeeSettingsTest is Test {
     event SetFeeDenominators(
-        uint256 tokenFeeDenominator,
-        uint256 publicFundraisingFeeDenominator,
-        uint256 privateOfferFeeDenominator
+        uint32 tokenFeeDenominator,
+        uint32 publicFundraisingFeeDenominator,
+        uint32 privateOfferFeeDenominator
     );
     event FeeCollectorsChanged(
         address indexed newTokenFeeCollector,
@@ -40,12 +40,12 @@ contract FeeSettingsTest is Test {
         Fees memory _fees;
 
         console.log("Testing token fee");
-        _fees = Fees(fee, 30, 100, 0);
+        _fees = Fees(1, fee, 1, 30, 1, 100, 0);
         vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
         new FeeSettings(_fees, admin, admin, admin);
 
         console.log("Testing PublicFundraising fee");
-        _fees = Fees(30, fee, 100, 0);
+        _fees = Fees(1, 30, 1, fee, 1, 100, 0);
         if (fee < 10) {
             vm.expectRevert("PublicFundraising fee must be equal or less 10% (denominator must be >= 10)");
             new FeeSettings(_fees, admin, admin, admin);
@@ -55,146 +55,122 @@ contract FeeSettingsTest is Test {
         }
 
         console.log("Testing PrivateOffer fee");
-        _fees = Fees(30, 40, fee, 0);
+        _fees = Fees(1, 30, 1, 40, 1, fee, 0);
         vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
         new FeeSettings(_fees, admin, admin, admin);
     }
 
     function testEnforceTokenFeeDenominatorRangeInFeeChanger(uint8 fee) public {
         vm.assume(!tokenOrPrivateOfferFeeInValidRange(fee));
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: fee,
-            publicFundraisingFeeDenominator: 100,
-            privateOfferFeeDenominator: 100,
-            time: block.timestamp + 7884001
-        });
+        Fees memory feeChange = Fees(1, fee, 1, 100, 1, 100, uint64(block.timestamp + 7884001));
         vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
         _feeSettings.planFeeChange(feeChange);
     }
 
     function testEnforcePublicFundraisingFeeDenominatorRangeInFeeChanger(uint8 fee) public {
         vm.assume(fee < 10);
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: 100,
-            publicFundraisingFeeDenominator: fee,
-            privateOfferFeeDenominator: 100,
-            time: block.timestamp + 7884001
-        });
+        Fees memory feeChange = Fees(1, 100, 1, fee, 1, 100, uint64(block.timestamp + 7884001));
         vm.expectRevert("PublicFundraising fee must be equal or less 10% (denominator must be >= 10)");
         _feeSettings.planFeeChange(feeChange);
     }
 
     function testEnforcePrivateOfferFeeDenominatorRangeInFeeChanger(uint8 fee) public {
         vm.assume(!tokenOrPrivateOfferFeeInValidRange(fee));
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: 100,
-            publicFundraisingFeeDenominator: 100,
-            privateOfferFeeDenominator: fee,
-            time: block.timestamp + 7884001
-        });
+        Fees memory feeChange = Fees(1, 100, 1, 100, 1, fee, uint64(block.timestamp + 7884001));
         vm.expectRevert("Fee must be equal or less 5% (denominator must be >= 20)");
         _feeSettings.planFeeChange(feeChange);
     }
 
-    function testEnforceFeeChangeDelayOnIncrease(uint delay, uint startDenominator, uint newDenominator) public {
+    function testEnforceFeeChangeDelayOnIncrease(uint delay, uint32 startDenominator, uint32 newDenominator) public {
         vm.assume(delay <= 12 weeks);
         vm.assume(startDenominator >= 20 && newDenominator >= 20);
         vm.assume(newDenominator < startDenominator);
-        Fees memory fees = Fees(startDenominator, startDenominator, startDenominator, 0);
+        Fees memory fees = Fees(1, startDenominator, 1, startDenominator, 1, startDenominator, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: newDenominator,
-            publicFundraisingFeeDenominator: UINT256_MAX,
-            privateOfferFeeDenominator: UINT256_MAX,
-            time: block.timestamp + delay
-        });
+        Fees memory feeChange = Fees(1, newDenominator, 0, 1, 0, 1, uint64(block.timestamp + 7884001));
         vm.prank(admin);
         vm.expectRevert("Fee change must be at least 12 weeks in the future");
         _feeSettings.planFeeChange(feeChange);
 
-        feeChange = Fees({
-            tokenFeeDenominator: UINT256_MAX,
-            publicFundraisingFeeDenominator: newDenominator,
-            privateOfferFeeDenominator: UINT256_MAX,
-            time: block.timestamp + delay
-        });
+        feeChange = Fees(0, 1, 1, newDenominator, 0, 1, uint64(block.timestamp + 7884001));
         vm.prank(admin);
         vm.expectRevert("Fee change must be at least 12 weeks in the future");
         _feeSettings.planFeeChange(feeChange);
 
-        feeChange = Fees({
-            tokenFeeDenominator: UINT256_MAX,
-            publicFundraisingFeeDenominator: UINT256_MAX,
-            privateOfferFeeDenominator: newDenominator,
-            time: block.timestamp + delay
-        });
+        feeChange = Fees(0, 1, 0, 1, 1, newDenominator, uint64(block.timestamp + 7884001));
         vm.prank(admin);
         vm.expectRevert("Fee change must be at least 12 weeks in the future");
         _feeSettings.planFeeChange(feeChange);
     }
 
-    function testExecuteFeeChangeTooEarly(uint delayAnnounced, uint256 tokenFee, uint256 investmentFee) public {
+    function testExecuteFeeChangeTooEarly(uint delayAnnounced, uint32 tokenFee, uint32 investmentFee) public {
         vm.assume(delayAnnounced > 12 weeks && delayAnnounced < 1000000000000);
         vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFee));
         vm.assume(tokenOrPrivateOfferFeeInValidRange(investmentFee));
 
-        Fees memory fees = Fees(50, 50, 50, 0);
+        Fees memory fees = Fees(1, 50, 1, 50, 1, 50, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: tokenFee,
-            publicFundraisingFeeDenominator: investmentFee,
-            privateOfferFeeDenominator: 100,
-            time: block.timestamp + delayAnnounced
-        });
+        Fees memory feeChange = Fees(
+            1,
+            tokenFee,
+            1,
+            investmentFee,
+            1,
+            investmentFee,
+            uint64(block.timestamp + delayAnnounced)
+        );
         vm.prank(admin);
         _feeSettings.planFeeChange(feeChange);
 
         vm.prank(admin);
         vm.expectRevert("Fee change must be executed after the change time");
-        vm.warp(block.timestamp + delayAnnounced - 1);
+        vm.warp(uint64(block.timestamp + delayAnnounced) - 1);
         _feeSettings.executeFeeChange();
     }
 
     function testExecuteFeeChangeProperly(
         uint delayAnnounced,
-        uint256 tokenFee,
-        uint256 fundraisingFee,
-        uint256 privateOfferFee
+        uint32 tokenFee,
+        uint32 fundraisingFee,
+        uint32 privateOfferFee
     ) public {
         vm.assume(delayAnnounced > 12 weeks && delayAnnounced < 100000000000);
         vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFee));
         vm.assume(tokenOrPrivateOfferFeeInValidRange(fundraisingFee));
         vm.assume(tokenOrPrivateOfferFeeInValidRange(privateOfferFee));
-        Fees memory fees = Fees(50, 50, 50, 0);
+        Fees memory fees = Fees(1, 50, 1, 50, 1, 50, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: tokenFee,
-            publicFundraisingFeeDenominator: fundraisingFee,
-            privateOfferFeeDenominator: privateOfferFee,
-            time: block.timestamp + delayAnnounced
-        });
+        Fees memory feeChange = Fees(
+            1,
+            tokenFee,
+            1,
+            fundraisingFee,
+            1,
+            privateOfferFee,
+            uint64(block.timestamp + delayAnnounced)
+        );
         vm.prank(admin);
         vm.expectEmit(true, true, true, true, address(_feeSettings));
         emit ChangeProposed(feeChange);
         _feeSettings.planFeeChange(feeChange);
 
         vm.prank(admin);
-        vm.warp(block.timestamp + delayAnnounced + 1);
+        vm.warp(uint64(block.timestamp + delayAnnounced) + 1);
         vm.expectEmit(true, true, true, true, address(_feeSettings));
         emit SetFeeDenominators(tokenFee, fundraisingFee, privateOfferFee);
         _feeSettings.executeFeeChange();
@@ -205,16 +181,11 @@ contract FeeSettingsTest is Test {
     }
 
     function testSetFeeTo0Immediately() public {
-        Fees memory fees = Fees(50, 20, 30, 0);
+        Fees memory fees = Fees(1, 50, 1, 20, 1, 30, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: UINT256_MAX,
-            publicFundraisingFeeDenominator: UINT256_MAX,
-            privateOfferFeeDenominator: UINT256_MAX,
-            time: 0
-        });
+        Fees memory feeChange = Fees(0, 1, 0, 1, 0, 1, uint64(block.timestamp));
 
         assertEq(_feeSettings.tokenFeeDenominator(), 50);
         assertEq(_feeSettings.publicFundraisingFeeDenominator(), 20);
@@ -224,7 +195,7 @@ contract FeeSettingsTest is Test {
         _feeSettings.planFeeChange(feeChange);
 
         vm.prank(admin);
-        //vm.warp(block.timestamp + delayAnnounced + 1);
+        //vm.warp(uint64(block.timestamp + delayAnnounced) + 1);
         _feeSettings.executeFeeChange();
 
         assertEq(_feeSettings.tokenFeeDenominator(), UINT256_MAX);
@@ -235,16 +206,11 @@ contract FeeSettingsTest is Test {
     }
 
     function testSetFeeToXFrom0Immediately() public {
-        Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
+        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: 20,
-            publicFundraisingFeeDenominator: 30,
-            privateOfferFeeDenominator: 50,
-            time: 0
-        });
+        Fees memory feeChange = Fees(1, 20, 1, 30, 1, 50, 0);
 
         assertEq(_feeSettings.tokenFeeDenominator(), UINT256_MAX);
         assertEq(_feeSettings.publicFundraisingFeeDenominator(), UINT256_MAX);
@@ -255,24 +221,15 @@ contract FeeSettingsTest is Test {
         _feeSettings.planFeeChange(feeChange);
     }
 
-    function testReduceFeeImmediately(
-        uint256 tokenReductor,
-        uint256 continuousReductor,
-        uint256 personalReductor
-    ) public {
+    function testReduceFeeImmediately(uint32 tokenReductor, uint32 continuousReductor, uint32 personalReductor) public {
         vm.assume(tokenReductor >= 50);
         vm.assume(continuousReductor >= 20);
         vm.assume(personalReductor >= 30);
-        Fees memory fees = Fees(50, 20, 30, 0);
+        Fees memory fees = Fees(1, 50, 1, 20, 1, 30, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        Fees memory feeChange = Fees({
-            tokenFeeDenominator: tokenReductor,
-            publicFundraisingFeeDenominator: continuousReductor,
-            privateOfferFeeDenominator: personalReductor,
-            time: 0
-        });
+        Fees memory feeChange = Fees(1, tokenReductor, 1, continuousReductor, 1, personalReductor, 0);
 
         assertEq(_feeSettings.tokenFeeDenominator(), 50);
         assertEq(_feeSettings.publicFundraisingFeeDenominator(), 20);
@@ -282,7 +239,7 @@ contract FeeSettingsTest is Test {
         _feeSettings.planFeeChange(feeChange);
 
         vm.prank(admin);
-        //vm.warp(block.timestamp + delayAnnounced + 1);
+        //vm.warp(uint64(block.timestamp + delayAnnounced) + 1);
         _feeSettings.executeFeeChange();
 
         assertEq(_feeSettings.tokenFeeDenominator(), tokenReductor);
@@ -296,7 +253,7 @@ contract FeeSettingsTest is Test {
         vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFee));
         vm.assume(tokenOrPrivateOfferFeeInValidRange(investmentFee));
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(tokenFee, investmentFee, investmentFee, 0);
+        Fees memory fees = Fees(1, tokenFee, 1, investmentFee, 1, investmentFee, 0);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
         assertEq(_feeSettings.tokenFeeDenominator(), tokenFee, "Token fee mismatch");
         assertEq(_feeSettings.publicFundraisingFeeDenominator(), investmentFee, "Investment fee mismatch");
@@ -305,13 +262,13 @@ contract FeeSettingsTest is Test {
     function testFeeCollector0FailsInConstructor() public {
         vm.expectRevert("Fee collector cannot be 0x0");
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         _feeSettings = new FeeSettings(fees, address(0), address(0), address(0));
     }
 
     function testFeeCollector0FailsInSetter() public {
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         vm.prank(admin);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
         vm.expectRevert("Fee collector cannot be 0x0");
@@ -334,7 +291,7 @@ contract FeeSettingsTest is Test {
         vm.assume(newPublicFundraisingFeeCollector != address(0));
         vm.assume(newPrivateOfferFeeCollector != address(0));
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         vm.prank(admin);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
         vm.expectEmit(true, true, true, true, address(_feeSettings));
@@ -356,16 +313,24 @@ contract FeeSettingsTest is Test {
     }
 
     function testCalculateProperFees(
-        uint256 tokenFeeDenominator,
-        uint256 publicFundraisingFeeDenominator,
-        uint256 privateOfferFeeDenominator,
+        uint32 tokenFeeDenominator,
+        uint32 publicFundraisingFeeDenominator,
+        uint32 privateOfferFeeDenominator,
         uint256 amount
     ) public {
         vm.assume(tokenFeeDenominator >= 20 && tokenFeeDenominator < UINT256_MAX);
         vm.assume(publicFundraisingFeeDenominator >= 20 && publicFundraisingFeeDenominator < UINT256_MAX);
         vm.assume(privateOfferFeeDenominator >= 20 && privateOfferFeeDenominator < UINT256_MAX);
 
-        Fees memory _fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory _fees = Fees(
+            1,
+            tokenFeeDenominator,
+            1,
+            publicFundraisingFeeDenominator,
+            1,
+            privateOfferFeeDenominator,
+            0
+        );
         FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
@@ -381,20 +346,20 @@ contract FeeSettingsTest is Test {
         );
     }
 
-    function testCalculate0FeesForAmountLessThanUINT256_MAX(
-        uint256 tokenFeeDenominator,
-        uint256 publicFundraisingFeeDenominator,
-        uint256 privateOfferFeeDenominator,
+    function testCalculate0FeesForAnyAmount(
+        uint32 tokenFeeDenominator,
+        uint32 publicFundraisingFeeDenominator,
+        uint32 privateOfferFeeDenominator,
         uint256 amount
     ) public {
-        vm.assume(tokenFeeDenominator >= 20 && tokenFeeDenominator < UINT256_MAX);
-        vm.assume(publicFundraisingFeeDenominator >= 20 && publicFundraisingFeeDenominator < UINT256_MAX);
-        vm.assume(privateOfferFeeDenominator >= 20 && privateOfferFeeDenominator < UINT256_MAX);
+        vm.assume(tokenFeeDenominator >= 20);
+        vm.assume(publicFundraisingFeeDenominator >= 20);
+        vm.assume(privateOfferFeeDenominator >= 20);
         vm.assume(amount < UINT256_MAX);
 
         // only token fee is 0
 
-        Fees memory _fees = Fees(UINT256_MAX, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory _fees = Fees(0, 1, 1, publicFundraisingFeeDenominator, 1, privateOfferFeeDenominator, 0);
         FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), 0, "Token fee mismatch");
@@ -411,7 +376,7 @@ contract FeeSettingsTest is Test {
 
         // only public fundraising fee is 0
 
-        _fees = Fees(tokenFeeDenominator, UINT256_MAX, privateOfferFeeDenominator, 0);
+        _fees = Fees(1, tokenFeeDenominator, 0, 1, 1, privateOfferFeeDenominator, 0);
         _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
@@ -424,7 +389,7 @@ contract FeeSettingsTest is Test {
 
         // only private offer fee is 0
 
-        _fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, UINT256_MAX, 0);
+        _fees = Fees(1, tokenFeeDenominator, 1, publicFundraisingFeeDenominator, 0, 1, 0);
         _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
@@ -438,7 +403,7 @@ contract FeeSettingsTest is Test {
 
     function testERC165IsAvailable() public {
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
         assertEq(
             _feeSettings.supportsInterface(0x01ffc9a7), // type(IERC165).interfaceId
@@ -449,7 +414,7 @@ contract FeeSettingsTest is Test {
 
     function testIFeeSettingsV1IsAvailable() public {
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         assertEq(
@@ -461,7 +426,7 @@ contract FeeSettingsTest is Test {
 
     function testIFeeSettingsV2IsAvailable() public {
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         assertEq(
@@ -476,7 +441,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_nonsenseInterface != type(IFeeSettingsV2).interfaceId);
         vm.assume(_nonsenseInterface != 0x01ffc9a7);
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         assertEq(_feeSettings.supportsInterface(0x01ffc9b7), false, "This interface should not be supported");
@@ -487,9 +452,9 @@ contract FeeSettingsTest is Test {
      *      if denominator is UINT256_MAX and amount is UINT256_MAX, the result will be 1 instead of 0
      */
     function testCalculate0FeesForAmountUINT256_MAX(
-        uint256 tokenFeeDenominator,
-        uint256 publicFundraisingFeeDenominator,
-        uint256 privateOfferFeeDenominator
+        uint32 tokenFeeDenominator,
+        uint32 publicFundraisingFeeDenominator,
+        uint32 privateOfferFeeDenominator
     ) public {
         vm.assume(tokenFeeDenominator >= 20 && tokenFeeDenominator < UINT256_MAX);
         vm.assume(publicFundraisingFeeDenominator >= 20 && publicFundraisingFeeDenominator < UINT256_MAX);
@@ -498,7 +463,7 @@ contract FeeSettingsTest is Test {
 
         // only token fee is 0
 
-        Fees memory _fees = Fees(UINT256_MAX, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory _fees = Fees(0, 1, 1, publicFundraisingFeeDenominator, 1, privateOfferFeeDenominator, 0);
         FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), 1, "Token fee mismatch");
@@ -515,7 +480,7 @@ contract FeeSettingsTest is Test {
 
         // only public fundraising fee is 0
 
-        _fees = Fees(tokenFeeDenominator, UINT256_MAX, privateOfferFeeDenominator, 0);
+        _fees = Fees(1, tokenFeeDenominator, 0, 1, 1, privateOfferFeeDenominator, 0);
         _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");
@@ -528,7 +493,7 @@ contract FeeSettingsTest is Test {
 
         // only private offer fee is 0
 
-        _fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, UINT256_MAX, 0);
+        _fees = Fees(1, tokenFeeDenominator, 1, publicFundraisingFeeDenominator, 0, 1, 0);
         _feeSettings = new FeeSettings(_fees, admin, admin, admin);
 
         assertEq(_feeSettings.tokenFee(amount), amount / tokenFeeDenominator, "Token fee mismatch");

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -61,7 +61,7 @@ contract MainnetCurrencies is Test {
 
     function setUp() public {
         list = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -48,7 +48,7 @@ contract PrivateOfferTest is Test {
 
         list.set(tokenReceiver, requirements);
 
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         feeSettings = new FeeSettings(fees, wrongFeeReceiver, wrongFeeReceiver, admin);
 
         Token implementation = new Token(trustedForwarder);
@@ -200,7 +200,7 @@ contract PrivateOfferTest is Test {
         );
 
         // set fees to 0, otherwise extra tokens are minted which causes an overflow
-        Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
+        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
         FeeSettings(address(token.feeSettings())).planFeeChange(fees);
         FeeSettings(address(token.feeSettings())).executeFeeChange();
 

--- a/test/PrivateOfferFactory.t.sol
+++ b/test/PrivateOfferFactory.t.sol
@@ -34,7 +34,7 @@ contract PrivateOfferFactoryTest is Test {
     function setUp() public {
         factory = new PrivateOfferFactory();
         list = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);

--- a/test/PrivateOfferTimeLock.t.sol
+++ b/test/PrivateOfferTimeLock.t.sol
@@ -41,7 +41,7 @@ contract PrivateOfferTimeLockTest is Test {
 
         list.set(tokenReceiver, requirements);
 
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);

--- a/test/PublicFundraising.t.sol
+++ b/test/PublicFundraising.t.sol
@@ -49,7 +49,7 @@ contract PublicFundraisingTest is Test {
 
     function setUp() public {
         list = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 100);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 100);
         feeSettings = new FeeSettings(fees, wrongFeeReceiver, admin, wrongFeeReceiver);
 
         // create token
@@ -1183,7 +1183,7 @@ contract PublicFundraisingTest is Test {
         );
 
         // set fees to 0, otherwise extra currency is minted which causes an overflow
-        Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
+        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
         FeeSettings(address(token.feeSettings())).planFeeChange(fees);
         FeeSettings(address(token.feeSettings())).executeFeeChange();
 

--- a/test/PublicFundraisingCloneFactory.t.sol
+++ b/test/PublicFundraisingCloneFactory.t.sol
@@ -33,7 +33,7 @@ contract tokenTest is Test {
     function setUp() public {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         feeSettings = new FeeSettings(
             fees,
             feeSettingsAndAllowListOwner,

--- a/test/PublicFundraisingERC2771.t.sol
+++ b/test/PublicFundraisingERC2771.t.sol
@@ -58,12 +58,20 @@ contract PublicFundraisingTest is Test {
     uint256 tokenBuyAmount;
     uint256 costInPaymentToken;
 
-    uint256 tokenFeeDenominator = 100;
-    uint256 paymentTokenFeeDenominator = 50;
+    uint32 tokenFeeDenominator = 100;
+    uint32 paymentTokenFeeDenominator = 50;
 
     function setUp() public {
         list = new AllowList();
-        Fees memory fees = Fees(tokenFeeDenominator, paymentTokenFeeDenominator, paymentTokenFeeDenominator, 0);
+        Fees memory fees = Fees(
+            1,
+            tokenFeeDenominator,
+            1,
+            paymentTokenFeeDenominator,
+            1,
+            paymentTokenFeeDenominator,
+            0
+        );
         feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);

--- a/test/PublicFundraisingIntegration.t.sol
+++ b/test/PublicFundraisingIntegration.t.sol
@@ -39,7 +39,7 @@ contract PublicFundraisingTest is Test {
 
     function setUp() public {
         list = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 100);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 100);
         vm.prank(platformAdmin);
         feeSettings = new FeeSettings(fees, platformAdmin, platformAdmin, platformAdmin);
         vm.prank(platformAdmin);
@@ -99,13 +99,16 @@ contract PublicFundraisingTest is Test {
     /*
     set up with FakePaymentToken which has variable decimals to make sure that doesn't break anything
     */
-    function feeCalculation(uint256 tokenFeeDenominator, uint256 publicFundraisingFeeDenominator) public {
+    function feeCalculation(uint32 tokenFeeDenominator, uint32 publicFundraisingFeeDenominator) public {
         // apply fees for test
         Fees memory fees = Fees(
+            1,
             tokenFeeDenominator,
+            1,
             publicFundraisingFeeDenominator,
+            1,
             publicFundraisingFeeDenominator,
-            block.timestamp + 13 weeks
+            uint64(block.timestamp + 13 weeks)
         );
         vm.prank(platformAdmin);
         feeSettings.planFeeChange(fees);
@@ -219,10 +222,10 @@ contract PublicFundraisingTest is Test {
     }
 
     function testFee0() public {
-        feeCalculation(UINT256_MAX, UINT256_MAX);
+        feeCalculation(type(uint32).max, type(uint32).max);
     }
 
-    function testVariousFees(uint256 tokenFeeDenominator, uint256 publicFundraisingFeeDenominator) public {
+    function testVariousFees(uint32 tokenFeeDenominator, uint32 publicFundraisingFeeDenominator) public {
         vm.assume(tokenFeeDenominator >= 20);
         vm.assume(publicFundraisingFeeDenominator >= 20);
         feeCalculation(tokenFeeDenominator, publicFundraisingFeeDenominator);

--- a/test/SetUpExampleCompany.t.sol
+++ b/test/SetUpExampleCompany.t.sol
@@ -79,8 +79,8 @@ contract CompanySetUpTest is Test {
     uint256 tokenBuyAmount;
     uint256 costInPaymentToken;
 
-    uint256 tokenFeeDenominator = 100;
-    uint256 paymentTokenFeeDenominator = 50;
+    uint32 tokenFeeDenominator = 100;
+    uint32 paymentTokenFeeDenominator = 50;
 
     string name = "ProductiveExampleCompany";
     string symbol = "PEC";
@@ -100,7 +100,15 @@ contract CompanySetUpTest is Test {
         companyAdmin = vm.addr(companyAdminPrivateKey);
 
         // set up FeeSettings
-        Fees memory fees = Fees(tokenFeeDenominator, paymentTokenFeeDenominator, paymentTokenFeeDenominator, 0);
+        Fees memory fees = Fees(
+            1,
+            tokenFeeDenominator,
+            1,
+            paymentTokenFeeDenominator,
+            1,
+            paymentTokenFeeDenominator,
+            0
+        );
         vm.prank(platformAdmin);
         feeSettings = new FeeSettings(fees, platformFeeCollector, platformFeeCollector, platformFeeCollector);
 

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -31,7 +31,7 @@ contract tokenTest is Test {
         vm.prank(admin);
         allowList = new AllowList();
         vm.prank(feeSettingsOwner);
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         feeSettings = new FeeSettings(fees, admin, admin, admin);
         token = Token(
             tokenCloneFactory.createTokenClone(

--- a/test/TokenCloneFactory.t.sol
+++ b/test/TokenCloneFactory.t.sol
@@ -31,7 +31,7 @@ contract tokenCloneFactoryTest is Test {
     function setUp() public {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         feeSettings = new FeeSettings(
             fees,
             feeSettingsAndAllowListOwner,
@@ -143,7 +143,7 @@ contract tokenCloneFactoryTest is Test {
         console.log("symbol: %s", symbol);
 
         FeeSettings _feeSettings = new FeeSettings(
-            Fees(100, 100, 100, 0),
+            Fees(1, 100, 1, 100, 1, 100, 0),
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner
@@ -208,7 +208,7 @@ contract tokenCloneFactoryTest is Test {
         vm.assume(rando != _admin);
 
         FeeSettings _feeSettings = new FeeSettings(
-            Fees(100, 100, 100, 0),
+            Fees(1, 100, 1, 100, 1, 100, 0),
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner
@@ -258,7 +258,7 @@ contract tokenCloneFactoryTest is Test {
         vm.assume(newPauser != admin);
 
         FeeSettings _feeSettings = new FeeSettings(
-            Fees(100, 100, 100, 0),
+            Fees(1, 100, 1, 100, 1, 100, 0),
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner

--- a/test/TokenERC2612.t.sol
+++ b/test/TokenERC2612.t.sol
@@ -47,9 +47,10 @@ contract TokenERC2612Test is Test {
     address public constant platformAdmin = 0x3109709ECfA91A80626fF3989D68f67F5B1Dd123;
     address public constant feeCollector = 0x0109709eCFa91a80626FF3989D68f67f5b1dD120;
 
-    uint256 public constant tokenFeeDenominator = UINT256_MAX;
-    uint256 public constant publicFundraisingFeeDenominator = 50;
-    uint256 public constant privateOfferFeeDenominator = 70;
+    uint32 public constant tokenFeeNumerator = 0;
+    uint32 public constant tokenFeeDenominator = 1;
+    uint32 public constant publicFundraisingFeeDenominator = 50;
+    uint32 public constant privateOfferFeeDenominator = 70;
 
     uint256 public constant tokenMintAmount = UINT256_MAX - 1; // -1 to avoid overflow caused by fee mint
     bytes32 domainSeparator;
@@ -64,7 +65,15 @@ contract TokenERC2612Test is Test {
         allowList = new AllowList();
 
         // deploy fee settings
-        Fees memory fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory fees = Fees(
+            tokenFeeNumerator,
+            tokenFeeDenominator,
+            1,
+            publicFundraisingFeeDenominator,
+            1,
+            privateOfferFeeDenominator,
+            0
+        );
         vm.prank(platformAdmin);
         feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
 

--- a/test/TokenERC2771.t.sol
+++ b/test/TokenERC2771.t.sol
@@ -46,9 +46,9 @@ contract TokenERC2771Test is Test {
     address public constant platformAdmin = 0x3109709ECfA91A80626fF3989D68f67F5B1Dd123;
     address public constant feeCollector = 0x0109709eCFa91a80626FF3989D68f67f5b1dD120;
 
-    uint256 public constant tokenFeeDenominator = 100;
-    uint256 public constant publicFundraisingFeeDenominator = 50;
-    uint256 public constant privateOfferFeeDenominator = 70;
+    uint32 public constant tokenFeeDenominator = 100;
+    uint32 public constant publicFundraisingFeeDenominator = 50;
+    uint32 public constant privateOfferFeeDenominator = 70;
 
     bytes32 domainSeparator;
     bytes32 requestType;
@@ -62,7 +62,15 @@ contract TokenERC2771Test is Test {
         allowList = new AllowList();
 
         // deploy fee settings
-        Fees memory fees = Fees(tokenFeeDenominator, publicFundraisingFeeDenominator, privateOfferFeeDenominator, 0);
+        Fees memory fees = Fees(
+            1,
+            tokenFeeDenominator,
+            1,
+            publicFundraisingFeeDenominator,
+            1,
+            privateOfferFeeDenominator,
+            0
+        );
         vm.prank(platformAdmin);
         feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
 

--- a/test/TokenGasConsumption.t.sol
+++ b/test/TokenGasConsumption.t.sol
@@ -27,7 +27,7 @@ contract tokenTest is Test {
     function setUp() public {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         feeSettings = new FeeSettings(
             fees,
             feeSettingsAndAllowListOwner,

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -31,7 +31,7 @@ contract tokenTest is Test {
         vm.prank(admin);
         allowList = new AllowList();
         vm.prank(feeSettingsOwner);
-        Fees memory fees = Fees(100, 100, 100, 0);
+        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
         feeSettings = new FeeSettings(fees, admin, admin, admin);
         Token implementation = new Token(trustedForwarder);
         TokenCloneFactory tokenCloneFactory = new TokenCloneFactory(address(implementation));
@@ -87,7 +87,7 @@ contract tokenTest is Test {
 
     function testSuggestNewFeeSettingsWrongCaller(address wrongUpdater) public {
         vm.assume(wrongUpdater != feeSettings.owner());
-        Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
+        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
         FeeSettings newFeeSettings = new FeeSettings(fees, pauser, pauser, pauser);
         vm.prank(wrongUpdater);
         vm.expectRevert("Only fee settings owner can suggest fee settings update");
@@ -95,7 +95,7 @@ contract tokenTest is Test {
     }
 
     function testSuggestNewFeeSettingsFeeCollector() public {
-        Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
+        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
         FeeSettings newFeeSettings = new FeeSettings(fees, pauser, pauser, pauser);
         vm.prank(feeSettings.feeCollector());
         vm.expectRevert("Only fee settings owner can suggest fee settings update");
@@ -110,7 +110,7 @@ contract tokenTest is Test {
 
     function testSuggestNewFeeSettings(address newCollector) public {
         vm.assume(newCollector != address(0));
-        Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
+        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
         FeeSettings newFeeSettings = new FeeSettings(fees, newCollector, newCollector, newCollector);
         FeeSettings oldFeeSettings = FeeSettings(address(token.feeSettings()));
         uint oldInvestmentFeeDenominator = oldFeeSettings.publicFundraisingFeeDenominator();
@@ -138,7 +138,7 @@ contract tokenTest is Test {
 
     function testAcceptNewFeeSettings(address newCollector) public {
         vm.assume(newCollector != address(0));
-        Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
+        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
         FeeSettings newFeeSettings = new FeeSettings(fees, newCollector, newCollector, newCollector);
         FeeSettings oldFeeSettings = FeeSettings(address(token.feeSettings()));
         uint oldInvestmentFeeDenominator = oldFeeSettings.publicFundraisingFeeDenominator();
@@ -165,7 +165,7 @@ contract tokenTest is Test {
 
     function testAcceptFeeCollectorInsteadOfFeeSettings(address newFeeSettingsPretendAddress) public {
         vm.assume(newFeeSettingsPretendAddress != address(0));
-        Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
+        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
         FeeSettings newFeeSettings = new FeeSettings(
             fees,
             newFeeSettingsPretendAddress,
@@ -185,7 +185,7 @@ contract tokenTest is Test {
     }
 
     function testAcceptWrongFeeSettings() public {
-        Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
+        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
         FeeSettings realNewFeeSettings = new FeeSettings(
             fees,
             feeSettings.feeCollector(),
@@ -306,7 +306,7 @@ contract tokenTest is Test {
     }
 
     function testFeeSettingsUpdateRevertsWhenContractFailsERC165Check() public {
-        Fees memory fees = Fees(UINT256_MAX, UINT256_MAX, UINT256_MAX, 0);
+        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
         FeeSettings[] memory feeSettingsArray = new FeeSettings[](3);
         feeSettingsArray[0] = new FeeSettingsFailERC165Check0(fees, feeSettings.feeCollector());
         feeSettingsArray[1] = new FeeSettingsFailERC165Check1(fees, feeSettings.feeCollector());


### PR DESCRIPTION
make fees more finely adjustable by adding a numerator.

The approach using structs made the code less efficient and more complex. Numerator and denominator are now stored in uint32 variables, which is definitely large enough and still saves a lot of storage.

Comparisons between these fractions are done like this, which is valid because all variables are positive:
```
a_n/a_d > b_n/b_d 
a_n*b_d > b_n * a_d
```

We can now define fees as "true zero" (0/1) or 5.03% (503/10000).