### PR TITLE
add check and test for 0 denominator to v4.2

### DIFF
--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -178,13 +178,19 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV1 {
      */
     function checkFeeLimits(Fees memory _fees) internal pure {
         require(
+            _fees.tokenFeeDenominator > 0 &&
+                _fees.continuousFundraisingFeeDenominator > 0 &&
+                _fees.personalInviteFeeDenominator > 0,
+            "Denominator cannot be 0"
+        );
+        require(
             !_isFractionAGreater(
                 _fees.tokenFeeNumerator,
                 _fees.tokenFeeDenominator,
                 MAX_TOKEN_FEE_NUMERATOR,
                 MAX_TOKEN_FEE_DENOMINATOR
             ),
-            "Fee must be equal or less 5%"
+            "Token fee must be equal or less 5%"
         );
         require(
             !_isFractionAGreater(
@@ -202,7 +208,7 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV1 {
                 MAX_PERSONAL_INVITE_FEE_NUMERATOR,
                 MAX_PERSONAL_INVITE_FEE_DENOMINATOR
             ),
-            "Fee must be equal or less 5%"
+            "PersonalInvite fee must be equal or less 5%"
         );
     }
 

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -41,7 +41,7 @@ contract FeeSettingsTest is Test {
 
         console.log("Testing token fee");
         _fees = Fees(numerator, denominator, 1, 30, 1, 100, 0);
-        vm.expectRevert("Fee must be equal or less 5%");
+        vm.expectRevert("Token fee must be equal or less 5%");
         new FeeSettings(_fees, admin);
 
         console.log("Testing ContinuousFundraising fee");
@@ -56,7 +56,7 @@ contract FeeSettingsTest is Test {
 
         console.log("Testing PersonalInvite fee");
         _fees = Fees(1, 30, 1, 40, numerator, denominator, 0);
-        vm.expectRevert("Fee must be equal or less 5%");
+        vm.expectRevert("PersonalInvite fee must be equal or less 5%");
         new FeeSettings(_fees, admin);
     }
 
@@ -67,7 +67,7 @@ contract FeeSettingsTest is Test {
         FeeSettings _feeSettings = new FeeSettings(fees, admin);
 
         Fees memory feeChange = Fees(numerator, denominator, 1, 100, 1, 100, uint64(block.timestamp + 7884001));
-        vm.expectRevert("Fee must be equal or less 5%");
+        vm.expectRevert("Token fee must be equal or less 5%");
         _feeSettings.planFeeChange(feeChange);
     }
 
@@ -89,7 +89,7 @@ contract FeeSettingsTest is Test {
         FeeSettings _feeSettings = new FeeSettings(fees, admin);
 
         Fees memory feeChange = Fees(1, 100, 1, 100, numerator, denominator, uint64(block.timestamp + 7884001));
-        vm.expectRevert("Fee must be equal or less 5%");
+        vm.expectRevert("PersonalInvite fee must be equal or less 5%");
         _feeSettings.planFeeChange(feeChange);
     }
 
@@ -483,5 +483,18 @@ contract FeeSettingsTest is Test {
         _feeSettings = new FeeSettings(fees, admin);
 
         assertEq(_feeSettings.supportsInterface(0x01ffc9b7), false, "This interface should not be supported");
+    }
+
+    function test0DenominatorIsNotPossible() public {
+        Fees memory fees = Fees(1, 0, 1, 0, 1, 0, 0);
+        vm.expectRevert("Denominator cannot be 0");
+        new FeeSettings(fees, admin);
+
+        // set 0 fee first, then update to 0 denominator
+        fees = Fees(0, 1, 0, 1, 0, 1, 0);
+        FeeSettings _feeSettings = new FeeSettings(fees, admin);
+        fees = Fees(0, 0, 0, 0, 0, 0, 0);
+        vm.expectRevert("Denominator cannot be 0");
+        _feeSettings.planFeeChange(fees);
     }
 }


### PR DESCRIPTION
checks that no denominator is 0, which was possible (though not easily achievable) before