### PR TITLE
Feature/public fundraising arguments struct

### DIFF
--- a/contracts/PublicFundraisingCloneFactory.sol
+++ b/contracts/PublicFundraisingCloneFactory.sol
@@ -6,55 +6,45 @@ import "./PublicFundraising.sol";
 import "./CloneFactory.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
 
+/// this struct is used to circumvent the stack too deep error that occurs when passing too many arguments to a function
+struct PublicFundraisingInitializerArguments {
+    address owner;
+    address currencyReceiver;
+    uint256 minAmountPerBuyer;
+    uint256 maxAmountPerBuyer;
+    uint256 tokenPrice;
+    uint256 maxAmountOfTokenToBeSold;
+    IERC20 currency;
+    Token token;
+    uint256 autoPauseDate;
+    address priceOracle;
+}
+
 contract PublicFundraisingCloneFactory is CloneFactory {
     constructor(address _implementation) CloneFactory(_implementation) {}
 
     function createPublicFundraisingClone(
         bytes32 _rawSalt,
         address _trustedForwarder,
-        address _owner,
-        address _currencyReceiver,
-        uint256 _minAmountPerBuyer,
-        uint256 _maxAmountPerBuyer,
-        uint256 _tokenPrice,
-        uint256 _maxAmountOfTokenToBeSold,
-        IERC20 _currency,
-        Token _token,
-        uint256 _autoPauseDate,
-        address _priceOracle
+        PublicFundraisingInitializerArguments memory _arguments
     ) external returns (address) {
-        bytes32 salt = keccak256(
-            abi.encodePacked(
-                _rawSalt,
-                _trustedForwarder,
-                _owner,
-                _currencyReceiver,
-                _minAmountPerBuyer,
-                _maxAmountPerBuyer,
-                _tokenPrice,
-                _maxAmountOfTokenToBeSold,
-                _currency,
-                _token,
-                _autoPauseDate,
-                _priceOracle
-            )
-        );
+        bytes32 salt = _generateSalt(_rawSalt, _trustedForwarder, _arguments);
         PublicFundraising publicFundraising = PublicFundraising(Clones.cloneDeterministic(implementation, salt));
         require(
             publicFundraising.isTrustedForwarder(_trustedForwarder),
             "PublicFundraisingCloneFactory: Unexpected trustedForwarder"
         );
         publicFundraising.initialize(
-            _owner,
-            _currencyReceiver,
-            _minAmountPerBuyer,
-            _maxAmountPerBuyer,
-            _tokenPrice,
-            _maxAmountOfTokenToBeSold,
-            _currency,
-            _token,
-            _autoPauseDate,
-            _priceOracle
+            _arguments.owner,
+            _arguments.currencyReceiver,
+            _arguments.minAmountPerBuyer,
+            _arguments.maxAmountPerBuyer,
+            _arguments.tokenPrice,
+            _arguments.maxAmountOfTokenToBeSold,
+            _arguments.currency,
+            _arguments.token,
+            _arguments.autoPauseDate,
+            _arguments.priceOracle
         );
         emit NewClone(address(publicFundraising));
         return address(publicFundraising);
@@ -63,33 +53,17 @@ contract PublicFundraisingCloneFactory is CloneFactory {
     function predictCloneAddress(
         bytes32 _rawSalt,
         address _trustedForwarder,
-        address _owner,
-        address _currencyReceiver,
-        uint256 _minAmountPerBuyer,
-        uint256 _maxAmountPerBuyer,
-        uint256 _tokenPrice,
-        uint256 _maxAmountOfTokenToBeSold,
-        IERC20 _currency,
-        Token _token,
-        uint256 _autoPauseDate,
-        address _priceOracle
+        PublicFundraisingInitializerArguments memory _arguments
     ) external view returns (address) {
-        bytes32 salt = keccak256(
-            abi.encodePacked(
-                _rawSalt,
-                _trustedForwarder,
-                _owner,
-                _currencyReceiver,
-                _minAmountPerBuyer,
-                _maxAmountPerBuyer,
-                _tokenPrice,
-                _maxAmountOfTokenToBeSold,
-                _currency,
-                _token,
-                _autoPauseDate,
-                _priceOracle
-            )
-        );
+        bytes32 salt = _generateSalt(_rawSalt, _trustedForwarder, _arguments);
         return Clones.predictDeterministicAddress(implementation, salt);
+    }
+
+    function _generateSalt(
+        bytes32 _rawSalt,
+        address _trustedForwarder,
+        PublicFundraisingInitializerArguments memory _arguments
+    ) internal pure returns (bytes32) {
+        return keccak256(abi.encode(_rawSalt, _trustedForwarder, _arguments));
     }
 }

--- a/contracts/PublicFundraisingCloneFactory.sol
+++ b/contracts/PublicFundraisingCloneFactory.sol
@@ -6,20 +6,6 @@ import "./PublicFundraising.sol";
 import "./CloneFactory.sol";
 import "@openzeppelin/contracts/proxy/Clones.sol";
 
-/// this struct is used to circumvent the stack too deep error that occurs when passing too many arguments to a function
-struct PublicFundraisingInitializerArguments {
-    address owner;
-    address currencyReceiver;
-    uint256 minAmountPerBuyer;
-    uint256 maxAmountPerBuyer;
-    uint256 tokenPrice;
-    uint256 maxAmountOfTokenToBeSold;
-    IERC20 currency;
-    Token token;
-    uint256 autoPauseDate;
-    address priceOracle;
-}
-
 contract PublicFundraisingCloneFactory is CloneFactory {
     constructor(address _implementation) CloneFactory(_implementation) {}
 
@@ -34,18 +20,7 @@ contract PublicFundraisingCloneFactory is CloneFactory {
             publicFundraising.isTrustedForwarder(_trustedForwarder),
             "PublicFundraisingCloneFactory: Unexpected trustedForwarder"
         );
-        publicFundraising.initialize(
-            _arguments.owner,
-            _arguments.currencyReceiver,
-            _arguments.minAmountPerBuyer,
-            _arguments.maxAmountPerBuyer,
-            _arguments.tokenPrice,
-            _arguments.maxAmountOfTokenToBeSold,
-            _arguments.currency,
-            _arguments.token,
-            _arguments.autoPauseDate,
-            _arguments.priceOracle
-        );
+        publicFundraising.initialize(_arguments);
         emit NewClone(address(publicFundraising));
         return address(publicFundraising);
     }

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -121,6 +121,8 @@ contract TokenERC2771Test is Test {
             minAmountPerBuyer: 1000 * 10 ** 18,
             maxAmountPerBuyer: 2000 * 10 ** 18,
             tokenPrice: 688,
+            priceMin: 688,
+            priceMax: 688,
             maxAmountOfTokenToBeSold: 10 * 1000 * 10 ** 18,
             currency: paymentToken,
             token: token,

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -114,21 +114,21 @@ contract TokenERC2771Test is Test {
         PublicFundraisingCloneFactory fundraisingFactory = new PublicFundraisingCloneFactory(
             address(new PublicFundraising(address(forwarder)))
         );
+
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments({
+            owner: companyAdmin,
+            currencyReceiver: receiver,
+            minAmountPerBuyer: 1000 * 10 ** 18,
+            maxAmountPerBuyer: 2000 * 10 ** 18,
+            tokenPrice: 688,
+            maxAmountOfTokenToBeSold: 10 * 1000 * 10 ** 18,
+            currency: paymentToken,
+            token: token,
+            autoPauseDate: 0,
+            priceOracle: address(0)
+        });
         PublicFundraising raise = PublicFundraising(
-            fundraisingFactory.createPublicFundraisingClone(
-                0,
-                address(forwarder),
-                companyAdmin,
-                receiver,
-                1000 * 10 ** 18,
-                2000 * 10 ** 18,
-                688,
-                10 * 1000 * 10 ** 18,
-                paymentToken,
-                token,
-                0,
-                address(0)
-            )
+            fundraisingFactory.createPublicFundraisingClone(0, address(forwarder), arguments)
         );
 
         // register domainSeparator with forwarder

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -109,6 +109,8 @@ contract MainnetCurrencies is Test {
             minAmountPerBuyer,
             maxAmountPerBuyer,
             _price,
+            _price,
+            _price,
             maxAmountOfTokenToBeSold,
             _currency,
             token,

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -102,21 +102,21 @@ contract MainnetCurrencies is Test {
         uint256 _currencyAmount = _currencyCost * 2;
 
         // set up fundraise with _currency
+
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+            owner,
+            payable(receiver),
+            minAmountPerBuyer,
+            maxAmountPerBuyer,
+            _price,
+            maxAmountOfTokenToBeSold,
+            _currency,
+            token,
+            0,
+            address(0)
+        );
         PublicFundraising _raise = PublicFundraising(
-            fundraisingFactory.createPublicFundraisingClone(
-                0,
-                trustedForwarder,
-                owner,
-                payable(receiver),
-                minAmountPerBuyer,
-                maxAmountPerBuyer,
-                _price,
-                maxAmountOfTokenToBeSold,
-                _currency,
-                token,
-                0,
-                address(0)
-            )
+            fundraisingFactory.createPublicFundraisingClone(0, trustedForwarder, arguments)
         );
 
         // allow raise contract to mint

--- a/test/PublicFundraising.t.sol
+++ b/test/PublicFundraising.t.sol
@@ -106,16 +106,18 @@ contract PublicFundraisingTest is Test {
         // try to initialize
         vm.expectRevert("Initializable: contract is already initialized");
         _logic.initialize(
-            address(this),
-            payable(receiver),
-            minAmountPerBuyer,
-            maxAmountPerBuyer,
-            price,
-            maxAmountOfTokenToBeSold,
-            paymentToken,
-            token,
-            0,
-            address(0)
+            PublicFundraisingInitializerArguments(
+                address(this),
+                payable(receiver),
+                minAmountPerBuyer,
+                maxAmountPerBuyer,
+                price,
+                maxAmountOfTokenToBeSold,
+                paymentToken,
+                token,
+                0,
+                address(0)
+            )
         );
 
         // owner and all settings are 0

--- a/test/PublicFundraising.t.sol
+++ b/test/PublicFundraising.t.sol
@@ -77,6 +77,8 @@ contract PublicFundraisingTest is Test {
             minAmountPerBuyer,
             maxAmountPerBuyer,
             price,
+            price,
+            price,
             maxAmountOfTokenToBeSold,
             paymentToken,
             token,
@@ -112,6 +114,8 @@ contract PublicFundraisingTest is Test {
                 minAmountPerBuyer,
                 maxAmountPerBuyer,
                 price,
+                price,
+                price,
                 maxAmountOfTokenToBeSold,
                 paymentToken,
                 token,
@@ -136,6 +140,8 @@ contract PublicFundraisingTest is Test {
             payable(receiver),
             minAmountPerBuyer,
             maxAmountPerBuyer,
+            price,
+            price,
             price,
             maxAmountOfTokenToBeSold,
             paymentToken,
@@ -164,6 +170,8 @@ contract PublicFundraisingTest is Test {
             minAmountPerBuyer,
             maxAmountPerBuyer,
             price,
+            price,
+            price,
             maxAmountOfTokenToBeSold,
             paymentToken,
             token,
@@ -183,6 +191,19 @@ contract PublicFundraisingTest is Test {
         tempArgs = clonePublicFundraisingInitializerArguments(arguments);
         tempArgs.currencyReceiver = address(0);
         vm.expectRevert("currencyReceiver can not be zero address");
+        factory.createPublicFundraisingClone(0, trustedForwarder, tempArgs);
+
+        // max price 0
+        tempArgs = clonePublicFundraisingInitializerArguments(arguments);
+        tempArgs.priceMax = 0;
+        tempArgs.priceOracle = address(3);
+        vm.expectRevert("priceMax needs to be larger or equal to priceBase");
+        factory.createPublicFundraisingClone(0, trustedForwarder, tempArgs);
+
+        // min price too high
+        tempArgs.priceMax = price;
+        tempArgs.priceMin = price + 1;
+        vm.expectRevert("priceMin needs to be smaller or equal to priceBase");
         factory.createPublicFundraisingClone(0, trustedForwarder, tempArgs);
 
         // currency 0
@@ -237,6 +258,8 @@ contract PublicFundraisingTest is Test {
             payable(receiver),
             1,
             _maxMintAmount / 100,
+            _price,
+            _price,
             _price,
             _maxMintAmount,
             maliciousPaymentToken,
@@ -1086,6 +1109,8 @@ contract PublicFundraisingTest is Test {
             0,
             UINT256_MAX,
             _price,
+            _price,
+            _price,
             UINT256_MAX,
             paymentToken,
             token,
@@ -1131,6 +1156,8 @@ contract PublicFundraisingTest is Test {
             payable(receiver),
             _tokenBuyAmount,
             _tokenBuyAmount,
+            _price,
+            _price,
             _price,
             _tokenBuyAmount,
             paymentToken,
@@ -1218,6 +1245,8 @@ contract PublicFundraisingTest is Test {
             minAmountPerBuyer,
             maxAmountPerBuyer,
             price,
+            price,
+            price,
             maxAmountOfTokenToBeSold,
             paymentToken,
             token,
@@ -1269,6 +1298,8 @@ contract PublicFundraisingTest is Test {
                 arguments.minAmountPerBuyer,
                 arguments.maxAmountPerBuyer,
                 arguments.tokenPrice,
+                arguments.priceMin,
+                arguments.priceMax,
                 arguments.maxAmountOfTokenToBeSold,
                 arguments.currency,
                 arguments.token,

--- a/test/PublicFundraisingCloneFactory.t.sol
+++ b/test/PublicFundraisingCloneFactory.t.sol
@@ -40,6 +40,7 @@ contract tokenTest is Test {
     IERC20 public constant exampleCurrency = IERC20(address(1));
     Token public constant exampleToken = Token(address(2));
     uint256 public constant exampleAutoPauseDate = 0;
+    address public constant examplePriceOracle = address(3);
 
     event RequirementsChanged(uint256 newRequirements);
 
@@ -62,72 +63,57 @@ contract tokenTest is Test {
         fundraisingFactory = new PublicFundraisingCloneFactory(address(fundraisingImplementation));
     }
 
-    function testAddressPrediction1(
-        bytes32 _rawSalt,
-        address _trustedForwarder,
-        address _owner,
-        address _currencyReceiver,
-        uint256 _minAmountPerBuyer,
-        uint256 _maxAmountPerBuyer,
-        uint256 _priceBase,
-        uint256 _maxAmountOfTokenToBeSold,
-        IERC20 _currency,
-        Token _token,
-        uint256 _autoPauseDate,
-        address _priceOracle
-    ) public {
-        vm.assume(_trustedForwarder != address(0));
-        vm.assume(_owner != address(0));
-        vm.assume(address(_currency) != address(0));
-        vm.assume(address(_token) != address(0));
-        vm.assume(_currencyReceiver != address(0));
-        vm.assume(_minAmountPerBuyer > 0);
-        vm.assume(_maxAmountPerBuyer >= _minAmountPerBuyer);
-        vm.assume(_priceBase > 0);
-        vm.assume(_maxAmountOfTokenToBeSold > _maxAmountPerBuyer);
+    // function testAddressPrediction1(
+    //     bytes32 _rawSalt,
+    //     address _trustedForwarder,
+    //     address _owner,
+    //     address _currencyReceiver,
+    //     uint256 _minAmountPerBuyer,
+    //     uint256 _maxAmountPerBuyer,
+    //     uint256 _priceBase,
+    //     uint256 _maxAmountOfTokenToBeSold,
+    //     IERC20 _currency,
+    //     Token _token,
+    //     uint256 _autoPauseDate,
+    //     address _priceOracle
+    // ) public {
+    //     vm.assume(_trustedForwarder != address(0));
+    //     vm.assume(_owner != address(0));
+    //     vm.assume(address(_currency) != address(0));
+    //     vm.assume(address(_token) != address(0));
+    //     vm.assume(_currencyReceiver != address(0));
+    //     vm.assume(_minAmountPerBuyer > 0);
+    //     vm.assume(_maxAmountPerBuyer >= _minAmountPerBuyer);
+    //     vm.assume(_priceBase > 0);
+    //     vm.assume(_maxAmountOfTokenToBeSold > _maxAmountPerBuyer);
 
-        // create new clone factory so we can use the local forwarder
-        fundraisingImplementation = new PublicFundraising(_trustedForwarder);
-        fundraisingFactory = new PublicFundraisingCloneFactory(address(fundraisingImplementation));
+    //     // create new clone factory so we can use the local forwarder
+    //     fundraisingImplementation = new PublicFundraising(_trustedForwarder);
+    //     fundraisingFactory = new PublicFundraisingCloneFactory(address(fundraisingImplementation));
 
-        address expected1 = fundraisingFactory.predictCloneAddress(
-            keccak256(
-                abi.encodePacked(
-                    _rawSalt,
-                    _trustedForwarder,
-                    _owner,
-                    _currencyReceiver,
-                    _minAmountPerBuyer,
-                    _maxAmountPerBuyer,
-                    _priceBase,
-                    _maxAmountOfTokenToBeSold,
-                    _currency,
-                    _token,
-                    _autoPauseDate,
-                    _priceOracle
-                )
-            )
-        );
-        address expected2 = fundraisingFactory.predictCloneAddress(
-            _rawSalt,
-            _trustedForwarder,
-            _owner,
-            _currencyReceiver,
-            _minAmountPerBuyer,
-            _maxAmountPerBuyer,
-            _priceBase,
-            _maxAmountOfTokenToBeSold,
-            _currency,
-            _token,
-            _autoPauseDate,
-            _priceOracle
-        );
+    //     PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+    //         _owner,
+    //         _currencyReceiver,
+    //         _minAmountPerBuyer,
+    //         _maxAmountPerBuyer,
+    //         _priceBase,
+    //         _maxAmountOfTokenToBeSold,
+    //         _currency,
+    //         _token,
+    //         _autoPauseDate,
+    //         _priceOracle
+    //     );
 
-        // log both addresses
-        console.log(expected1);
-        console.log(expected2);
-        assertEq(expected1, expected2, "address prediction with salt and params not equal");
-    }
+    //     address expected1 = fundraisingFactory.predictCloneAddress(
+    //         keccak256(abi.encode(_rawSalt, _trustedForwarder, arguments))
+    //     );
+    //     address expected2 = fundraisingFactory.predictCloneAddress(_rawSalt, _trustedForwarder, arguments);
+
+    //     // log both addresses
+    //     console.log(expected1);
+    //     console.log(expected2);
+    //     assertEq(expected1, expected2, "address prediction with salt and params not equal");
+    // }
 
     function testAddressPrediction2(
         uint256 _maxAmountPerBuyer,
@@ -149,28 +135,7 @@ contract tokenTest is Test {
         fundraisingImplementation = new PublicFundraising(exampleTrustedForwarder);
         fundraisingFactory = new PublicFundraisingCloneFactory(address(fundraisingImplementation));
 
-        address expected1 = fundraisingFactory.predictCloneAddress(
-            keccak256(
-                abi.encodePacked(
-                    exampleRawSalt,
-                    exampleTrustedForwarder,
-                    exampleOwner,
-                    exampleCurrencyReceiver,
-                    exampleMinAmountPerBuyer,
-                    _maxAmountPerBuyer,
-                    _tokenPrice,
-                    _maxAmountOfTokenToBeSold,
-                    _currency,
-                    _token,
-                    _autoPauseDate,
-                    _priceOracle
-                )
-            )
-        );
-
-        address actual = fundraisingFactory.createPublicFundraisingClone(
-            exampleRawSalt,
-            exampleTrustedForwarder,
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
             exampleOwner,
             exampleCurrencyReceiver,
             exampleMinAmountPerBuyer,
@@ -181,6 +146,16 @@ contract tokenTest is Test {
             _token,
             _autoPauseDate,
             _priceOracle
+        );
+
+        address expected1 = fundraisingFactory.predictCloneAddress(
+            keccak256(abi.encode(exampleRawSalt, exampleTrustedForwarder, arguments))
+        );
+
+        address actual = fundraisingFactory.createPublicFundraisingClone(
+            exampleRawSalt,
+            exampleTrustedForwarder,
+            arguments
         );
         assertEq(expected1, actual, "address prediction failed");
     }
@@ -201,28 +176,7 @@ contract tokenTest is Test {
         fundraisingImplementation = new PublicFundraising(_trustedForwarder);
         fundraisingFactory = new PublicFundraisingCloneFactory(address(fundraisingImplementation));
 
-        bytes32 salt = keccak256(
-            abi.encodePacked(
-                _rawSalt,
-                _trustedForwarder,
-                _owner,
-                _currencyReceiver,
-                _minAmountPerBuyer,
-                exampleMaxAmountPerBuyer,
-                exampleTokenPrice,
-                exampleMaxAmountOfTokenToBeSold,
-                exampleCurrency,
-                exampleToken,
-                exampleAutoPauseDate,
-                address(0)
-            )
-        );
-
-        address expected1 = fundraisingFactory.predictCloneAddress(salt);
-
-        address actual = fundraisingFactory.createPublicFundraisingClone(
-            _rawSalt,
-            _trustedForwarder,
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
             _owner,
             _currencyReceiver,
             _minAmountPerBuyer,
@@ -232,8 +186,14 @@ contract tokenTest is Test {
             exampleCurrency,
             exampleToken,
             exampleAutoPauseDate,
-            address(0)
+            examplePriceOracle
         );
+
+        bytes32 salt = keccak256(abi.encode(_rawSalt, _trustedForwarder, arguments));
+
+        address expected1 = fundraisingFactory.predictCloneAddress(salt);
+
+        address actual = fundraisingFactory.createPublicFundraisingClone(_rawSalt, _trustedForwarder, arguments);
         assertEq(expected1, actual, "address prediction failed");
     }
 
@@ -257,10 +217,7 @@ contract tokenTest is Test {
         vm.assume(_priceBase > 0);
         vm.assume(_maxAmountOfTokenToBeSold > _maxAmountPerBuyer);
 
-        // deploy once
-        fundraisingFactory.createPublicFundraisingClone(
-            _rawSalt,
-            trustedForwarder,
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
             _owner,
             _currencyReceiver,
             _minAmountPerBuyer,
@@ -269,69 +226,51 @@ contract tokenTest is Test {
             _maxAmountOfTokenToBeSold,
             _currency,
             _token,
-            0,
-            address(0)
+            exampleAutoPauseDate,
+            examplePriceOracle
         );
+
+        // deploy once
+        fundraisingFactory.createPublicFundraisingClone(_rawSalt, trustedForwarder, arguments);
 
         // deploy again
         vm.expectRevert("ERC1167: create2 failed");
-        fundraisingFactory.createPublicFundraisingClone(
-            _rawSalt,
-            trustedForwarder,
-            _owner,
-            _currencyReceiver,
-            _minAmountPerBuyer,
-            _maxAmountPerBuyer,
-            _priceBase,
-            _maxAmountOfTokenToBeSold,
-            _currency,
-            _token,
-            0,
-            address(0)
-        );
+        fundraisingFactory.createPublicFundraisingClone(_rawSalt, trustedForwarder, arguments);
     }
 
-    function testInitialization(
+    function testInitialization1(
         bytes32 _rawSalt,
         address _trustedForwarder,
         address _owner,
         address _currencyReceiver,
         uint256 _minAmountPerBuyer,
-        uint256 _maxAmountPerBuyer,
-        uint256 _priceBase,
-        uint256 _maxAmountOfTokenToBeSold,
-        IERC20 _currency,
-        Token _token
+        uint256 _maxAmountPerBuyer
     ) public {
         vm.assume(_trustedForwarder != address(0));
         vm.assume(_owner != address(0));
-        vm.assume(address(_currency) != address(0));
-        vm.assume(address(_token) != address(0));
         vm.assume(_currencyReceiver != address(0));
         vm.assume(_minAmountPerBuyer > 0);
         vm.assume(_maxAmountPerBuyer >= _minAmountPerBuyer);
-        vm.assume(_priceBase > 0);
-        vm.assume(_maxAmountOfTokenToBeSold > _maxAmountPerBuyer);
 
         // create new clone factory so we can use the local forwarder
         fundraisingImplementation = new PublicFundraising(_trustedForwarder);
         fundraisingFactory = new PublicFundraisingCloneFactory(address(fundraisingImplementation));
 
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+            _owner,
+            _currencyReceiver,
+            _minAmountPerBuyer,
+            _maxAmountPerBuyer,
+            exampleTokenPrice,
+            exampleMaxAmountOfTokenToBeSold,
+            exampleCurrency,
+            exampleToken,
+            exampleAutoPauseDate,
+            examplePriceOracle
+        );
+
         PublicFundraising raise = PublicFundraising(
-            fundraisingFactory.createPublicFundraisingClone(
-                _rawSalt,
-                _trustedForwarder,
-                _owner,
-                _currencyReceiver,
-                _minAmountPerBuyer,
-                _maxAmountPerBuyer,
-                _priceBase,
-                _maxAmountOfTokenToBeSold,
-                _currency,
-                _token,
-                0,
-                address(0)
-            )
+            fundraisingFactory.createPublicFundraisingClone(_rawSalt, _trustedForwarder, arguments)
         );
 
         assertTrue(raise.isTrustedForwarder(_trustedForwarder), "trustedForwarder not set");
@@ -339,10 +278,51 @@ contract tokenTest is Test {
         assertEq(raise.currencyReceiver(), _currencyReceiver, "currencyReceiver not set");
         assertEq(raise.minAmountPerBuyer(), _minAmountPerBuyer, "minAmountPerBuyer not set");
         assertEq(raise.maxAmountPerBuyer(), _maxAmountPerBuyer, "maxAmountPerBuyer not set");
+    }
+
+    function testInitialization2(
+        uint256 _maxAmountPerBuyer,
+        uint256 _priceBase,
+        uint256 _maxAmountOfTokenToBeSold,
+        IERC20 _currency,
+        Token _token,
+        uint256 _autoPauseDate,
+        address _priceOracle
+    ) public {
+        vm.assume(address(_currency) != address(0));
+        vm.assume(address(_token) != address(0));
+        vm.assume(_priceBase > 0);
+        vm.assume(_maxAmountOfTokenToBeSold > _maxAmountPerBuyer);
+        vm.assume(_maxAmountPerBuyer > 0);
+
+        // create new clone factory so we can use the local forwarder
+        fundraisingImplementation = new PublicFundraising(exampleTrustedForwarder);
+        fundraisingFactory = new PublicFundraisingCloneFactory(address(fundraisingImplementation));
+
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+            exampleOwner,
+            exampleCurrencyReceiver,
+            exampleMinAmountPerBuyer,
+            _maxAmountPerBuyer,
+            _priceBase,
+            _maxAmountOfTokenToBeSold,
+            _currency,
+            _token,
+            _autoPauseDate,
+            _priceOracle
+        );
+
+        PublicFundraising raise = PublicFundraising(
+            fundraisingFactory.createPublicFundraisingClone(exampleRawSalt, exampleTrustedForwarder, arguments)
+        );
+
+        assertEq(raise.maxAmountPerBuyer(), _maxAmountPerBuyer, "maxAmountPerBuyer not set");
         assertEq(raise.priceBase(), _priceBase, "priceBase not set");
         assertEq(raise.maxAmountOfTokenToBeSold(), _maxAmountOfTokenToBeSold, "maxAmountOfTokenToBeSold not set");
         assertEq(address(raise.currency()), address(_currency), "currency not set");
         assertEq(address(raise.token()), address(_token), "token not set");
+        assertEq(raise.autoPauseDate(), _autoPauseDate, "autoPauseDate not set");
+        assertEq(address(raise.priceOracle()), _priceOracle, "priceOracle not set");
     }
 
     /*
@@ -353,21 +333,21 @@ contract tokenTest is Test {
         vm.assume(rando != address(0));
         vm.assume(rando != _admin);
 
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+            _admin,
+            _admin,
+            exampleMinAmountPerBuyer,
+            exampleMaxAmountPerBuyer,
+            exampleTokenPrice,
+            exampleMaxAmountOfTokenToBeSold,
+            exampleCurrency,
+            exampleToken,
+            exampleAutoPauseDate,
+            examplePriceOracle
+        );
+
         PublicFundraising raise = PublicFundraising(
-            fundraisingFactory.createPublicFundraisingClone(
-                0,
-                trustedForwarder,
-                _admin,
-                _admin,
-                1,
-                2,
-                3,
-                4,
-                IERC20(address(1)),
-                Token(address(2)),
-                0,
-                address(0)
-            )
+            fundraisingFactory.createPublicFundraisingClone(0, trustedForwarder, arguments)
         );
 
         vm.prank(rando);

--- a/test/PublicFundraisingCloneFactory.t.sol
+++ b/test/PublicFundraisingCloneFactory.t.sol
@@ -35,7 +35,9 @@ contract tokenTest is Test {
     address public constant exampleCurrencyReceiver = address(54);
     uint256 public constant exampleMinAmountPerBuyer = 1;
     uint256 public constant exampleMaxAmountPerBuyer = type(uint256).max;
-    uint256 public constant exampleTokenPrice = 1;
+    uint256 public constant exampleTokenPrice = 2;
+    uint256 public constant exampleMinTokenPrice = 1;
+    uint256 public constant exampleMaxTokenPrice = type(uint256).max;
     uint256 public constant exampleMaxAmountOfTokenToBeSold = 82398479821374;
     IERC20 public constant exampleCurrency = IERC20(address(1));
     Token public constant exampleToken = Token(address(2));
@@ -118,6 +120,8 @@ contract tokenTest is Test {
     function testAddressPrediction2(
         uint256 _maxAmountPerBuyer,
         uint256 _tokenPrice,
+        uint256 _tokenPriceMin,
+        uint256 _tokenPriceMax,
         uint256 _maxAmountOfTokenToBeSold,
         IERC20 _currency,
         Token _token,
@@ -129,6 +133,8 @@ contract tokenTest is Test {
         vm.assume(exampleMinAmountPerBuyer > 0);
         vm.assume(_maxAmountPerBuyer >= exampleMinAmountPerBuyer);
         vm.assume(_tokenPrice > 0);
+        vm.assume(_tokenPriceMin <= _tokenPrice);
+        vm.assume(_tokenPriceMax >= _tokenPrice);
         vm.assume(_maxAmountOfTokenToBeSold > _maxAmountPerBuyer);
 
         // create new clone factory so we can use the local forwarder
@@ -141,6 +147,8 @@ contract tokenTest is Test {
             exampleMinAmountPerBuyer,
             _maxAmountPerBuyer,
             _tokenPrice,
+            _tokenPriceMin,
+            _tokenPriceMax,
             _maxAmountOfTokenToBeSold,
             _currency,
             _token,
@@ -182,6 +190,8 @@ contract tokenTest is Test {
             _minAmountPerBuyer,
             exampleMaxAmountPerBuyer,
             exampleTokenPrice,
+            exampleMinTokenPrice,
+            exampleMaxTokenPrice,
             exampleMaxAmountOfTokenToBeSold,
             exampleCurrency,
             exampleToken,
@@ -204,6 +214,8 @@ contract tokenTest is Test {
         uint256 _minAmountPerBuyer,
         uint256 _maxAmountPerBuyer,
         uint256 _priceBase,
+        uint256 _tokenPriceMin,
+        uint256 _tokenPriceMax,
         uint256 _maxAmountOfTokenToBeSold,
         IERC20 _currency,
         Token _token
@@ -215,6 +227,8 @@ contract tokenTest is Test {
         vm.assume(_minAmountPerBuyer > 0);
         vm.assume(_maxAmountPerBuyer >= _minAmountPerBuyer);
         vm.assume(_priceBase > 0);
+        vm.assume(_tokenPriceMin <= _priceBase);
+        vm.assume(_tokenPriceMax >= _priceBase);
         vm.assume(_maxAmountOfTokenToBeSold > _maxAmountPerBuyer);
 
         PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
@@ -223,6 +237,8 @@ contract tokenTest is Test {
             _minAmountPerBuyer,
             _maxAmountPerBuyer,
             _priceBase,
+            _tokenPriceMin,
+            _tokenPriceMax,
             _maxAmountOfTokenToBeSold,
             _currency,
             _token,
@@ -262,6 +278,8 @@ contract tokenTest is Test {
             _minAmountPerBuyer,
             _maxAmountPerBuyer,
             exampleTokenPrice,
+            exampleMinTokenPrice,
+            exampleMaxTokenPrice,
             exampleMaxAmountOfTokenToBeSold,
             exampleCurrency,
             exampleToken,
@@ -283,6 +301,8 @@ contract tokenTest is Test {
     function testInitialization2(
         uint256 _maxAmountPerBuyer,
         uint256 _priceBase,
+        uint256 _priceMin,
+        uint256 _priceMax,
         uint256 _maxAmountOfTokenToBeSold,
         IERC20 _currency,
         Token _token,
@@ -292,6 +312,8 @@ contract tokenTest is Test {
         vm.assume(address(_currency) != address(0));
         vm.assume(address(_token) != address(0));
         vm.assume(_priceBase > 0);
+        vm.assume(_priceMin <= _priceBase);
+        vm.assume(_priceMax >= _priceBase);
         vm.assume(_maxAmountOfTokenToBeSold > _maxAmountPerBuyer);
         vm.assume(_maxAmountPerBuyer > 0);
 
@@ -305,6 +327,8 @@ contract tokenTest is Test {
             exampleMinAmountPerBuyer,
             _maxAmountPerBuyer,
             _priceBase,
+            _priceMin,
+            _priceMax,
             _maxAmountOfTokenToBeSold,
             _currency,
             _token,
@@ -339,6 +363,8 @@ contract tokenTest is Test {
             exampleMinAmountPerBuyer,
             exampleMaxAmountPerBuyer,
             exampleTokenPrice,
+            exampleMinTokenPrice,
+            exampleMaxTokenPrice,
             exampleMaxAmountOfTokenToBeSold,
             exampleCurrency,
             exampleToken,

--- a/test/PublicFundraisingCloneFactory.t.sol
+++ b/test/PublicFundraisingCloneFactory.t.sol
@@ -342,6 +342,8 @@ contract tokenTest is Test {
 
         assertEq(raise.maxAmountPerBuyer(), _maxAmountPerBuyer, "maxAmountPerBuyer not set");
         assertEq(raise.priceBase(), _priceBase, "priceBase not set");
+        assertEq(raise.priceMin(), _priceMin, "priceMin not set");
+        assertEq(raise.priceMax(), _priceMax, "priceMax not set");
         assertEq(raise.maxAmountOfTokenToBeSold(), _maxAmountOfTokenToBeSold, "maxAmountOfTokenToBeSold not set");
         assertEq(address(raise.currency()), address(_currency), "currency not set");
         assertEq(address(raise.token()), address(_token), "token not set");

--- a/test/PublicFundraisingDynamicPricing.t.sol
+++ b/test/PublicFundraisingDynamicPricing.t.sol
@@ -111,23 +111,19 @@ contract PublicFundraisingTest is Test {
 
         // create fundraising
         factory = new PublicFundraisingCloneFactory(address(new PublicFundraising(trustedForwarder)));
-
-        raise = PublicFundraising(
-            factory.createPublicFundraisingClone(
-                0,
-                trustedForwarder,
-                companyAdmin,
-                payable(receiver),
-                minAmountPerBuyer,
-                maxAmountPerBuyer,
-                price,
-                maxAmountOfTokenToBeSold,
-                paymentToken,
-                token,
-                0,
-                address(0)
-            )
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+            companyAdmin,
+            payable(receiver),
+            minAmountPerBuyer,
+            maxAmountPerBuyer,
+            price,
+            maxAmountOfTokenToBeSold,
+            paymentToken,
+            token,
+            0,
+            address(0)
         );
+        raise = PublicFundraising(factory.createPublicFundraisingClone(0, trustedForwarder, arguments));
 
         vm.stopPrank();
 

--- a/test/PublicFundraisingDynamicPricing.t.sol
+++ b/test/PublicFundraisingDynamicPricing.t.sol
@@ -117,6 +117,8 @@ contract PublicFundraisingTest is Test {
             minAmountPerBuyer,
             maxAmountPerBuyer,
             price,
+            price,
+            price,
             maxAmountOfTokenToBeSold,
             paymentToken,
             token,

--- a/test/PublicFundraisingERC2771.t.sol
+++ b/test/PublicFundraisingERC2771.t.sol
@@ -22,6 +22,8 @@ contract PublicFundraisingTest is Test {
     //Forwarder trustedForwarder;
     ERC2771Helper ERC2771helper;
 
+    PublicFundraisingInitializerArguments arguments;
+
     // copied from openGSN IForwarder
     struct ForwardRequest {
         address from;
@@ -94,28 +96,28 @@ contract PublicFundraisingTest is Test {
 
         tokenBuyAmount = 5 * 10 ** token.decimals();
         costInPaymentToken = (tokenBuyAmount * price) / 10 ** 18;
+
+        arguments = PublicFundraisingInitializerArguments(
+            address(this),
+            payable(receiver),
+            minAmountPerBuyer,
+            maxAmountPerBuyer,
+            price,
+            0,
+            0,
+            maxAmountOfTokenToBeSold,
+            paymentToken,
+            token,
+            0,
+            address(0)
+        );
     }
 
     function buyWithERC2771(Forwarder forwarder) public {
         vm.prank(owner);
         fundraisingFactory = new PublicFundraisingCloneFactory(address(new PublicFundraising(address(forwarder))));
 
-        raise = PublicFundraising(
-            fundraisingFactory.createPublicFundraisingClone(
-                0,
-                address(forwarder),
-                address(this),
-                payable(receiver),
-                minAmountPerBuyer,
-                maxAmountPerBuyer,
-                price,
-                maxAmountOfTokenToBeSold,
-                paymentToken,
-                token,
-                0,
-                address(0)
-            )
-        );
+        raise = PublicFundraising(fundraisingFactory.createPublicFundraisingClone(0, address(forwarder), arguments));
 
         // allow raise contract to mint
         bytes32 roleMintAllower = token.MINTALLOWER_ROLE();

--- a/test/PublicFundraisingERC677.t.sol
+++ b/test/PublicFundraisingERC677.t.sol
@@ -70,22 +70,22 @@ contract PublicFundraisingTest is Test {
         vm.prank(owner);
         factory = new PublicFundraisingCloneFactory(address(new PublicFundraising(trustedForwarder)));
 
-        raise = PublicFundraising(
-            factory.createPublicFundraisingClone(
-                0,
-                trustedForwarder,
-                owner,
-                payable(receiver),
-                minAmountPerBuyer,
-                maxAmountPerBuyer,
-                price,
-                maxAmountOfTokenToBeSold,
-                paymentToken,
-                token,
-                0,
-                address(0)
-            )
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+            owner,
+            receiver,
+            minAmountPerBuyer,
+            maxAmountPerBuyer,
+            price,
+            0,
+            0,
+            maxAmountOfTokenToBeSold,
+            paymentToken,
+            token,
+            0,
+            address(0)
         );
+
+        raise = PublicFundraising(factory.createPublicFundraisingClone(0, trustedForwarder, arguments));
 
         // allow raise contract to mint
         bytes32 roleMintAllower = token.MINTALLOWER_ROLE();
@@ -134,21 +134,22 @@ contract PublicFundraisingTest is Test {
         maliciousPaymentToken = new MaliciousPaymentToken(_paymentTokenAmount);
         vm.prank(owner);
 
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+            owner,
+            receiver,
+            minAmountPerBuyer,
+            maxAmountPerBuyer,
+            _price,
+            0,
+            0,
+            _maxMintAmount,
+            maliciousPaymentToken,
+            _token,
+            0,
+            address(0)
+        );
         PublicFundraising _raise = PublicFundraising(
-            factory.createPublicFundraisingClone(
-                0,
-                trustedForwarder,
-                address(this),
-                payable(receiver),
-                1,
-                _maxMintAmount / 100,
-                _price,
-                _maxMintAmount,
-                maliciousPaymentToken,
-                _token,
-                0,
-                address(0)
-            )
+            factory.createPublicFundraisingClone(0, trustedForwarder, arguments)
         );
 
         // allow invite contract to mint

--- a/test/PublicFundraisingIntegration.t.sol
+++ b/test/PublicFundraisingIntegration.t.sol
@@ -68,22 +68,22 @@ contract PublicFundraisingTest is Test {
 
         fundraisingFactory = new PublicFundraisingCloneFactory(address(new PublicFundraising(trustedForwarder)));
 
-        raise = PublicFundraising(
-            fundraisingFactory.createPublicFundraisingClone(
-                0,
-                trustedForwarder,
-                address(this),
-                payable(receiver),
-                minAmountPerBuyer,
-                maxAmountPerBuyer,
-                price,
-                maxAmountOfTokenToBeSold,
-                paymentToken,
-                token,
-                0,
-                address(0)
-            )
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+            address(this),
+            payable(receiver),
+            minAmountPerBuyer,
+            maxAmountPerBuyer,
+            price,
+            price,
+            price,
+            maxAmountOfTokenToBeSold,
+            paymentToken,
+            token,
+            0,
+            address(0)
         );
+
+        raise = PublicFundraising(fundraisingFactory.createPublicFundraisingClone(0, trustedForwarder, arguments));
 
         // allow raise contract to mint
         bytes32 roleMintAllower = token.MINTALLOWER_ROLE();
@@ -155,21 +155,23 @@ contract PublicFundraisingTest is Test {
         paymentToken = new FakePaymentToken(_paymentTokenAmount, _paymentTokenDecimals);
         vm.prank(companyOwner);
 
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+            address(this),
+            payable(receiver),
+            1,
+            _maxMintAmount / 100,
+            _price,
+            _price,
+            _price,
+            _maxMintAmount,
+            paymentToken,
+            _token,
+            0,
+            address(0)
+        );
+
         PublicFundraising _raise = PublicFundraising(
-            fundraisingFactory.createPublicFundraisingClone(
-                0,
-                trustedForwarder,
-                address(this),
-                payable(receiver),
-                1,
-                _maxMintAmount / 100,
-                _price,
-                _maxMintAmount,
-                paymentToken,
-                _token,
-                0,
-                address(0)
-            )
+            fundraisingFactory.createPublicFundraisingClone(0, trustedForwarder, arguments)
         );
 
         // allow invite contract to mint
@@ -273,21 +275,23 @@ contract PublicFundraisingTest is Test {
             paymentToken = new FakePaymentToken(_paymentTokenAmount, _paymentTokenDecimals);
             vm.prank(companyOwner);
 
+            PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+                address(this),
+                payable(receiver),
+                1,
+                _maxMintAmount / 100,
+                _price,
+                _price,
+                _price,
+                _maxMintAmount,
+                paymentToken,
+                _token,
+                0,
+                address(0)
+            );
+
             PublicFundraising _raise = PublicFundraising(
-                fundraisingFactory.createPublicFundraisingClone(
-                    0,
-                    trustedForwarder,
-                    address(this),
-                    payable(receiver),
-                    1,
-                    _maxMintAmount / 100,
-                    _price,
-                    _maxMintAmount,
-                    paymentToken,
-                    _token,
-                    0,
-                    address(0)
-                )
+                fundraisingFactory.createPublicFundraisingClone(0, trustedForwarder, arguments)
             );
             // allow invite contract to mint
             bytes32 roleMintAllower = token.MINTALLOWER_ROLE();

--- a/test/PublicFundraisingPrice.t.sol
+++ b/test/PublicFundraisingPrice.t.sol
@@ -70,22 +70,22 @@ contract PublicFundraisingTest is Test {
         vm.prank(owner);
         factory = new PublicFundraisingCloneFactory(address(new PublicFundraising(trustedForwarder)));
 
-        raise = PublicFundraising(
-            factory.createPublicFundraisingClone(
-                0,
-                trustedForwarder,
-                owner,
-                payable(receiver),
-                minAmountPerBuyer,
-                maxAmountPerBuyer,
-                price,
-                maxAmountOfTokenToBeSold,
-                paymentToken,
-                token,
-                0,
-                address(0)
-            )
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+            owner,
+            payable(receiver),
+            minAmountPerBuyer,
+            maxAmountPerBuyer,
+            price,
+            price,
+            price,
+            maxAmountOfTokenToBeSold,
+            paymentToken,
+            token,
+            0,
+            address(0)
         );
+
+        raise = PublicFundraising(factory.createPublicFundraisingClone(0, trustedForwarder, arguments));
 
         // allow raise contract to mint
         bytes32 roleMintAllower = token.MINTALLOWER_ROLE();

--- a/test/SetUpExampleCompany.t.sol
+++ b/test/SetUpExampleCompany.t.sol
@@ -198,22 +198,22 @@ contract CompanySetUpTest is Test {
         vm.prank(platformHotWallet);
         fundraisingFactory = new PublicFundraisingCloneFactory(address(new PublicFundraising(address(forwarder))));
 
-        raise = PublicFundraising(
-            fundraisingFactory.createPublicFundraisingClone(
-                0,
-                address(forwarder),
-                companyAdmin,
-                companyCurrencyReceiver,
-                minAmountPerBuyer,
-                maxAmountPerBuyer,
-                price,
-                maxAmountOfTokenToBeSold,
-                paymentToken,
-                token,
-                0,
-                address(0)
-            )
+        PublicFundraisingInitializerArguments memory arguments = PublicFundraisingInitializerArguments(
+            companyAdmin,
+            companyCurrencyReceiver,
+            minAmountPerBuyer,
+            maxAmountPerBuyer,
+            price,
+            price,
+            price,
+            maxAmountOfTokenToBeSold,
+            paymentToken,
+            token,
+            0,
+            address(0)
         );
+
+        raise = PublicFundraising(fundraisingFactory.createPublicFundraisingClone(0, address(forwarder), arguments));
 
         // the company admin can now enable the fundraising campaign by granting it a token minting allowance.
         // Because the company admin does not hold eth, they will use a meta transaction to call the function.

--- a/test/TokenSnapshots.t.sol
+++ b/test/TokenSnapshots.t.sol
@@ -98,6 +98,8 @@ contract tokenTest is Test {
         vm.assume(amount1 < (type(uint256).max - amount2) - 1000);
         vm.assume(rando1 != address(0));
         vm.assume(rando2 != address(0));
+        vm.assume(rando1 != trustedForwarder);
+        vm.assume(rando2 != trustedForwarder);
         vm.assume(token.balanceOf(rando1) == 0);
         vm.assume(token.balanceOf(rando2) == 0);
 


### PR DESCRIPTION
The `createPublicFundraisingClone` function takes lots of arguments (11, soon 13). The EVM should be able to handle up to 16 arguments, but it appears foundry needs some stack space as well while analyzing coverage, because the compilation fails:
 

```
Compiler run failed:
Error: Compiler error (/solidity/libyul/backends/evm/AsmCodeGen.cpp:62):Stack too deep. Try compiling with `--via-ir` (cli) or the equivalent `viaIR: true` (standard JSON) while enabling the optimizer. Otherwise, try removing local variables. When compiling inline assembly: Variable headStart is 1 slot(s) too deep inside the stack. Stack too deep. Try compiling with `--via-ir` (cli) or the equivalent `viaIR: true` (standard JSON) while enabling the optimizer. Otherwise, try removing local variables.
```

Mitigating this (while still being able to use both yul and non-yul pipelines) is possible by packing some of the arguments in a struct. This is what I am currently working on. 