### PR TITLE
Feature/activate dynamic pricing at deploy

### DIFF
--- a/contracts/PublicFundraising.sol
+++ b/contracts/PublicFundraising.sol
@@ -32,8 +32,8 @@ contract PublicFundraising is
     using SafeERC20 for IERC20;
 
     /// @notice Minimum waiting time between pause or parameter change and unpause.
-    /// @dev delay is calculated from pause or parameter change to unpause.
-    uint256 public constant delay = 1 days;
+    /// @dev delay is calculated from parameter change to unpause.
+    uint256 public constant delay = 1 hours;
 
     /// address that receives the currency when tokens are bought
     address public currencyReceiver;

--- a/contracts/PublicFundraising.sol
+++ b/contracts/PublicFundraising.sol
@@ -133,7 +133,8 @@ contract PublicFundraising is
         uint256 _maxAmountOfTokenToBeSold,
         IERC20 _currency,
         Token _token,
-        uint256 _autoPauseDate
+        uint256 _autoPauseDate,
+        address _priceOracle
     ) external initializer {
         require(_owner != address(0), "owner can not be zero address");
         __Ownable2Step_init(); // sets msgSender() as owner
@@ -147,6 +148,7 @@ contract PublicFundraising is
         currency = _currency;
         token = _token;
         autoPauseDate = _autoPauseDate;
+        priceOracle = IPriceDynamic(_priceOracle);
         require(_currencyReceiver != address(0), "currencyReceiver can not be zero address");
         require(address(_currency) != address(0), "currency can not be zero address");
         require(address(_token) != address(0), "token can not be zero address");

--- a/contracts/PublicFundraisingCloneFactory.sol
+++ b/contracts/PublicFundraisingCloneFactory.sol
@@ -39,8 +39,7 @@ contract PublicFundraisingCloneFactory is CloneFactory {
                 _priceOracle
             )
         );
