### PR TITLE
fix fee settings interface

### DIFF
--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -307,12 +307,22 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
         return tokenFeeCollector;
     }
 
+    /**
+     * @notice calculate the fee for a given currency amount in Crowdinvesting (formerly ContinuousFundraising)
+     * @dev this is a compatibility function for IFeeSettingsV1. It enables older token contracts to use the new fee settings contract.
+     * @param _currencyAmount The amount of currency to calculate the fee for
+     */
     function continuousFundraisingFee(
         uint256 _currencyAmount
     ) external view override(IFeeSettingsV1) returns (uint256) {
         return _crowdinvestingFee(_currencyAmount);
     }
 
+    /**
+     * @notice calculate the fee for a given currency amount in PrivateOffer (formerly PersonalInvite)
+     * @dev this is a compatibility function for IFeeSettingsV1. It enables older token contracts to use the new fee settings contract.
+     * @param _currencyAmount The amount of currency to calculate the fee for
+     */
     function personalInviteFee(uint256 _currencyAmount) external view override(IFeeSettingsV1) returns (uint256) {
         return _privateOfferFee(_currencyAmount);
     }

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -254,9 +254,11 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
      * @param _currencyAmount The amount of currency to calculate the fee for
      * @return The fee
      */
-    function crowdinvestingFee(
-        uint256 _currencyAmount
-    ) external view override(IFeeSettingsV1, IFeeSettingsV2) returns (uint256) {
+    function crowdinvestingFee(uint256 _currencyAmount) external view override(IFeeSettingsV2) returns (uint256) {
+        return _crowdinvestingFee(_currencyAmount);
+    }
+
+    function _crowdinvestingFee(uint256 _currencyAmount) internal view returns (uint256) {
         return (_currencyAmount * crowdinvestingFeeNumerator) / crowdinvestingFeeDenominator;
     }
 
@@ -266,9 +268,11 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
      * @param _currencyAmount The amount of currency to calculate the fee for
      * @return The fee
      */
-    function privateOfferFee(
-        uint256 _currencyAmount
-    ) external view override(IFeeSettingsV1, IFeeSettingsV2) returns (uint256) {
+    function privateOfferFee(uint256 _currencyAmount) external view override(IFeeSettingsV2) returns (uint256) {
+        return _privateOfferFee(_currencyAmount);
+    }
+
+    function _privateOfferFee(uint256 _currencyAmount) internal view returns (uint256) {
         return (_currencyAmount * privateOfferFeeNumerator) / privateOfferFeeDenominator;
     }
 
@@ -301,5 +305,15 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
      */
     function feeCollector() external view override(IFeeSettingsV1) returns (address) {
         return tokenFeeCollector;
+    }
+
+    function continuousFundraisingFee(
+        uint256 _currencyAmount
+    ) external view override(IFeeSettingsV1) returns (uint256) {
+        return _crowdinvestingFee(_currencyAmount);
+    }
+
+    function personalInviteFee(uint256 _currencyAmount) external view override(IFeeSettingsV1) returns (uint256) {
+        return _privateOfferFee(_currencyAmount);
     }
 }

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -6,9 +6,9 @@ import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 interface IFeeSettingsV1 {
     function tokenFee(uint256) external view returns (uint256);
 
-    function crowdinvestingFee(uint256) external view returns (uint256);
+    function continuousFundraisingFee(uint256) external view returns (uint256);
 
-    function privateOfferFee(uint256) external view returns (uint256);
+    function personalInviteFee(uint256) external view returns (uint256);
 
     function feeCollector() external view returns (address);
 

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -499,7 +499,7 @@ contract FeeSettingsTest is Test {
         assertEq(
             _feeSettings.supportsInterface(type(IFeeSettingsV2).interfaceId),
             true,
-            "IFeeSettingsV1 not supported"
+            "IFeeSettingsV2 not supported"
         );
     }
 

--- a/test/IFeeSettings.t.sol
+++ b/test/IFeeSettings.t.sol
@@ -5,15 +5,40 @@ import "../lib/forge-std/src/Test.sol";
 import "../contracts/interfaces/IFeeSettings.sol";
 
 contract IFeeSettingsTest is Test {
-    function testManuallyVerifyInterfaceID() public {
+    function testManuallyVerifyInterfaceIDV1() public {
         // see https://medium.com/@chiqing/ethereum-standard-erc165-explained-63b54ca0d273
         bytes4 expected = getFunctionSelector("tokenFee(uint256)");
-        expected = expected ^ getFunctionSelector("crowdinvestingFee(uint256)");
-        expected = expected ^ getFunctionSelector("privateOfferFee(uint256)");
+        expected = expected ^ getFunctionSelector("continuousFundraisingFee(uint256)");
+        expected = expected ^ getFunctionSelector("personalInviteFee(uint256)");
         expected = expected ^ getFunctionSelector("feeCollector()");
         expected = expected ^ getFunctionSelector("owner()");
         expected = expected ^ getFunctionSelector("supportsInterface(bytes4)");
         bytes4 actual = type(IFeeSettingsV1).interfaceId;
+
+        // hardcoding this here so this test throws when search and replace changes the interface
+        bytes4 fixedValue = 0xc664b798;
+
+        assertEq(actual, fixedValue, "interface ID mismatch: did search and replace change the interface?");
+
+        assertEq(actual, expected, "interface ID mismatch");
+    }
+
+    function testManuallyVerifyInterfaceIDV2() public {
+        // see https://medium.com/@chiqing/ethereum-standard-erc165-explained-63b54ca0d273
+        bytes4 expected = getFunctionSelector("crowdinvestingFee(uint256)");
+        expected = expected ^ getFunctionSelector("crowdinvestingFeeCollector()");
+        expected = expected ^ getFunctionSelector("privateOfferFee(uint256)");
+        expected = expected ^ getFunctionSelector("privateOfferFeeCollector()");
+        expected = expected ^ getFunctionSelector("tokenFee(uint256)");
+        expected = expected ^ getFunctionSelector("tokenFeeCollector()");
+        expected = expected ^ getFunctionSelector("owner()");
+        expected = expected ^ getFunctionSelector("supportsInterface(bytes4)");
+        bytes4 actual = type(IFeeSettingsV2).interfaceId;
+
+        // hardcoding this here so this test throws when search and replace changes the interface
+        bytes4 fixedValue = 0x9fc80df3;
+
+        assertEq(actual, fixedValue, "interface ID mismatch: did search and replace change the interface?");
 
         assertEq(actual, expected, "interface ID mismatch");
     }


### PR DESCRIPTION
The old IFeeSettingsV1 interface was broken through search and replace while renaming contracts. Fixed it and added hard-coded tests that will fail if it happens again.