### PR TITLE
Feature/improve crowdinvesting again

### DIFF
--- a/contracts/Crowdinvesting.sol
+++ b/contracts/Crowdinvesting.sol
@@ -329,12 +329,14 @@ contract Crowdinvesting is
 
     /**
      * @notice change currency to `_currency` and tokenPrice to `_tokenPrice`
+     * @dev If price dynamic is active, it will be deactivated.
      * @param _currency new currency
      * @param _tokenPrice new tokenPrice
      */
     function setCurrencyAndTokenPrice(IERC20 _currency, uint256 _tokenPrice) external onlyOwner whenPaused {
         require(address(_currency) != address(0), "currency can not be zero address");
         require(_tokenPrice != 0, "_tokenPrice needs to be a non-zero amount");
+        priceOracle = IPriceDynamic(address(0)); // deactivate dynamic pricing because price changed, so min and max need to be updated
         priceBase = _tokenPrice;
         currency = _currency;
         emit TokenPriceAndCurrencyChanged(_tokenPrice, _currency);

--- a/contracts/Crowdinvesting.sol
+++ b/contracts/Crowdinvesting.sol
@@ -208,7 +208,14 @@ contract Crowdinvesting is
 
     function getPrice() public view returns (uint256) {
         if (address(priceOracle) != address(0)) {
-            return Math.min(Math.max(priceOracle.getPrice(priceBase), priceMin), priceMax);
+            uint256 price = priceOracle.getPrice(priceBase);
+            if (price > priceMax) {
+                return priceMax;
+            }
+            if (price < priceMin) {
+                return priceMin;
+            }
+            return price;
         }
 
         return priceBase;

--- a/test/CrowdinvestingPrice.t.sol
+++ b/test/CrowdinvestingPrice.t.sol
@@ -390,4 +390,59 @@ contract CrowdinvestingTest is Test {
         vm.warp(type(uint64).max);
         assertEq(crowdinvesting.getPrice(), priceMax, "Price should be priceMax now");
     }
+
+    function testChangingPriceDisablesPriceDynamic() public {
+        // create oracle
+        vm.warp(1 hours + 1); // otherwise, price linear thinks it has to cool down
+        PriceLinear priceLinear = PriceLinear(
+            priceLinearCloneFactory.createPriceLinearClone(
+                0,
+                trustedForwarder,
+                owner,
+                1e10,
+                1,
+                2 hours,
+                1,
+                false,
+                true // price will rise
+            )
+        );
+
+        CrowdinvestingInitializerArguments memory arguments = CrowdinvestingInitializerArguments(
+            owner,
+            payable(receiver),
+            minAmountPerBuyer,
+            maxAmountPerBuyer,
+            price,
+            priceMin,
+            priceMax,
+            maxAmountOfTokenToBeSold,
+            paymentToken,
+            token,
+            0,
+            address(priceLinear)
+        );
+
+        crowdinvesting = Crowdinvesting(factory.createCrowdinvestingClone(0, trustedForwarder, arguments));
+
+        vm.warp(200 days);
+
+        console.log("Oracle address: ", address(crowdinvesting.priceOracle()));
+        console.log("Price through oracle: ", priceLinear.getPrice(price));
+        console.log("Price through crowdinvesting: ", crowdinvesting.getPrice());
+        // check that price is changed by oracle
+        assertTrue(crowdinvesting.priceBase() == price, "Price not as expected");
+        assertTrue(crowdinvesting.getPrice() > price, "Price should have changed!");
+
+        // change price
+        vm.startPrank(owner);
+        crowdinvesting.pause();
+        crowdinvesting.setCurrencyAndTokenPrice(IERC20(address(20)), price / 2);
+        vm.warp(201 days);
+        crowdinvesting.unpause();
+
+        // check that price is not changed anymore
+        assertTrue(crowdinvesting.getPrice() == price / 2, "Price should not have changed!");
+        assertTrue(crowdinvesting.priceBase() == price / 2, "Token price should have changed!");
+    }
 }

--- a/test/VestingBlind.t.sol
+++ b/test/VestingBlind.t.sol
@@ -143,6 +143,7 @@ contract VestingBlindTest is Test {
     ) public {
         vm.assume(checkLimits(_allocation, _beneficiary, _start, _cliff, _duration, trustedForwarder));
         vm.assume(_rando != address(0));
+        vm.assume(_rando != trustedForwarder);
         bytes32 hash = keccak256(
             abi.encodePacked(_allocation, _beneficiary, _start, _cliff, _duration, _isMintable, _salt)
         );


### PR DESCRIPTION
MythX did not like that a nested call could revert, see attached report.
To fix this, I changed the way the price boundaries are enforced. The new code is easier to understand, too.

Also, I realized that changing priceBase does not change priceMin and priceMax. To prevent unwanted parameter sets from providing wrong prices, I added a line that deactivates dynamic pricing when priceBase is changed.
 
[ad3fd22535d6b7f23a42a6fa.pdf](https://github.com/corpus-io/tokenize.it-smart-contracts/files/13400766/ad3fd22535d6b7f23a42a6fa.pdf)