-        address clone = Clones.cloneDeterministic(implementation, salt);
-        PublicFundraising publicFundraising = PublicFundraising(clone);
+        PublicFundraising publicFundraising = PublicFundraising(Clones.cloneDeterministic(implementation, salt));
         require(
             publicFundraising.isTrustedForwarder(_trustedForwarder),
             "PublicFundraisingCloneFactory: Unexpected trustedForwarder"
@@ -57,8 +56,8 @@ contract PublicFundraisingCloneFactory is CloneFactory {
             _autoPauseDate,
             _priceOracle
         );
-        emit NewClone(clone);
-        return clone;
+        emit NewClone(address(publicFundraising));
+        return address(publicFundraising);
     }
 
     function predictCloneAddress(

--- a/contracts/PublicFundraisingCloneFactory.sol
+++ b/contracts/PublicFundraisingCloneFactory.sol
@@ -20,7 +20,8 @@ contract PublicFundraisingCloneFactory is CloneFactory {
         uint256 _maxAmountOfTokenToBeSold,
         IERC20 _currency,
         Token _token,
-        uint256 _autoPauseDate
+        uint256 _autoPauseDate,
+        address _priceOracle
     ) external returns (address) {
         bytes32 salt = keccak256(
             abi.encodePacked(
@@ -34,7 +35,8 @@ contract PublicFundraisingCloneFactory is CloneFactory {
                 _maxAmountOfTokenToBeSold,
                 _currency,
                 _token,
-                _autoPauseDate
+                _autoPauseDate,
+                _priceOracle
             )
         );
         address clone = Clones.cloneDeterministic(implementation, salt);
@@ -52,7 +54,8 @@ contract PublicFundraisingCloneFactory is CloneFactory {
             _maxAmountOfTokenToBeSold,
             _currency,
             _token,
-            _autoPauseDate
+            _autoPauseDate,
+            _priceOracle
         );
         emit NewClone(clone);
         return clone;
@@ -69,7 +72,8 @@ contract PublicFundraisingCloneFactory is CloneFactory {
         uint256 _maxAmountOfTokenToBeSold,
         IERC20 _currency,
         Token _token,
-        uint256 _autoPauseDate
+        uint256 _autoPauseDate,
+        address _priceOracle
     ) external view returns (address) {
         bytes32 salt = keccak256(
             abi.encodePacked(
@@ -83,7 +87,8 @@ contract PublicFundraisingCloneFactory is CloneFactory {
                 _maxAmountOfTokenToBeSold,
                 _currency,
                 _token,
-                _autoPauseDate
+                _autoPauseDate,
+                _priceOracle
             )
         );
         return Clones.predictDeterministicAddress(implementation, salt);

--- a/docs/dev_overview.md
+++ b/docs/dev_overview.md
@@ -39,7 +39,7 @@ This is a personal investment invite allowing a particular investor (represented
 
 This contract allows everyone who has the `Transferer`-role on the `token` contract or who is certified by the allow-list to meet the requirements set in the `token` contract to buy newly issued tokens at a fixed price. The number of tokens that can be minted in this way can be limited to `maxAmountOfTokenToBeSold`, which is the maximal amount of token to be sold in this fundraising round.
 
-Furthermore, this contract can be paused by the owner to change the parameters. After any parameter change, a delay of 1 day is enforced before the contract can be unpaused again. This is to prevent frontrunning attacks.
+Furthermore, this contract can be paused by the owner to change the parameters. After any parameter change, a delay of 1 hour is enforced before the contract can be unpaused again. This is to prevent frontrunning attacks.
 
 ## Employee participation
 

--- a/docs/using_the_contracts.md
+++ b/docs/using_the_contracts.md
@@ -103,7 +103,8 @@ factory.createPublicFundraisingClone(
         uint256 _maxAmountOfTokenToBeSold,
         IERC20 _currency,
         Token _token,
-        uint256 _autoPauseDate
+        uint256 _autoPauseDate,
+        address _priceOracle
     )
 ```
 
@@ -122,6 +123,7 @@ factory.createPublicFundraisingClone(
 
 - `_token` : address of the token deployed when creating the new company
 - `_autoPauseDate` : Unix timestamp at which the fundraising will be paused automatically. This is to ensure the fundraising can not be forgotten to be paused when regulations require it to be paused.
+- `_priceOracle` : address of the price oracle contract. The price oracle can influence the price of the token. It is used to implement dynamic pricing. If no dynamic pricing is used, this can be set to 0x0.
 
 The contract needs to be given a minting allowance in the company token contract by calling `increaseMintingAllowance` from an address which has the role of the MintAllower. The allowance should be set to `_maxAmountOfTokenToBeSold` tokens.
 

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -126,7 +126,8 @@ contract TokenERC2771Test is Test {
                 10 * 1000 * 10 ** 18,
                 paymentToken,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -114,7 +114,8 @@ contract MainnetCurrencies is Test {
                 maxAmountOfTokenToBeSold,
                 _currency,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 

--- a/test/PublicFundraising.t.sol
+++ b/test/PublicFundraising.t.sol
@@ -84,7 +84,8 @@ contract PublicFundraisingTest is Test {
                 maxAmountOfTokenToBeSold,
                 paymentToken,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 

--- a/test/PublicFundraising.t.sol
+++ b/test/PublicFundraising.t.sol
@@ -846,7 +846,7 @@ contract PublicFundraisingTest is Test {
         uint32 changeDelay,
         uint32 attemptUnpauseDelay
     ) public {
-        uint256 unpauseDelay = raise.delay();
+        uint256 unpauseDelay = 1 hours;
         vm.assume(startTime < type(uint128).max / 2);
         vm.assume(startTime > 0);
         vm.assume(changeDelay > 0);

--- a/test/PublicFundraising.t.sol
+++ b/test/PublicFundraising.t.sol
@@ -118,7 +118,8 @@ contract PublicFundraisingTest is Test {
             maxAmountOfTokenToBeSold,
             paymentToken,
             token,
-            0
+            0,
+            address(0)
         );
 
         // owner and all settings are 0
@@ -144,7 +145,8 @@ contract PublicFundraisingTest is Test {
                 maxAmountOfTokenToBeSold,
                 paymentToken,
                 token,
-                autoPauseDate
+                autoPauseDate,
+                address(0)
             )
         );
         assertTrue(_raise.owner() == address(this));
@@ -172,7 +174,8 @@ contract PublicFundraisingTest is Test {
                 maxAmountOfTokenToBeSold,
                 paymentToken,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 
@@ -188,7 +191,8 @@ contract PublicFundraisingTest is Test {
             maxAmountOfTokenToBeSold,
             paymentToken,
             token,
-            0
+            0,
+            address(0)
         );
 
         vm.expectRevert("currencyReceiver can not be zero address");
@@ -203,7 +207,8 @@ contract PublicFundraisingTest is Test {
             maxAmountOfTokenToBeSold,
             paymentToken,
             token,
-            0
+            0,
+            address(0)
         );
 
         vm.expectRevert("currency can not be zero address");
@@ -218,7 +223,8 @@ contract PublicFundraisingTest is Test {
             maxAmountOfTokenToBeSold,
             IERC20(address(0)),
             token,
-            0
+            0,
+            address(0)
         );
 
         vm.expectRevert("token can not be zero address");
@@ -233,7 +239,8 @@ contract PublicFundraisingTest is Test {
             maxAmountOfTokenToBeSold,
             paymentToken,
             Token(address(0)),
-            0
+            0,
+            address(0)
         );
     }
 
@@ -283,7 +290,8 @@ contract PublicFundraisingTest is Test {
                 _maxMintAmount,
                 maliciousPaymentToken,
                 _token,
-                0
+                0,
+                address(0)
             )
         );
 
@@ -1131,7 +1139,8 @@ contract PublicFundraisingTest is Test {
                 UINT256_MAX,
                 paymentToken,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 
@@ -1179,7 +1188,8 @@ contract PublicFundraisingTest is Test {
                 _tokenBuyAmount,
                 paymentToken,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 
@@ -1266,7 +1276,8 @@ contract PublicFundraisingTest is Test {
                 maxAmountOfTokenToBeSold,
                 paymentToken,
                 token,
-                _autoPauseDate
+                _autoPauseDate,
+                address(0)
             )
         );
 

--- a/test/PublicFundraisingCloneFactory.t.sol
+++ b/test/PublicFundraisingCloneFactory.t.sol
@@ -73,7 +73,8 @@ contract tokenTest is Test {
         uint256 _maxAmountOfTokenToBeSold,
         IERC20 _currency,
         Token _token,
-        uint256 _autoPauseDate
+        uint256 _autoPauseDate,
+        address _priceOracle
     ) public {
         vm.assume(_trustedForwarder != address(0));
         vm.assume(_owner != address(0));
@@ -89,23 +90,24 @@ contract tokenTest is Test {
         fundraisingImplementation = new PublicFundraising(_trustedForwarder);
         fundraisingFactory = new PublicFundraisingCloneFactory(address(fundraisingImplementation));
 
-        bytes32 salt = keccak256(
-            abi.encodePacked(
-                _rawSalt,
-                _trustedForwarder,
-                _owner,
-                _currencyReceiver,
-                _minAmountPerBuyer,
-                _maxAmountPerBuyer,
-                _priceBase,
-                _maxAmountOfTokenToBeSold,
-                _currency,
-                _token,
-                _autoPauseDate
+        address expected1 = fundraisingFactory.predictCloneAddress(
+            keccak256(
+                abi.encodePacked(
+                    _rawSalt,
+                    _trustedForwarder,
+                    _owner,
+                    _currencyReceiver,
+                    _minAmountPerBuyer,
+                    _maxAmountPerBuyer,
+                    _priceBase,
+                    _maxAmountOfTokenToBeSold,
+                    _currency,
+                    _token,
+                    _autoPauseDate,
+                    _priceOracle
+                )
             )
         );
-
-        address expected1 = fundraisingFactory.predictCloneAddress(salt);
         address expected2 = fundraisingFactory.predictCloneAddress(
             _rawSalt,
             _trustedForwarder,
@@ -117,7 +119,8 @@ contract tokenTest is Test {
             _maxAmountOfTokenToBeSold,
             _currency,
             _token,
-            _autoPauseDate
+            _autoPauseDate,
+            _priceOracle
         );
 
         // log both addresses
@@ -132,7 +135,8 @@ contract tokenTest is Test {
         uint256 _maxAmountOfTokenToBeSold,
         IERC20 _currency,
         Token _token,
-        uint256 _autoPauseDate
+        uint256 _autoPauseDate,
+        address _priceOracle
     ) public {
         vm.assume(address(_currency) != address(0));
         vm.assume(address(_token) != address(0));
@@ -145,23 +149,24 @@ contract tokenTest is Test {
         fundraisingImplementation = new PublicFundraising(exampleTrustedForwarder);
         fundraisingFactory = new PublicFundraisingCloneFactory(address(fundraisingImplementation));
 
-        bytes32 salt = keccak256(
-            abi.encodePacked(
-                exampleRawSalt,
-                exampleTrustedForwarder,
-                exampleOwner,
-                exampleCurrencyReceiver,
-                exampleMinAmountPerBuyer,
-                _maxAmountPerBuyer,
-                _tokenPrice,
-                _maxAmountOfTokenToBeSold,
-                _currency,
-                _token,
-                _autoPauseDate
+        address expected1 = fundraisingFactory.predictCloneAddress(
+            keccak256(
+                abi.encodePacked(
+                    exampleRawSalt,
+                    exampleTrustedForwarder,
+                    exampleOwner,
+                    exampleCurrencyReceiver,
+                    exampleMinAmountPerBuyer,
+                    _maxAmountPerBuyer,
+                    _tokenPrice,
+                    _maxAmountOfTokenToBeSold,
+                    _currency,
+                    _token,
+                    _autoPauseDate,
+                    _priceOracle
+                )
             )
         );
-
-        address expected1 = fundraisingFactory.predictCloneAddress(salt);
 
         address actual = fundraisingFactory.createPublicFundraisingClone(
             exampleRawSalt,
@@ -174,7 +179,8 @@ contract tokenTest is Test {
             _maxAmountOfTokenToBeSold,
             _currency,
             _token,
-            _autoPauseDate
+            _autoPauseDate,
+            _priceOracle
         );
         assertEq(expected1, actual, "address prediction failed");
     }
@@ -207,7 +213,8 @@ contract tokenTest is Test {
                 exampleMaxAmountOfTokenToBeSold,
                 exampleCurrency,
                 exampleToken,
-                exampleAutoPauseDate
+                exampleAutoPauseDate,
+                address(0)
             )
         );
 
@@ -224,7 +231,8 @@ contract tokenTest is Test {
             exampleMaxAmountOfTokenToBeSold,
             exampleCurrency,
             exampleToken,
-            exampleAutoPauseDate
+            exampleAutoPauseDate,
+            address(0)
         );
         assertEq(expected1, actual, "address prediction failed");
     }
@@ -261,7 +269,8 @@ contract tokenTest is Test {
             _maxAmountOfTokenToBeSold,
             _currency,
             _token,
-            0
+            0,
+            address(0)
         );
 
         // deploy again
@@ -277,7 +286,8 @@ contract tokenTest is Test {
             _maxAmountOfTokenToBeSold,
             _currency,
             _token,
-            0
+            0,
+            address(0)
         );
     }
 
@@ -319,7 +329,8 @@ contract tokenTest is Test {
                 _maxAmountOfTokenToBeSold,
                 _currency,
                 _token,
-                0
+                0,
+                address(0)
             )
         );
 
@@ -354,7 +365,8 @@ contract tokenTest is Test {
                 4,
                 IERC20(address(1)),
                 Token(address(2)),
-                0
+                0,
+                address(0)
             )
         );
 

--- a/test/PublicFundraisingDynamicPricing.t.sol
+++ b/test/PublicFundraisingDynamicPricing.t.sol
@@ -124,7 +124,8 @@ contract PublicFundraisingTest is Test {
                 maxAmountOfTokenToBeSold,
                 paymentToken,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 

--- a/test/PublicFundraisingERC2771.t.sol
+++ b/test/PublicFundraisingERC2771.t.sol
@@ -112,7 +112,8 @@ contract PublicFundraisingTest is Test {
                 maxAmountOfTokenToBeSold,
                 paymentToken,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 

--- a/test/PublicFundraisingERC677.t.sol
+++ b/test/PublicFundraisingERC677.t.sol
@@ -82,7 +82,8 @@ contract PublicFundraisingTest is Test {
                 maxAmountOfTokenToBeSold,
                 paymentToken,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 
@@ -145,7 +146,8 @@ contract PublicFundraisingTest is Test {
                 _maxMintAmount,
                 maliciousPaymentToken,
                 _token,
-                0
+                0,
+                address(0)
             )
         );
 

--- a/test/PublicFundraisingIntegration.t.sol
+++ b/test/PublicFundraisingIntegration.t.sol
@@ -80,7 +80,8 @@ contract PublicFundraisingTest is Test {
                 maxAmountOfTokenToBeSold,
                 paymentToken,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 
@@ -166,7 +167,8 @@ contract PublicFundraisingTest is Test {
                 _maxMintAmount,
                 paymentToken,
                 _token,
-                0
+                0,
+                address(0)
             )
         );
 
@@ -283,7 +285,8 @@ contract PublicFundraisingTest is Test {
                     _maxMintAmount,
                     paymentToken,
                     _token,
-                    0
+                    0,
+                    address(0)
                 )
             );
             // allow invite contract to mint

--- a/test/PublicFundraisingPrice.t.sol
+++ b/test/PublicFundraisingPrice.t.sol
@@ -82,7 +82,8 @@ contract PublicFundraisingTest is Test {
                 maxAmountOfTokenToBeSold,
                 paymentToken,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 

--- a/test/SetUpExampleCompany.t.sol
+++ b/test/SetUpExampleCompany.t.sol
@@ -210,7 +210,8 @@ contract CompanySetUpTest is Test {
                 maxAmountOfTokenToBeSold,
                 paymentToken,
                 token,
-                0
+                0,
+                address(0)
             )
         );
 


### PR DESCRIPTION
- include dynamic pricing in clone creation
- reduce parameter change cooldown to 1 hour (from 1 day, because 1h is enough to prevent frontrunning, too)