### PR TITLE
Feature/fee discounts2

### DIFF
--- a/.github/workflows/wordscan.yml
+++ b/.github/workflows/wordscan.yml
@@ -10,6 +10,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16.x
-      - run: test "$(grep msg.sender contracts/Token.sol contracts/ContinuousFundraising.sol |wc -l)" -eq 0 && test "$(grep msg.data contracts/Token.sol contracts/ContinuousFundraising.sol |wc -l)" -eq 0
+      - run: test "$(grep msg.sender contracts/Token.sol contracts/ContinuousFundraising.sol contracts/FeeSettings.sol |wc -l)" -eq 0 && test "$(grep msg.data contracts/Token.sol contracts/ContinuousFundraising.sol contracts/FeeSettings.sol |wc -l)" -eq 0
 
-      # these two contracts inherit from ERC2771Context and may not contain msg.sender or msg.data. Instead, they must use _msgSender() and _msgData()
+      # these contracts inherit from ERC2771Context and may not contain msg.sender or msg.data. Instead, they must use _msgSender() and _msgData()

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -137,6 +137,22 @@ contract FeeSettings is Ownable2Step, ERC165, IFeeSettingsV2, IFeeSettingsV1 {
     }
 
     /**
+     * @notice Adds a manager
+     * @param _manager The manager to add
+     */
+    function addManager(address _manager) external onlyOwner {
+        managers[_manager] = true;
+    }
+
+    /**
+     * @notice Removes a manager
+     * @param _manager The manager to remove
+     */
+    function removeManager(address _manager) external onlyOwner {
+        delete managers[_manager];
+    }
+
+    /**
      * @notice Prepares a fee change. Fee increases are subject to a minimum delay of 12 weeks, while fee reductions can be executed immediately.
      * @dev reducing fees = increasing the denominator
      * @param _fees The new fee denominators

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -99,6 +99,8 @@ contract FeeSettings is
         uint256 time
     );
 
+    event RemoveCustomFee(address indexed token);
+
     /**
      * @notice The fee collector has been changed to `newFeeCollector`
      * @param newFeeCollector The new fee collector
@@ -236,6 +238,7 @@ contract FeeSettings is
      */
     function removeCustomFee(address _token) external onlyManager {
         delete customFees[_token];
+        emit RemoveCustomFee(_token);
     }
 
     /**

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -200,7 +200,10 @@ contract FeeSettings is
                 privateOfferFeeDenominator
             )
         ) {
-            require(_fees.time > block.timestamp + 12 weeks, "Fee change must be at least 12 weeks in the future");
+            require(
+                _fees.validityDate > block.timestamp + 12 weeks,
+                "Fee change must be at least 12 weeks in the future"
+            );
         }
         proposedFees = _fees;
         emit ChangeProposed(_fees);
@@ -213,7 +216,7 @@ contract FeeSettings is
      */
     function setCustomFee(address _token, Fees memory _fees) external onlyManager {
         checkFeeLimits(_fees);
-        require(_fees.time > block.timestamp, "Custom fee expiry time must be in the future");
+        require(_fees.validityDate > block.timestamp, "Custom fee expiry time must be in the future");
         customFees[_token] = _fees;
         emit SetCustomFee(
             _token,
@@ -223,7 +226,7 @@ contract FeeSettings is
             _fees.crowdinvestingFeeDenominator,
             _fees.privateOfferFeeNumerator,
             _fees.privateOfferFeeDenominator,
-            _fees.time
+            _fees.validityDate
         );
     }
 
@@ -239,7 +242,7 @@ contract FeeSettings is
      * @notice Executes a fee change that has been planned before
      */
     function executeFeeChange() external onlyOwner {
-        require(block.timestamp >= proposedFees.time, "Fee change must be executed after the change time");
+        require(block.timestamp >= proposedFees.validityDate, "Fee change must be executed after the change time");
         tokenFeeNumerator = proposedFees.tokenFeeNumerator;
         tokenFeeDenominator = proposedFees.tokenFeeDenominator;
         crowdinvestingFeeNumerator = proposedFees.crowdinvestingFeeNumerator;
@@ -352,7 +355,7 @@ contract FeeSettings is
 
     function tokenFee(uint256 _tokenAmount, address _token) public view returns (uint256) {
         uint256 baseFee = _fee(_tokenAmount, tokenFeeNumerator, tokenFeeDenominator);
-        if (customFees[_token].time > block.timestamp) {
+        if (customFees[_token].validityDate > block.timestamp) {
             uint256 customFee = _fee(
                 _tokenAmount,
                 customFees[_token].tokenFeeNumerator,
@@ -385,7 +388,7 @@ contract FeeSettings is
      */
     function crowdinvestingFee(uint256 _currencyAmount, address _token) public view returns (uint256) {
         uint256 baseFee = _fee(_currencyAmount, crowdinvestingFeeNumerator, crowdinvestingFeeDenominator);
-        if (customFees[_token].time > block.timestamp) {
+        if (customFees[_token].validityDate > block.timestamp) {
             uint256 customFee = _fee(
                 _currencyAmount,
                 customFees[_token].crowdinvestingFeeNumerator,
@@ -417,7 +420,7 @@ contract FeeSettings is
      */
     function _privateOfferFee(uint256 _currencyAmount, address _token) internal view returns (uint256) {
         uint256 baseFee = _fee(_currencyAmount, privateOfferFeeNumerator, privateOfferFeeDenominator);
-        if (customFees[_token].time > block.timestamp) {
+        if (customFees[_token].validityDate > block.timestamp) {
             uint256 customFee = _fee(
                 _currencyAmount,
                 customFees[_token].privateOfferFeeNumerator,

--- a/contracts/PrivateOffer.sol
+++ b/contracts/PrivateOffer.sol
@@ -84,7 +84,7 @@ contract PrivateOffer {
         );
 
         IFeeSettingsV2 feeSettings = _arguments.token.feeSettings();
-        uint256 fee = feeSettings.privateOfferFee(currencyAmount);
+        uint256 fee = feeSettings.privateOfferFee(currencyAmount, address(_arguments.token));
         if (fee != 0) {
             _arguments.currency.safeTransferFrom(_arguments.currencyPayer, feeSettings.privateOfferFeeCollector(), fee);
         }

--- a/contracts/factories/FeeSettingsCloneFactory.sol
+++ b/contracts/factories/FeeSettingsCloneFactory.sol
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.23;
+
+import "../FeeSettings.sol";
+import "./CloneFactory.sol";
+
+/**
+ * @title FeeSettingsCloneFactory
+ * @author malteish
+ * @notice Create clones of a FeeSettings contract with deterministic addresses
+ */
+contract FeeSettingsCloneFactory is CloneFactory {
+    constructor(address _implementation) CloneFactory(_implementation) {}
+
+    /**
+     * Create a clone
+
+     */
+    function createFeeSettingsClone(
+        bytes32 _rawSalt,
+        address _trustedForwarder,
+        address _owner,
+        Fees memory _fees,
+        address _tokenFeeCollector,
+        address _crowdinvestingFeeCollector,
+        address _privateOfferFeeCollector
+    ) external returns (address) {
+        bytes32 salt = _generateSalt(
+            _rawSalt,
+            _trustedForwarder,
+            _owner,
+            _fees,
+            _tokenFeeCollector,
+            _crowdinvestingFeeCollector,
+            _privateOfferFeeCollector
+        );
+        address clone = Clones.cloneDeterministic(implementation, salt);
+        FeeSettings clonePriceOracle = FeeSettings(clone);
+        require(
+            clonePriceOracle.isTrustedForwarder(_trustedForwarder),
+            "FeeSettingsCloneFactory: Unexpected trustedForwarder"
+        );
+        clonePriceOracle.initialize(
+            _owner,
+            _fees,
+            _tokenFeeCollector,
+            _crowdinvestingFeeCollector,
+            _privateOfferFeeCollector
+        );
+        emit NewClone(clone);
+        return clone;
+    }
+
+    /**
+     * Return the address a clone would have if it was created with these parameters.
+     * @param _rawSalt this value influences the address of the clone, but not the initialization
+     * @param _trustedForwarder the trusted forwarder (ERC2771) can not be changed, but is checked for security
+     * @param _owner address that will own the new clone
+     */
+    function predictCloneAddress(
+        bytes32 _rawSalt,
+        address _trustedForwarder,
+        address _owner,
+        Fees memory _fees,
+        address _tokenFeeCollector,
+        address _crowdinvestingFeeCollector,
+        address _privateOfferFeeCollector
+    ) external view returns (address) {
+        bytes32 salt = _generateSalt(
+            _rawSalt,
+            _trustedForwarder,
+            _owner,
+            _fees,
+            _tokenFeeCollector,
+            _crowdinvestingFeeCollector,
+            _privateOfferFeeCollector
+        );
+        return Clones.predictDeterministicAddress(implementation, salt);
+    }
+
+    /**
+     * Generate a single salt from all input parameters
+   
+     */
+    function _generateSalt(
+        bytes32 _rawSalt,
+        address _trustedForwarder,
+        address _owner,
+        Fees memory _fees,
+        address _tokenFeeCollector,
+        address _crowdinvestingFeeCollector,
+        address _privateOfferFeeCollector
+    ) internal pure returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    _rawSalt,
+                    _trustedForwarder,
+                    _owner,
+                    _fees,
+                    _tokenFeeCollector,
+                    _crowdinvestingFeeCollector,
+                    _privateOfferFeeCollector
+                )
+            );
+    }
+}

--- a/contracts/factories/FeeSettingsCloneFactory.sol
+++ b/contracts/factories/FeeSettingsCloneFactory.sol
@@ -36,12 +36,12 @@ contract FeeSettingsCloneFactory is CloneFactory {
             _privateOfferFeeCollector
         );
         address clone = Clones.cloneDeterministic(implementation, salt);
-        FeeSettings clonePriceOracle = FeeSettings(clone);
+        FeeSettings cloneFeeSettings = FeeSettings(clone);
         require(
-            clonePriceOracle.isTrustedForwarder(_trustedForwarder),
+            cloneFeeSettings.isTrustedForwarder(_trustedForwarder),
             "FeeSettingsCloneFactory: Unexpected trustedForwarder"
         );
-        clonePriceOracle.initialize(
+        cloneFeeSettings.initialize(
             _owner,
             _fees,
             _tokenFeeCollector,

--- a/contracts/factories/PriceLinearCloneFactory.sol
+++ b/contracts/factories/PriceLinearCloneFactory.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.23;
 
 import "../PriceLinear.sol";
 import "./CloneFactory.sol";
-import "@openzeppelin/contracts/proxy/Clones.sol";
 
 /**
  * @title PriceLinearCloneFactory

--- a/contracts/factories/PrivateOfferFactory.sol
+++ b/contracts/factories/PrivateOfferFactory.sol
@@ -79,13 +79,13 @@ contract PrivateOfferFactory {
             false
         ); // this plan is not mintable
 
+        vesting.removeManager(address(this));
+
         // transfer ownership of the vesting contract
         if (_vestingContractOwner == address(0)) {
             // if the owner is 0, the vesting contract will not have an owner. So no one can interfere with the vesting.
-            vesting.removeManager(address(this));
             vesting.renounceOwnership();
         } else {
-            vesting.removeManager(address(this));
             vesting.transferOwnership(_vestingContractOwner);
         }
 

--- a/contracts/factories/VestingCloneFactory.sol
+++ b/contracts/factories/VestingCloneFactory.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.23;
 
 import "../Vesting.sol";
 import "./CloneFactory.sol";
-import "@openzeppelin/contracts/proxy/Clones.sol";
 
 /**
  * @title VestingCloneFactory

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -63,5 +63,5 @@ struct Fees {
     uint32 crowdinvestingFeeDenominator;
     uint32 privateOfferFeeNumerator;
     uint32 privateOfferFeeDenominator;
-    uint64 time;
+    uint64 validityDate;
 }

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -39,7 +39,7 @@ interface IFeeSettingsV2 {
 
     function crowdinvestingFeeCollector() external view returns (address);
 
-    function privateOfferFee(uint256) external view returns (uint256);
+    function privateOfferFee(uint256, address) external view returns (uint256);
 
     function privateOfferFeeCollector() external view returns (address);
 

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -51,7 +51,10 @@ interface IFeeSettingsV2 {
 /**
  * @notice The Fees struct contains all the parameters to change fee quantities and fee collector addresses,
  * as well as the time when the new settings can be activated.
- * @dev time is ignored when the struct is used during initialization.
+ * @dev time has different meanings:
+ *  1. it is ignored when the struct is used during initialization.
+ *  2. it is the time when the new settings can be activated when the struct is used during a fee change.
+ *  3. it is the time up to which the settings are valid when the struct is used for fee discounts for specific customers
  */
 struct Fees {
     uint32 tokenFeeNumerator;

--- a/script/DeployPlatform.s.sol
+++ b/script/DeployPlatform.s.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 // taken from https://moveseventyeight.com/deploy-your-first-nft-contract-with-foundry#heading-prepare-a-basic-deployment-script
 
 import "../lib/forge-std/src/Script.sol";
-import "../contracts/FeeSettings.sol";
+import "../contracts/factories/FeeSettingsCloneFactory.sol";
 import "../contracts/AllowList.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
 import "../contracts/factories/VestingCloneFactory.sol";
@@ -28,9 +28,26 @@ contract DeployPlatform is Script {
 
         vm.startBroadcast(deployerPrivateKey);
 
+        console.log("Deploying FeeSettingsCloneFactory contract...");
+        FeeSettings feeSettingsLogicContract = new FeeSettings(trustedForwarder);
+        FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(
+            address(feeSettingsLogicContract)
+        );
+        console.log("FeeSettingsCloneFactory deployed at: ", address(feeSettingsCloneFactory));
+
         console.log("Deploying FeeSettings contract...");
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        FeeSettings feeSettings = new FeeSettings(fees, platformColdWallet, platformColdWallet, platformColdWallet);
+        FeeSettings feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                bytes32(0),
+                trustedForwarder,
+                platformColdWallet,
+                fees,
+                platformColdWallet,
+                platformColdWallet,
+                platformColdWallet
+            )
+        );
         console.log("FeeSettings deployed at: ", address(feeSettings));
         feeSettings.transferOwnership(platformColdWallet);
         console.log("Started ownership transfer to: ", platformColdWallet);

--- a/script/DeployTokenFromScratch.s.sol
+++ b/script/DeployTokenFromScratch.s.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 // taken from https://moveseventyeight.com/deploy-your-first-nft-contract-with-foundry#heading-prepare-a-basic-deployment-script
 
 import "../lib/forge-std/src/Script.sol";
-import "../contracts/FeeSettings.sol";
+import "../contracts/factories/FeeSettingsCloneFactory.sol";
 import "../contracts/AllowList.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
@@ -14,6 +14,8 @@ contract DeployPlatform is Script {
 
     function run() public {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
+
+        address trustedForwarder = 0xAa3E82b4c4093b4bA13Cb5714382C99ADBf750cA;
 
         // Goerli
         //address platformColdWallet = 0x1695F52e342f3554eC8BC06621B7f5d1644cCE39;
@@ -35,9 +37,26 @@ contract DeployPlatform is Script {
 
         vm.startBroadcast(deployerPrivateKey);
 
+        console.log("Deploying FeeSettingsCloneFactory contract...");
+        FeeSettings feeSettingsLogicContract = new FeeSettings(trustedForwarder);
+        FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(
+            address(feeSettingsLogicContract)
+        );
+        console.log("FeeSettingsCloneFactory deployed at: ", address(feeSettingsCloneFactory));
+
         console.log("Deploying FeeSettings contract...");
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        FeeSettings feeSettings = new FeeSettings(fees, platformColdWallet, platformColdWallet, platformColdWallet);
+        FeeSettings feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                bytes32(0),
+                trustedForwarder,
+                platformAdminWallet,
+                fees,
+                platformColdWallet,
+                platformColdWallet,
+                platformColdWallet
+            )
+        );
         console.log("FeeSettings deployed at: ", address(feeSettings));
         feeSettings.transferOwnership(platformColdWallet);
         console.log("Started ownership transfer to: ", platformColdWallet);

--- a/test/Crowdinvesting.t.sol
+++ b/test/Crowdinvesting.t.sol
@@ -7,6 +7,7 @@ import "../contracts/FeeSettings.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/MaliciousPaymentToken.sol";
+import "./resources/FakeCrowdinvestingAndToken.sol";
 
 contract CrowdinvestingTest is Test {
     event CurrencyReceiverChanged(address indexed);
@@ -334,6 +335,7 @@ contract CrowdinvestingTest is Test {
         uint256 paymentTokenBalanceBefore = paymentToken.balanceOf(buyer);
 
         FeeSettings localFeeSettings = FeeSettings(address(token.feeSettings()));
+        FakeCrowdinvesting fakeCrowdinvesting = new FakeCrowdinvesting(address(token));
 
         vm.prank(buyer);
         vm.expectEmit(true, true, true, true, address(crowdinvesting));
@@ -342,13 +344,12 @@ contract CrowdinvestingTest is Test {
         assertTrue(paymentToken.balanceOf(buyer) == paymentTokenBalanceBefore - costInPaymentToken, "buyer has paid");
         assertTrue(token.balanceOf(buyer) == tokenBuyAmount, "buyer has tokens");
         assertTrue(
-            paymentToken.balanceOf(receiver) ==
-                costInPaymentToken - localFeeSettings.crowdinvestingFee(costInPaymentToken),
+            paymentToken.balanceOf(receiver) == costInPaymentToken - fakeCrowdinvesting.fee(costInPaymentToken),
             "receiver has payment tokens"
         );
         assertTrue(
             paymentToken.balanceOf(token.feeSettings().crowdinvestingFeeCollector()) ==
-                localFeeSettings.crowdinvestingFee(costInPaymentToken),
+                fakeCrowdinvesting.fee(costInPaymentToken),
             "fee collector has collected fee in payment tokens"
         );
         assertTrue(

--- a/test/Crowdinvesting.t.sol
+++ b/test/Crowdinvesting.t.sol
@@ -8,6 +8,7 @@ import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/MaliciousPaymentToken.sol";
 import "./resources/FakeCrowdinvestingAndToken.sol";
+import "./resources/FeeSettingsCreator.sol";
 
 contract CrowdinvestingTest is Test {
     event CurrencyReceiverChanged(address indexed);
@@ -53,7 +54,14 @@ contract CrowdinvestingTest is Test {
     function setUp() public {
         list = new AllowList();
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 100);
-        feeSettings = new FeeSettings(fees, wrongFeeReceiver, admin, wrongFeeReceiver);
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            fees,
+            wrongFeeReceiver,
+            admin,
+            wrongFeeReceiver
+        );
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/CrowdinvestingCloneFactory.t.sol
+++ b/test/CrowdinvestingCloneFactory.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
-import "../contracts/FeeSettings.sol";
+import "../contracts/factories/FeeSettingsCloneFactory.sol";
 import "./resources/ERC2771Helper.sol";
 
 contract tokenTest is Test {
@@ -50,11 +50,20 @@ contract tokenTest is Test {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        feeSettings = new FeeSettings(
-            fees,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner
+        FeeSettings feeSettingsLogicContract = new FeeSettings(trustedForwarder);
+        FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(
+            address(feeSettingsLogicContract)
+        );
+        feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                0,
+                trustedForwarder,
+                feeSettingsAndAllowListOwner,
+                fees,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner
+            )
         );
         vm.stopPrank();
 

--- a/test/CrowdinvestingDynamicPricing.t.sol
+++ b/test/CrowdinvestingDynamicPricing.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.23;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
-import "../contracts/FeeSettings.sol";
+import "../contracts/factories/FeeSettingsCloneFactory.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "../contracts/factories/PriceLinearCloneFactory.sol";
 import "./resources/FakePaymentToken.sol";
@@ -91,7 +91,19 @@ contract CrowdinvestingTest is Test {
         vm.startPrank(platformAdmin);
         list = new AllowList();
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 100);
-        feeSettings = new FeeSettings(fees, platformAdmin, platformAdmin, platformAdmin);
+        FeeSettings feeLogic = new FeeSettings(trustedForwarder);
+        FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(address(feeLogic));
+        feeSettings = IFeeSettingsV2(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                0,
+                trustedForwarder,
+                platformAdmin,
+                fees,
+                platformAdmin,
+                platformAdmin,
+                platformAdmin
+            )
+        );
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/CrowdinvestingERC2771.t.sol
+++ b/test/CrowdinvestingERC2771.t.sol
@@ -7,6 +7,7 @@ import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/ERC2771Helper.sol";
+import "./resources/FeeSettingsCreator.sol";
 import "@opengsn/contracts/src/forwarder/Forwarder.sol"; // chose specific version to avoid import error: yarn add @opengsn/contracts@2.2.5
 
 contract CrowdinvestingTest is Test {
@@ -74,7 +75,7 @@ contract CrowdinvestingTest is Test {
             paymentTokenFeeDenominator,
             0
         );
-        feeSettings = new FeeSettings(fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, address(this), fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenFactory = new TokenProxyFactory(address(implementation));

--- a/test/CrowdinvestingERC677.t.sol
+++ b/test/CrowdinvestingERC677.t.sol
@@ -3,11 +3,11 @@ pragma solidity 0.8.23;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
-import "../contracts/FeeSettings.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/MaliciousPaymentToken.sol";
 import "./resources/FakeCrowdinvestingAndToken.sol";
+import "./resources/FeeSettingsCreator.sol";
 
 contract CrowdinvestingTest is Test {
     event CurrencyReceiverChanged(address indexed);
@@ -51,7 +51,14 @@ contract CrowdinvestingTest is Test {
     function setUp() public {
         list = new AllowList();
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 100);
-        feeSettings = new FeeSettings(fees, wrongFeeReceiver, admin, wrongFeeReceiver);
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            fees,
+            wrongFeeReceiver,
+            admin,
+            wrongFeeReceiver
+        );
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/CrowdinvestingERC677.t.sol
+++ b/test/CrowdinvestingERC677.t.sol
@@ -7,6 +7,7 @@ import "../contracts/FeeSettings.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/MaliciousPaymentToken.sol";
+import "./resources/FakeCrowdinvestingAndToken.sol";
 
 contract CrowdinvestingTest is Test {
     event CurrencyReceiverChanged(address indexed);
@@ -220,20 +221,24 @@ contract CrowdinvestingTest is Test {
 
         assertTrue(paymentToken.balanceOf(buyer) == paymentTokenBalanceBefore - costInPaymentToken, "buyer has paid");
         assertTrue(token.balanceOf(buyer) == realTokenBuyAmount, "buyer has wrong token amount");
+
+        FakeCrowdinvesting fakeCrowdinvesting = new FakeCrowdinvesting(address(token));
+
         assertTrue(
-            paymentToken.balanceOf(receiver) ==
-                costInPaymentToken - localFeeSettings.crowdinvestingFee(costInPaymentToken),
+            paymentToken.balanceOf(receiver) == costInPaymentToken - fakeCrowdinvesting.fee(costInPaymentToken),
             "receiver has payment tokens"
         );
         assertTrue(
             paymentToken.balanceOf(token.feeSettings().crowdinvestingFeeCollector()) ==
-                localFeeSettings.crowdinvestingFee(costInPaymentToken),
+                fakeCrowdinvesting.fee(costInPaymentToken),
             "fee collector has collected fee in payment tokens"
         );
+
         assertTrue(
             token.balanceOf(token.feeSettings().tokenFeeCollector()) >= localFeeSettings.tokenFee(tokenBuyAmount),
             "fee collector has collected fee in tokens"
         );
+
         assertTrue(crowdinvesting.tokensSold() == realTokenBuyAmount, "crowdinvesting has sold wrong amount of tokens");
         assertTrue(
             crowdinvesting.tokensBought(buyer) == realTokenBuyAmount,

--- a/test/CrowdinvestingIntegration.t.sol
+++ b/test/CrowdinvestingIntegration.t.sol
@@ -121,7 +121,7 @@ contract CrowdinvestingTest is Test {
         );
         vm.prank(platformAdmin);
         feeSettings.planFeeChange(fees);
-        vm.warp(fees.time + 1 seconds);
+        vm.warp(fees.validityDate + 1 seconds);
         vm.prank(platformAdmin);
         feeSettings.executeFeeChange();
 

--- a/test/CrowdinvestingIntegration.t.sol
+++ b/test/CrowdinvestingIntegration.t.sol
@@ -7,6 +7,7 @@ import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/MaliciousPaymentToken.sol";
+import "./resources/FeeSettingsCreator.sol";
 
 contract CrowdinvestingTest is Test {
     Crowdinvesting crowdinvesting;
@@ -40,8 +41,14 @@ contract CrowdinvestingTest is Test {
     function setUp() public {
         list = new AllowList();
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 100);
-        vm.prank(platformAdmin);
-        feeSettings = new FeeSettings(fees, platformAdmin, platformAdmin, platformAdmin);
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            platformAdmin,
+            fees,
+            platformAdmin,
+            platformAdmin,
+            platformAdmin
+        );
         vm.prank(platformAdmin);
         token = Token(
             tokenFactory.createTokenProxy(

--- a/test/CrowdinvestingPrice.t.sol
+++ b/test/CrowdinvestingPrice.t.sol
@@ -3,12 +3,12 @@ pragma solidity 0.8.23;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
-import "../contracts/FeeSettings.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "../contracts/factories/PriceLinearCloneFactory.sol";
 import "../contracts/PriceLinear.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/MaliciousPaymentToken.sol";
+import "./resources/FeeSettingsCreator.sol";
 
 contract CrowdinvestingTest is Test {
     event CurrencyReceiverChanged(address indexed);
@@ -55,7 +55,14 @@ contract CrowdinvestingTest is Test {
     function setUp() public {
         list = new AllowList();
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 100);
-        feeSettings = new FeeSettings(fees, wrongFeeReceiver, admin, wrongFeeReceiver);
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            fees,
+            wrongFeeReceiver,
+            admin,
+            wrongFeeReceiver
+        );
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.23;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
-import "../contracts/FeeSettings.sol";
+import "./resources/FeeSettingsCreator.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/ERC2771Helper.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
@@ -79,7 +79,14 @@ contract TokenERC2771Test is Test {
             0
         );
         vm.prank(platformAdmin);
-        feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            platformAdmin,
+            fees,
+            feeCollector,
+            feeCollector,
+            feeCollector
+        );
 
         Token implementation = new Token(address(forwarder));
         factory = new TokenProxyFactory(address(implementation));

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -494,11 +494,9 @@ contract FeeSettingsTest is Test {
         // set up fake crowdinvesting for this to work
         FakeToken _fakeToken = new FakeToken(address(_feeSettings));
         FakeCrowdinvesting _fakeCrowdinvesting = new FakeCrowdinvesting(address(_fakeToken));
-        assertEq(
-            _fakeCrowdinvesting.fee(_amount),
-            _feeSettings.continuousFundraisingFee(_amount),
-            "Crowdinvesting Fee mismatch"
-        );
+
+        assertEq(_fakeCrowdinvesting.fee(_amount), _fakeCrowdinvesting.feeV1(_amount), "Crowdinvesting Fee mismatch");
+
         assertEq(
             _feeSettings.privateOfferFee(_amount, address(0)),
             _feeSettings.personalInviteFee(_amount),

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -664,7 +664,7 @@ contract FeeSettingsTest is Test {
         assertEq(_feeSettings.privateOfferFee(1000, _someTokenAddress), 50, "Private offer fee should be 50 again");
     }
 
-    function testOnlyOwnerCanAddCustomFees(address _rando) public {
+    function testOnlyManagerCanAddCustomFees(address _rando) public {
         address someTokenAddress = address(74);
         vm.assume(_rando != address(0));
         vm.assume(_rando != admin);
@@ -674,7 +674,7 @@ contract FeeSettingsTest is Test {
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
         _feeSettings.setCustomFee(someTokenAddress, fees);
     }
@@ -752,7 +752,7 @@ contract FeeSettingsTest is Test {
         assertEq(_feeSettings.privateOfferFee(1000, someTokenAddress), 50, "Private offer fee should be 50");
     }
 
-    function testOnlyOwnerCanRemoveCustomFees(address _rando) public {
+    function testOnlyManagerCanRemoveCustomFees(address _rando) public {
         address someTokenAddress = address(74);
         vm.assume(_rando != address(0));
         vm.assume(_rando != admin);
@@ -762,7 +762,7 @@ contract FeeSettingsTest is Test {
         vm.prank(admin);
         FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        vm.expectRevert("Ownable: caller is not the owner");
+        vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
         _feeSettings.removeCustomFee(someTokenAddress);
     }

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.23;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/Token.sol";
-import "../contracts/FeeSettings.sol";
+import "../contracts/factories/FeeSettingsCloneFactory.sol";
 import "./resources/FakeCrowdinvestingAndToken.sol";
 
 contract FeeSettingsTest is Test {
@@ -23,6 +23,8 @@ contract FeeSettingsTest is Test {
     event ChangeProposed(Fees proposal);
 
     FeeSettings feeSettings;
+    FeeSettingsCloneFactory feeSettingsCloneFactory;
+    Fees fees;
     Token token;
     Token currency;
 
@@ -40,12 +42,17 @@ contract FeeSettingsTest is Test {
     uint256 public constant price = 10000000;
 
     function setUp() public {
-        Fees memory fees = Fees(1, 100, 2, 100, 3, 100, 0);
+        FeeSettings logic = new FeeSettings(trustedForwarder);
+        feeSettingsCloneFactory = new FeeSettingsCloneFactory(address(logic));
+
+        fees = Fees(1, 101, 2, 102, 3, 103, 0);
         vm.prank(admin);
-        feeSettings = new FeeSettings(fees, admin, admin, admin);
+        feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, fees, admin, admin, admin)
+        );
     }
 
-    function testEnforceFeeRangeInConstructor(uint32 numerator, uint32 denominator) public {
+    function testEnforceFeeRangeInInitializer(uint32 numerator, uint32 denominator) public {
         vm.assume(denominator > 0);
         vm.assume(!tokenOrPrivateOfferFeeInValidRange(numerator, denominator));
         Fees memory _fees;
@@ -53,64 +60,62 @@ contract FeeSettingsTest is Test {
         console.log("Testing token fee");
         _fees = Fees(numerator, denominator, 1, 30, 1, 100, 0);
         vm.expectRevert("Token fee must be equal or less 5%");
-        new FeeSettings(_fees, admin, admin, admin);
+        feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin);
 
         console.log("Testing Crowdinvesting fee");
         _fees = Fees(1, 30, numerator, denominator, 1, 100, 0);
         if (!crowdinvestingFeeInValidRange(numerator, denominator)) {
             vm.expectRevert("Crowdinvesting fee must be equal or less 10%");
-            new FeeSettings(_fees, admin, admin, admin);
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin);
         } else {
             // this should not revert, as the fee is in valid range for crowdinvesting
-            new FeeSettings(_fees, admin, admin, admin);
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin);
         }
 
         console.log("Testing PrivateOffer fee");
         _fees = Fees(1, 30, 1, 40, numerator, denominator, 0);
         vm.expectRevert("PrivateOffer fee must be equal or less 5%");
-        new FeeSettings(_fees, admin, admin, admin);
+        feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin);
     }
 
     function testEnforceTokenFeeRangeInFeeChanger(uint32 numerator, uint32 denominator) public {
         vm.assume(denominator > 0);
         vm.assume(!tokenOrPrivateOfferFeeInValidRange(numerator, denominator));
-        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees(numerator, denominator, 1, 100, 1, 100, uint64(block.timestamp + 7884001));
         vm.expectRevert("Token fee must be equal or less 5%");
-        _feeSettings.planFeeChange(feeChange);
+        vm.prank(admin);
+        feeSettings.planFeeChange(feeChange);
     }
 
     function testEnforceCrowdinvestingFeeRangeInFeeChanger(uint32 numerator, uint32 denominator) public {
         vm.assume(denominator > 0);
         vm.assume(!crowdinvestingFeeInValidRange(numerator, denominator));
-        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees(1, 100, numerator, denominator, 1, 100, uint64(block.timestamp + 7884001));
         vm.expectRevert("Crowdinvesting fee must be equal or less 10%");
-        _feeSettings.planFeeChange(feeChange);
+        vm.prank(admin);
+        feeSettings.planFeeChange(feeChange);
     }
 
     function testEnforcePrivateOfferFeeRangeInFeeChanger(uint32 numerator, uint32 denominator) public {
         vm.assume(denominator > 0);
         vm.assume(!tokenOrPrivateOfferFeeInValidRange(numerator, denominator));
-        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
         Fees memory feeChange = Fees(1, 100, 1, 100, numerator, denominator, uint64(block.timestamp + 7884001));
         vm.expectRevert("PrivateOffer fee must be equal or less 5%");
-        _feeSettings.planFeeChange(feeChange);
+        vm.prank(admin);
+        feeSettings.planFeeChange(feeChange);
     }
 
     function testEnforceFeeChangeDelayOnIncrease(uint delay, uint32 startDenominator, uint32 newDenominator) public {
         vm.assume(delay <= 12 weeks);
         vm.assume(startDenominator >= 20 && newDenominator >= 20);
         vm.assume(newDenominator < startDenominator);
-        Fees memory fees = Fees(1, startDenominator, 1, startDenominator, 1, startDenominator, 0);
-        vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
+        Fees memory _fees = Fees(1, startDenominator, 1, startDenominator, 1, startDenominator, 0);
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+        );
 
         Fees memory feeChange = Fees(1, newDenominator, 0, 1, 0, 1, uint64(block.timestamp + delay));
         vm.prank(admin);
@@ -133,10 +138,6 @@ contract FeeSettingsTest is Test {
         vm.assume(tokenOrPrivateOfferFeeInValidRange(1, tokenFee));
         vm.assume(tokenOrPrivateOfferFeeInValidRange(1, investmentFee));
 
-        Fees memory fees = Fees(1, 50, 1, 50, 1, 50, 0);
-        vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
-
         Fees memory feeChange = Fees(
             1,
             tokenFee,
@@ -147,12 +148,12 @@ contract FeeSettingsTest is Test {
             uint64(block.timestamp + delayAnnounced)
         );
         vm.prank(admin);
-        _feeSettings.planFeeChange(feeChange);
+        feeSettings.planFeeChange(feeChange);
 
         vm.prank(admin);
         vm.expectRevert("Fee change must be executed after the change time");
         vm.warp(uint64(block.timestamp + delayAnnounced) - 1);
-        _feeSettings.executeFeeChange();
+        feeSettings.executeFeeChange();
     }
 
     function testExecuteFeeChangeProperly(
@@ -169,10 +170,6 @@ contract FeeSettingsTest is Test {
         vm.assume(crowdinvestingFeeInValidRange(crowdinvestingFeeNumerator, crowdinvestingFeeDenominator));
         vm.assume(tokenOrPrivateOfferFeeInValidRange(privateOfferFeeNumerator, privateOfferFeeDenominator));
 
-        Fees memory fees = Fees(1, 50, 1, 50, 1, 50, 0);
-        vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
-
         Fees memory feeChange = Fees(
             tokenFeeNumerator,
             tokenFeeDenominator,
@@ -183,13 +180,13 @@ contract FeeSettingsTest is Test {
             uint64(block.timestamp + delayAnnounced)
         );
         vm.prank(admin);
-        vm.expectEmit(true, true, true, true, address(_feeSettings));
+        vm.expectEmit(true, true, true, true, address(feeSettings));
         emit ChangeProposed(feeChange);
-        _feeSettings.planFeeChange(feeChange);
+        feeSettings.planFeeChange(feeChange);
 
         vm.prank(admin);
         vm.warp(uint64(block.timestamp + delayAnnounced) + 1);
-        vm.expectEmit(true, true, true, true, address(_feeSettings));
+        vm.expectEmit(true, true, true, true, address(feeSettings));
         emit SetFee(
             tokenFeeNumerator,
             tokenFeeDenominator,
@@ -198,51 +195,52 @@ contract FeeSettingsTest is Test {
             privateOfferFeeNumerator,
             privateOfferFeeDenominator
         );
-        _feeSettings.executeFeeChange();
+        feeSettings.executeFeeChange();
 
-        assertEq(_feeSettings.tokenFeeNumerator(), tokenFeeNumerator);
-        assertEq(_feeSettings.tokenFeeDenominator(), tokenFeeDenominator);
-        assertEq(_feeSettings.crowdinvestingFeeNumerator(), crowdinvestingFeeNumerator);
-        assertEq(_feeSettings.crowdinvestingFeeDenominator(), crowdinvestingFeeDenominator);
-        assertEq(_feeSettings.privateOfferFeeNumerator(), privateOfferFeeNumerator);
-        assertEq(_feeSettings.privateOfferFeeDenominator(), privateOfferFeeDenominator);
+        assertEq(feeSettings.tokenFeeNumerator(), tokenFeeNumerator);
+        assertEq(feeSettings.tokenFeeDenominator(), tokenFeeDenominator);
+        assertEq(feeSettings.crowdinvestingFeeNumerator(), crowdinvestingFeeNumerator);
+        assertEq(feeSettings.crowdinvestingFeeDenominator(), crowdinvestingFeeDenominator);
+        assertEq(feeSettings.privateOfferFeeNumerator(), privateOfferFeeNumerator);
+        assertEq(feeSettings.privateOfferFeeDenominator(), privateOfferFeeDenominator);
     }
 
     function testSetFeeTo0Immediately() public {
-        Fees memory fees = Fees(1, 50, 1, 20, 1, 30, 0);
-        vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
-
         Fees memory feeChange = Fees(0, 1, 0, 1, 0, 1, uint64(block.timestamp));
 
-        assertEq(_feeSettings.tokenFeeNumerator(), 1);
-        assertEq(_feeSettings.tokenFeeDenominator(), 50);
-        assertEq(_feeSettings.crowdinvestingFeeNumerator(), 1);
-        assertEq(_feeSettings.crowdinvestingFeeDenominator(), 20);
-        assertEq(_feeSettings.privateOfferFeeNumerator(), 1);
-        assertEq(_feeSettings.privateOfferFeeDenominator(), 30);
+        assertEq(feeSettings.tokenFeeNumerator(), 1);
+        assertEq(feeSettings.tokenFeeDenominator(), 101);
+        assertEq(feeSettings.crowdinvestingFeeNumerator(), 2);
+        assertEq(feeSettings.crowdinvestingFeeDenominator(), 102);
+        assertEq(feeSettings.privateOfferFeeNumerator(), 3);
+        assertEq(feeSettings.privateOfferFeeDenominator(), 103);
 
         vm.prank(admin);
-        _feeSettings.planFeeChange(feeChange);
+        feeSettings.planFeeChange(feeChange);
 
         vm.prank(admin);
         //vm.warp(uint64(block.timestamp + delayAnnounced) + 1);
-        _feeSettings.executeFeeChange();
+        feeSettings.executeFeeChange();
 
-        assertEq(_feeSettings.tokenFeeNumerator(), 0);
-        assertEq(_feeSettings.tokenFeeDenominator(), 1);
-        assertEq(_feeSettings.crowdinvestingFeeNumerator(), 0);
-        assertEq(_feeSettings.crowdinvestingFeeDenominator(), 1);
-        assertEq(_feeSettings.privateOfferFeeNumerator(), 0);
-        assertEq(_feeSettings.privateOfferFeeDenominator(), 1);
+        assertEq(feeSettings.tokenFeeNumerator(), 0);
+        assertEq(feeSettings.tokenFeeDenominator(), 1);
+        assertEq(feeSettings.crowdinvestingFeeNumerator(), 0);
+        assertEq(feeSettings.crowdinvestingFeeDenominator(), 1);
+        assertEq(feeSettings.privateOfferFeeNumerator(), 0);
+        assertEq(feeSettings.privateOfferFeeDenominator(), 1);
 
-        //assertEq(_feeSettings.change, 0);
+        (, uint32 tokenFeeDenominator, , , , , uint64 time) = feeSettings.proposedFees();
+
+        assertEq(tokenFeeDenominator, 0, "Token fee denominator mismatch");
+        assertEq(time, 0, "Time mismatch");
     }
 
     function testSetFeeToXFrom0Immediately() public {
-        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
+        Fees memory _fees = Fees(0, 1, 0, 1, 0, 1, 0);
         vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+        );
 
         Fees memory feeChange = Fees(1, 20, 1, 30, 1, 50, 0);
 
@@ -259,34 +257,31 @@ contract FeeSettingsTest is Test {
     }
 
     function testReduceFeeImmediately(uint32 tokenReductor, uint32 continuousReductor, uint32 personalReductor) public {
-        vm.assume(tokenReductor >= 50);
-        vm.assume(continuousReductor >= 20);
-        vm.assume(personalReductor >= 30);
-        Fees memory fees = Fees(1, 50, 1, 20, 1, 30, 0);
-        vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
+        vm.assume(tokenReductor >= 101);
+        vm.assume(continuousReductor >= 102);
+        vm.assume(personalReductor >= 103);
 
-        Fees memory feeChange = Fees(1, tokenReductor, 1, continuousReductor, 1, personalReductor, 0);
+        Fees memory feeChange = Fees(1, tokenReductor, 2, continuousReductor, 3, personalReductor, 0);
 
-        assertEq(_feeSettings.tokenFeeDenominator(), 50);
-        assertEq(_feeSettings.crowdinvestingFeeDenominator(), 20);
-        assertEq(_feeSettings.privateOfferFeeDenominator(), 30);
+        assertEq(feeSettings.tokenFeeDenominator(), 101, "Token fee denominator mismatch");
+        assertEq(feeSettings.crowdinvestingFeeDenominator(), 102, "Crowdinvesting fee denominator mismatch");
+        assertEq(feeSettings.privateOfferFeeDenominator(), 103, "Private offer fee denominator mismatch");
 
         vm.prank(admin);
-        _feeSettings.planFeeChange(feeChange);
+        feeSettings.planFeeChange(feeChange);
 
         vm.prank(admin);
         //vm.warp(uint64(block.timestamp + delayAnnounced) + 1);
-        _feeSettings.executeFeeChange();
+        feeSettings.executeFeeChange();
 
-        assertEq(_feeSettings.tokenFeeDenominator(), tokenReductor);
-        assertEq(_feeSettings.crowdinvestingFeeDenominator(), continuousReductor);
-        assertEq(_feeSettings.privateOfferFeeDenominator(), personalReductor);
+        assertEq(feeSettings.tokenFeeDenominator(), tokenReductor);
+        assertEq(feeSettings.crowdinvestingFeeDenominator(), continuousReductor);
+        assertEq(feeSettings.privateOfferFeeDenominator(), personalReductor);
 
         //assertEq(_feeSettings.change, 0);
     }
 
-    function testSetFeeInConstructor(
+    function testSetFeeInInitializer(
         uint32 tokenFeeNumerator,
         uint32 tokenFeeDenominator,
         uint32 crowdinvestingFeeNumerator,
@@ -299,7 +294,7 @@ contract FeeSettingsTest is Test {
         vm.assume(tokenOrPrivateOfferFeeInValidRange(privateOfferFeeNumerator, privateOfferFeeDenominator));
         vm.assume(crowdinvestingFeeInValidRange(crowdinvestingFeeNumerator, crowdinvestingFeeDenominator));
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(
+        Fees memory _fees = Fees(
             tokenFeeNumerator,
             tokenFeeDenominator,
             crowdinvestingFeeNumerator,
@@ -308,7 +303,9 @@ contract FeeSettingsTest is Test {
             privateOfferFeeDenominator,
             0
         );
-        _feeSettings = new FeeSettings(fees, admin, admin, admin);
+        _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+        );
         assertEq(_feeSettings.tokenFeeNumerator(), tokenFeeNumerator, "Token fee numerator mismatch");
         assertEq(_feeSettings.tokenFeeDenominator(), tokenFeeDenominator, "Token fee denominator mismatch");
         assertEq(
@@ -333,27 +330,64 @@ contract FeeSettingsTest is Test {
         );
     }
 
-    function testFeeCollector0FailsInConstructor() public {
-        vm.expectRevert("Fee collector cannot be 0x0");
+    function testFeeCollector0FailsInInitializer() public {
         FeeSettings _feeSettings;
-        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        _feeSettings = new FeeSettings(fees, address(0), address(0), address(0));
+
+        vm.expectRevert("Fee collector cannot be 0x0");
+        _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                admin,
+                fees,
+                address(0),
+                admin,
+                admin
+            )
+        );
+
+        vm.expectRevert("Fee collector cannot be 0x0");
+        _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                admin,
+                fees,
+                admin,
+                address(0),
+                admin
+            )
+        );
+
+        vm.expectRevert("Fee collector cannot be 0x0");
+        _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                admin,
+                fees,
+                admin,
+                admin,
+                address(0)
+            )
+        );
+    }
+
+    function testOwner0FailsInInitializer() public {
+        vm.expectRevert("owner can not be zero address");
+        feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, address(0), fees, admin, admin, admin);
     }
 
     function testFeeCollector0FailsInSetter() public {
-        FeeSettings _feeSettings;
-        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        vm.prank(admin);
-        _feeSettings = new FeeSettings(fees, admin, admin, admin);
         vm.expectRevert("Fee collector cannot be 0x0");
         vm.prank(admin);
-        _feeSettings.setFeeCollectors(address(0), address(1), address(2));
+        feeSettings.setFeeCollectors(address(0), address(1), address(2));
         vm.expectRevert("Fee collector cannot be 0x0");
         vm.prank(admin);
-        _feeSettings.setFeeCollectors(address(2), address(0), address(1));
+        feeSettings.setFeeCollectors(address(2), address(0), address(1));
         vm.expectRevert("Fee collector cannot be 0x0");
         vm.prank(admin);
-        _feeSettings.setFeeCollectors(address(1), address(2), address(0));
+        feeSettings.setFeeCollectors(address(1), address(2), address(0));
     }
 
     function testUpdateFeeCollectors(
@@ -364,18 +398,15 @@ contract FeeSettingsTest is Test {
         vm.assume(newTokenFeeCollector != address(0));
         vm.assume(newCrowdinvestingFeeCollector != address(0));
         vm.assume(newPrivateOfferFeeCollector != address(0));
-        FeeSettings _feeSettings;
-        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        vm.prank(admin);
-        _feeSettings = new FeeSettings(fees, admin, admin, admin);
-        vm.expectEmit(true, true, true, true, address(_feeSettings));
+
+        vm.expectEmit(true, true, true, true, address(feeSettings));
         emit FeeCollectorsChanged(newTokenFeeCollector, newCrowdinvestingFeeCollector, newPrivateOfferFeeCollector);
         vm.prank(admin);
-        _feeSettings.setFeeCollectors(newTokenFeeCollector, newCrowdinvestingFeeCollector, newPrivateOfferFeeCollector);
-        assertEq(_feeSettings.feeCollector(), newTokenFeeCollector); // IFeeSettingsV1
-        assertEq(_feeSettings.tokenFeeCollector(), newTokenFeeCollector);
-        assertEq(_feeSettings.crowdinvestingFeeCollector(), newCrowdinvestingFeeCollector);
-        assertEq(_feeSettings.privateOfferFeeCollector(), newPrivateOfferFeeCollector);
+        feeSettings.setFeeCollectors(newTokenFeeCollector, newCrowdinvestingFeeCollector, newPrivateOfferFeeCollector);
+        assertEq(feeSettings.feeCollector(), newTokenFeeCollector); // IFeeSettingsV1
+        assertEq(feeSettings.tokenFeeCollector(), newTokenFeeCollector);
+        assertEq(feeSettings.crowdinvestingFeeCollector(), newCrowdinvestingFeeCollector);
+        assertEq(feeSettings.privateOfferFeeCollector(), newPrivateOfferFeeCollector);
     }
 
     function tokenOrPrivateOfferFeeInValidRange(uint32 numerator, uint32 denominator) internal pure returns (bool) {
@@ -405,7 +436,9 @@ contract FeeSettingsTest is Test {
             privateOfferFeeDenominator,
             0
         );
-        FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+        );
 
         FakeToken _fakeToken = new FakeToken(address(_feeSettings));
         FakeCrowdinvesting _fakeCrowdinvesting = new FakeCrowdinvesting(address(_fakeToken));
@@ -433,7 +466,9 @@ contract FeeSettingsTest is Test {
         // only token fee is 0
 
         Fees memory _fees = Fees(0, 1, 1, crowdinvestingFeeDenominator, 1, privateOfferFeeDenominator, 0);
-        FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+        );
 
         FakeToken _fakeToken = new FakeToken(address(_feeSettings));
         FakeCrowdinvesting _fakeCrowdinvesting = new FakeCrowdinvesting(address(_fakeToken));
@@ -449,7 +484,9 @@ contract FeeSettingsTest is Test {
         // only crowdinvesting fee is 0
 
         _fees = Fees(1, tokenFeeDenominator, 0, 1, 1, privateOfferFeeDenominator, 0);
-        _feeSettings = new FeeSettings(_fees, admin, admin, admin);
+        _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+        );
         _fakeToken = new FakeToken(address(_feeSettings));
         _fakeCrowdinvesting = new FakeCrowdinvesting(address(_fakeToken));
 
@@ -464,7 +501,9 @@ contract FeeSettingsTest is Test {
         // only private offer fee is 0
 
         _fees = Fees(1, tokenFeeDenominator, 1, crowdinvestingFeeDenominator, 0, 1, 0);
-        _feeSettings = new FeeSettings(_fees, admin, admin, admin);
+        _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+        );
         _fakeToken = new FakeToken(address(_feeSettings));
         _fakeCrowdinvesting = new FakeCrowdinvesting(address(_fakeToken));
 
@@ -474,64 +513,43 @@ contract FeeSettingsTest is Test {
     }
 
     function testERC165IsAvailable() public {
-        FeeSettings _feeSettings;
-        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        _feeSettings = new FeeSettings(fees, admin, admin, admin);
         assertEq(
-            _feeSettings.supportsInterface(0x01ffc9a7), // type(IERC165).interfaceId
+            feeSettings.supportsInterface(0x01ffc9a7), // type(IERC165).interfaceId
             true,
             "ERC165 not supported"
         );
     }
 
     function testIFeeSettingsV1IsAvailable(uint256 _amount) public {
-        FeeSettings _feeSettings;
-        Fees memory fees = Fees(1, 100, 1, 25, 1, 40, 0);
-        _feeSettings = new FeeSettings(fees, admin, admin, admin);
-
-        assertEq(
-            _feeSettings.supportsInterface(type(IFeeSettingsV1).interfaceId),
-            true,
-            "IFeeSettingsV1 not supported"
-        );
+        vm.assume(_amount < UINT256_MAX / 3);
+        assertEq(feeSettings.supportsInterface(type(IFeeSettingsV1).interfaceId), true, "IFeeSettingsV1 not supported");
 
         // these functions must be present, so the call can not revert
 
         // set up fake crowdinvesting for this to work
-        FakeToken _fakeToken = new FakeToken(address(_feeSettings));
+        FakeToken _fakeToken = new FakeToken(address(feeSettings));
         FakeCrowdinvesting _fakeCrowdinvesting = new FakeCrowdinvesting(address(_fakeToken));
 
         assertEq(_fakeCrowdinvesting.fee(_amount), _fakeCrowdinvesting.feeV1(_amount), "Crowdinvesting Fee mismatch");
 
         assertEq(
-            _feeSettings.privateOfferFee(_amount, address(0)),
-            _feeSettings.personalInviteFee(_amount),
+            feeSettings.privateOfferFee(_amount, address(0)),
+            feeSettings.personalInviteFee(_amount),
             "Private offer fee mismatch"
         );
-        assertEq(_feeSettings.feeCollector(), _feeSettings.tokenFeeCollector(), "Fee collector mismatch");
+        assertEq(feeSettings.feeCollector(), feeSettings.tokenFeeCollector(), "Fee collector mismatch");
     }
 
     function testIFeeSettingsV2IsAvailable() public {
-        FeeSettings _feeSettings;
-        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        _feeSettings = new FeeSettings(fees, admin, admin, admin);
-
-        assertEq(
-            _feeSettings.supportsInterface(type(IFeeSettingsV2).interfaceId),
-            true,
-            "IFeeSettingsV2 not supported"
-        );
+        assertEq(feeSettings.supportsInterface(type(IFeeSettingsV2).interfaceId), true, "IFeeSettingsV2 not supported");
     }
 
     function testNonsenseInterfacesAreNotAvailable(bytes4 _nonsenseInterface) public {
         vm.assume(_nonsenseInterface != type(IFeeSettingsV1).interfaceId);
         vm.assume(_nonsenseInterface != type(IFeeSettingsV2).interfaceId);
         vm.assume(_nonsenseInterface != 0x01ffc9a7);
-        FeeSettings _feeSettings;
-        Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        _feeSettings = new FeeSettings(fees, admin, admin, admin);
 
-        assertEq(_feeSettings.supportsInterface(0x01ffc9b7), false, "This interface should not be supported");
+        assertEq(feeSettings.supportsInterface(0x01ffc9b7), false, "This interface should not be supported");
     }
 
     /**
@@ -552,7 +570,9 @@ contract FeeSettingsTest is Test {
         // only token fee is 0
 
         Fees memory _fees = Fees(0, 1, 1, crowdinvestingFeeDenominator, 1, privateOfferFeeDenominator, 0);
-        FeeSettings _feeSettings = new FeeSettings(_fees, admin, admin, admin);
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+        );
 
         FakeToken _fakeToken = new FakeToken(address(_feeSettings));
         FakeCrowdinvesting _fakeCrowdinvesting = new FakeCrowdinvesting(address(_fakeToken));
@@ -568,7 +588,9 @@ contract FeeSettingsTest is Test {
         // only crowdinvesting fee is 0
 
         _fees = Fees(1, tokenFeeDenominator, 0, 1, 1, privateOfferFeeDenominator, 0);
-        _feeSettings = new FeeSettings(_fees, admin, admin, admin);
+        _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+        );
         _fakeToken = new FakeToken(address(_feeSettings));
         _fakeCrowdinvesting = new FakeCrowdinvesting(address(_fakeToken));
 
@@ -583,7 +605,9 @@ contract FeeSettingsTest is Test {
         // only private offer fee is 0
 
         _fees = Fees(1, tokenFeeDenominator, 1, crowdinvestingFeeDenominator, 0, 1, 0);
-        _feeSettings = new FeeSettings(_fees, admin, admin, admin);
+        _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+        );
         _fakeToken = new FakeToken(address(_feeSettings));
         _fakeCrowdinvesting = new FakeCrowdinvesting(address(_fakeToken));
 
@@ -593,25 +617,47 @@ contract FeeSettingsTest is Test {
     }
 
     function test0DenominatorIsNotPossible() public {
-        Fees memory fees = Fees(1, 0, 1, 0, 1, 0, 0);
+        Fees memory _fees = Fees(1, 0, 1, 0, 1, 0, 0);
         vm.expectRevert("Denominator cannot be 0");
-        new FeeSettings(fees, admin, admin, admin);
+        feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin);
 
         // set 0 fee first, then update to 0 denominator
-        fees = Fees(0, 1, 0, 1, 0, 1, 0);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
-        fees = Fees(0, 0, 0, 0, 0, 0, 0);
+        _fees = Fees(0, 1, 0, 1, 0, 1, 0);
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+        );
+        _fees = Fees(0, 0, 0, 1, 0, 1, 0);
         vm.expectRevert("Denominator cannot be 0");
-        _feeSettings.planFeeChange(fees);
+        vm.prank(admin);
+        _feeSettings.planFeeChange(_fees);
+
+        _fees = Fees(0, 1, 0, 0, 0, 1, 0);
+        vm.expectRevert("Denominator cannot be 0");
+        vm.prank(admin);
+        _feeSettings.planFeeChange(_fees);
+
+        _fees = Fees(0, 1, 0, 1, 0, 0, 0);
+        vm.expectRevert("Denominator cannot be 0");
+        vm.prank(admin);
+        _feeSettings.planFeeChange(_fees);
     }
 
     function testAddingCustomFees(address _someTokenAddress) public {
         vm.assume(_someTokenAddress != address(0));
 
-        Fees memory fees = Fees(1, 100, 1, 50, 1, 20, 0);
+        Fees memory _fees = Fees(1, 100, 1, 50, 1, 20, 0);
         // deploying from here makes address(this) the admin
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
-
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                address(this),
+                _fees,
+                address(this),
+                address(this),
+                address(this)
+            )
+        );
         // check there is no entry for this token address
         (
             uint32 tokenFeeNumerator,
@@ -637,8 +683,8 @@ contract FeeSettingsTest is Test {
 
         // add custom fee entry for this token address
         uint256 realEndTime = block.timestamp + 100;
-        fees = Fees(3, 1000, 4, 1000, 2, 1000, uint64(realEndTime));
-        _feeSettings.setCustomFee(_someTokenAddress, fees);
+        _fees = Fees(3, 1000, 4, 1000, 2, 1000, uint64(realEndTime));
+        _feeSettings.setCustomFee(_someTokenAddress, _fees);
 
         // check the token fee, private offer fee and crowdinvesting fee change as expected
         assertEq(_feeSettings.tokenFee(1000, _someTokenAddress), 3, "Token fee should be 3");
@@ -675,14 +721,11 @@ contract FeeSettingsTest is Test {
         vm.assume(_rando != address(0));
         vm.assume(_rando != admin);
 
-        Fees memory fees = Fees(1, 100, 1, 50, 1, 20, 0);
-
-        vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
+        Fees memory _fees = Fees(1, 100, 1, 50, 1, 20, 0);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        _feeSettings.setCustomFee(someTokenAddress, fees);
+        feeSettings.setCustomFee(someTokenAddress, _fees);
     }
 
     function testCustomFeesAreNotAppliedToOtherTokens(address _someTokenAddress, address _otherTokenAddress) public {
@@ -690,12 +733,21 @@ contract FeeSettingsTest is Test {
         vm.assume(_otherTokenAddress != address(0));
         vm.assume(_someTokenAddress != _otherTokenAddress);
 
-        Fees memory fees = Fees(1, 100, 1, 50, 1, 20, 0);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
-
+        Fees memory _fees = Fees(1, 100, 1, 50, 1, 20, 0);
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                address(this),
+                _fees,
+                admin,
+                admin,
+                admin
+            )
+        );
         // add custom fee entry for this token address
-        fees = Fees(3, 1000, 4, 1000, 2, 1000, uint64(block.timestamp + 100));
-        _feeSettings.setCustomFee(_someTokenAddress, fees);
+        _fees = Fees(3, 1000, 4, 1000, 2, 1000, uint64(block.timestamp + 100));
+        _feeSettings.setCustomFee(_someTokenAddress, _fees);
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(1000, _otherTokenAddress), 10, "Token fee should be 10");
@@ -705,8 +757,18 @@ contract FeeSettingsTest is Test {
 
     function testCustomFeesDoNotIncreaseFee() public {
         address someTokenAddress = address(74);
-        Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
+        Fees memory _fees = Fees(0, 1, 0, 1, 0, 1, 0);
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                address(this),
+                _fees,
+                admin,
+                admin,
+                admin
+            )
+        );
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(type(uint256).max, someTokenAddress), 0, "Token fee should be 0");
@@ -718,8 +780,8 @@ contract FeeSettingsTest is Test {
         assertEq(_feeSettings.privateOfferFee(type(uint256).max, someTokenAddress), 0, "Private offer fee should be 0");
 
         // add custom fee entry for this token address
-        fees = Fees(1, 20, 1, 10, 1, 20, uint64(block.timestamp + 100));
-        _feeSettings.setCustomFee(someTokenAddress, fees);
+        _fees = Fees(1, 20, 1, 10, 1, 20, uint64(block.timestamp + 100));
+        _feeSettings.setCustomFee(someTokenAddress, _fees);
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(type(uint256).max, someTokenAddress), 0, "Token fee should still be 0");
@@ -737,12 +799,21 @@ contract FeeSettingsTest is Test {
 
     function testRemovingCustomFee() public {
         address someTokenAddress = address(74);
-        Fees memory fees = Fees(1, 100, 1, 50, 1, 20, 0);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
-
+        Fees memory _fees = Fees(1, 100, 1, 50, 1, 20, 0);
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                address(this),
+                _fees,
+                admin,
+                admin,
+                admin
+            )
+        );
         // add custom fee entry for this token address
-        fees = Fees(3, 1000, 4, 1000, 2, 1000, uint64(block.timestamp + 100));
-        _feeSettings.setCustomFee(someTokenAddress, fees);
+        _fees = Fees(3, 1000, 4, 1000, 2, 1000, uint64(block.timestamp + 100));
+        _feeSettings.setCustomFee(someTokenAddress, _fees);
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(1000, someTokenAddress), 3, "Token fee should be 3");
@@ -760,17 +831,10 @@ contract FeeSettingsTest is Test {
 
     function testOnlyManagerCanRemoveCustomFees(address _rando) public {
         address someTokenAddress = address(74);
-        vm.assume(_rando != address(0));
-        vm.assume(_rando != admin);
-
-        Fees memory fees = Fees(1, 100, 1, 50, 1, 20, 0);
-
-        vm.prank(admin);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
-
+        vm.assume(feeSettings.managers(_rando) == false);
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        _feeSettings.removeCustomFee(someTokenAddress);
+        feeSettings.removeCustomFee(someTokenAddress);
     }
 
     function testOwnerCanAddManager(address _manager) public {
@@ -819,8 +883,18 @@ contract FeeSettingsTest is Test {
     }
 
     function testFeeCalculationFunctionsAreEqual() public {
-        Fees memory fees = Fees(1, 100, 1, 50, 1, 20, 0);
-        FeeSettings _feeSettings = new FeeSettings(fees, admin, admin, admin);
+        Fees memory _fees = Fees(1, 100, 1, 50, 1, 20, 0);
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                address(this),
+                _fees,
+                admin,
+                admin,
+                admin
+            )
+        );
 
         FakeToken fakeToken = new FakeToken(address(_feeSettings));
         FakeCrowdinvesting fakeCrowdinvesting = new FakeCrowdinvesting(address(fakeToken));

--- a/test/IFeeSettings.t.sol
+++ b/test/IFeeSettings.t.sol
@@ -27,7 +27,7 @@ contract IFeeSettingsTest is Test {
         // see https://medium.com/@chiqing/ethereum-standard-erc165-explained-63b54ca0d273
         bytes4 expected = getFunctionSelector("crowdinvestingFee(uint256)");
         expected = expected ^ getFunctionSelector("crowdinvestingFeeCollector()");
-        expected = expected ^ getFunctionSelector("privateOfferFee(uint256)");
+        expected = expected ^ getFunctionSelector("privateOfferFee(uint256,address)");
         expected = expected ^ getFunctionSelector("privateOfferFeeCollector()");
         expected = expected ^ getFunctionSelector("tokenFee(uint256)");
         expected = expected ^ getFunctionSelector("tokenFeeCollector()");
@@ -35,8 +35,11 @@ contract IFeeSettingsTest is Test {
         expected = expected ^ getFunctionSelector("supportsInterface(bytes4)");
         bytes4 actual = type(IFeeSettingsV2).interfaceId;
 
+        console.logBytes4(expected);
+        console.logBytes4(actual);
+
         // hardcoding this here so this test throws when search and replace changes the interface
-        bytes4 fixedValue = 0x9fc80df3;
+        bytes4 fixedValue = 0xc8408cdb;
 
         assertEq(actual, fixedValue, "interface ID mismatch: did search and replace change the interface?");
 

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -154,17 +154,17 @@ contract MainnetCurrencies is Test {
         assertEq(token.balanceOf(receiver), 0, "receiver has no tokens");
         assertEq(
             _currency.balanceOf(receiver),
-            _currencyCost - _currencyCost / FeeSettings(address(token.feeSettings())).crowdinvestingFeeDenominator(),
+            _currencyCost - FeeSettings(address(token.feeSettings())).crowdinvestingFee(_currencyCost, address(token)),
             "receiver should have received currency"
         );
         assertEq(
             _currency.balanceOf(FeeSettings(address(token.feeSettings())).feeCollector()),
-            _currencyCost / FeeSettings(address(token.feeSettings())).crowdinvestingFeeDenominator(),
+            FeeSettings(address(token.feeSettings())).crowdinvestingFee(_currencyCost, address(token)),
             "fee receiver should have received currency"
         );
         assertEq(
             token.balanceOf(FeeSettings(address(token.feeSettings())).feeCollector()),
-            amountOfTokenToBuy / FeeSettings(address(token.feeSettings())).crowdinvestingFeeDenominator(),
+            FeeSettings(address(token.feeSettings())).crowdinvestingFee(amountOfTokenToBuy, address(token)),
             "fee receiver should have received tokens"
         );
         assertEq(_currency.balanceOf(buyer), _currencyAmount - _currencyCost, "buyer should have paid currency");
@@ -231,17 +231,17 @@ contract MainnetCurrencies is Test {
         assertEq(token.balanceOf(receiver), 0, "receiver has no tokens");
         assertEq(
             _currency.balanceOf(receiver),
-            currencyCost - token.feeSettings().crowdinvestingFee(currencyCost),
+            currencyCost - FeeSettings(address(token.feeSettings())).crowdinvestingFee(currencyCost, address(token)),
             "receiver should have received currency"
         );
         assertEq(
             _currency.balanceOf(token.feeSettings().crowdinvestingFeeCollector()),
-            token.feeSettings().crowdinvestingFee(currencyCost),
+            FeeSettings(address(token.feeSettings())).crowdinvestingFee(currencyCost, address(token)),
             "fee receiver should have received currency"
         );
         assertEq(
             token.balanceOf(FeeSettings(address(token.feeSettings())).feeCollector()),
-            FeeSettings(address(token.feeSettings())).tokenFee(amountOfTokenToBuy),
+            FeeSettings(address(token.feeSettings())).tokenFee(amountOfTokenToBuy, address(token)),
             "fee receiver should have received tokens"
         );
         assertEq(_currency.balanceOf(buyer), currencyAmount - currencyCost, "buyer should have paid currency");

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -8,7 +8,7 @@ import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "../contracts/PrivateOffer.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
-import "../contracts/FeeSettings.sol";
+import "./resources/FeeSettingsCreator.sol";
 import "./resources/ERC20Helper.sol";
 
 /**
@@ -62,7 +62,7 @@ contract MainnetCurrencies is Test {
     function setUp() public {
         list = new AllowList();
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        feeSettings = new FeeSettings(fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, address(this), fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -149,13 +149,13 @@ contract PrivateOfferTest is Test {
 
         assertEq(
             currency.balanceOf(currencyReceiver),
-            currencyAmount - FeeSettings(address(token.feeSettings())).privateOfferFee(currencyAmount)
+            currencyAmount - FeeSettings(address(token.feeSettings())).privateOfferFee(currencyAmount, address(token))
         );
 
         assertEq(
             currency.balanceOf(FeeSettings(address(token.feeSettings())).privateOfferFeeCollector()),
             feeCollectorCurrencyBalanceBefore +
-                FeeSettings(address(token.feeSettings())).privateOfferFee(currencyAmount),
+                FeeSettings(address(token.feeSettings())).privateOfferFee(currencyAmount, address(token)),
             "feeCollector currency balance is not correct"
         );
 
@@ -410,12 +410,12 @@ contract PrivateOfferTest is Test {
 
         assertEq(
             currency.balanceOf(currencyReceiver),
-            currencyAmount - token.feeSettings().privateOfferFee(currencyAmount)
+            currencyAmount - token.feeSettings().privateOfferFee(currencyAmount, address(token))
         );
 
         assertEq(
             currency.balanceOf(token.feeSettings().privateOfferFeeCollector()),
-            token.feeSettings().privateOfferFee(currencyAmount),
+            token.feeSettings().privateOfferFee(currencyAmount, address(token)),
             "feeCollector currency balance is not correct"
         );
 

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -5,7 +5,7 @@ import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/PrivateOffer.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
-import "../contracts/FeeSettings.sol";
+import "./resources/FeeSettingsCreator.sol";
 import "./resources/FakePaymentToken.sol";
 
 contract PrivateOfferTest is Test {
@@ -51,7 +51,14 @@ contract PrivateOfferTest is Test {
         list.set(tokenReceiver, requirements);
 
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        feeSettings = new FeeSettings(fees, wrongFeeReceiver, wrongFeeReceiver, admin);
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            fees,
+            wrongFeeReceiver,
+            wrongFeeReceiver,
+            admin
+        );
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/PrivateOfferFactory.t.sol
+++ b/test/PrivateOfferFactory.t.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/utils/Address.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/PrivateOffer.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
-import "../contracts/FeeSettings.sol";
+import "./resources/FeeSettingsCreator.sol";
 import "./resources/ERC20MintableByAnyone.sol";
 
 contract PrivateOfferFactoryTest is Test {
@@ -44,7 +44,7 @@ contract PrivateOfferFactoryTest is Test {
         factory = new PrivateOfferFactory(vestingCloneFactory);
         list = new AllowList();
         Fees memory fees = Fees(0, 100, 0, 100, 0, 100, 0);
-        feeSettings = new FeeSettings(fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, address(this), fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/PrivateOfferTimeLock.t.sol
+++ b/test/PrivateOfferTimeLock.t.sol
@@ -168,13 +168,13 @@ contract PrivateOfferTimeLockTest is Test {
 
         assertEq(
             currency.balanceOf(currencyReceiver),
-            currencyAmount - token.feeSettings().privateOfferFee(currencyAmount),
+            currencyAmount - token.feeSettings().privateOfferFee(currencyAmount, address(token)),
             "currencyReceiver wrong balance after deployment"
         );
 
         assertEq(
             currency.balanceOf(token.feeSettings().privateOfferFeeCollector()),
-            token.feeSettings().privateOfferFee(currencyAmount),
+            token.feeSettings().privateOfferFee(currencyAmount, address(token)),
             "feeCollector currency balance is not correct"
         );
 

--- a/test/PrivateOfferTimeLock.t.sol
+++ b/test/PrivateOfferTimeLock.t.sol
@@ -5,7 +5,7 @@ import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/PrivateOffer.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
-import "../contracts/FeeSettings.sol";
+import "./resources/FeeSettingsCreator.sol";
 import "./resources/FakePaymentToken.sol";
 
 contract PrivateOfferTimeLockTest is Test {
@@ -40,7 +40,7 @@ contract PrivateOfferTimeLockTest is Test {
         list.set(tokenReceiver, requirements);
 
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        feeSettings = new FeeSettings(fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, address(this), fees, admin, admin, admin);
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/SetUpExampleCompany.t.sol
+++ b/test/SetUpExampleCompany.t.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.23;
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
-import "../contracts/FeeSettings.sol";
+import "./resources/FeeSettingsCreator.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/ERC2771Helper.sol";
@@ -109,8 +109,14 @@ contract CompanySetUpTest is Test {
             paymentTokenFeeDenominator,
             0
         );
-        vm.prank(platformAdmin);
-        feeSettings = new FeeSettings(fees, platformFeeCollector, platformFeeCollector, platformFeeCollector);
+        feeSettings = createFeeSettings(
+            address(8), // fake forwarder
+            platformAdmin,
+            fees,
+            platformFeeCollector,
+            platformFeeCollector,
+            platformFeeCollector
+        );
 
         // set up AllowList
         vm.prank(platformAdmin);

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.23;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
-import "../contracts/FeeSettings.sol";
+import "./resources/FeeSettingsCreator.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 contract tokenTest is Test {
@@ -32,7 +32,7 @@ contract tokenTest is Test {
         allowList = new AllowList();
         vm.prank(feeSettingsOwner);
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        feeSettings = new FeeSettings(fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, address(this), fees, admin, admin, admin);
         token = Token(
             tokenCloneFactory.createTokenProxy(
                 0,

--- a/test/TokenERC2612.t.sol
+++ b/test/TokenERC2612.t.sol
@@ -5,6 +5,7 @@ import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/FakePaymentToken.sol";
+import "./resources/FeeSettingsCreator.sol";
 import "@opengsn/contracts/src/forwarder/Forwarder.sol"; // chose specific version to avoid import error: yarn add @opengsn/contracts@2.2.5
 
 contract TokenERC2612Test is Test {
@@ -74,8 +75,14 @@ contract TokenERC2612Test is Test {
             privateOfferFeeDenominator,
             0
         );
-        vm.prank(platformAdmin);
-        feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            platformAdmin,
+            fees,
+            feeCollector,
+            feeCollector,
+            feeCollector
+        );
 
         // deploy forwarder
         Forwarder forwarder = new Forwarder();

--- a/test/TokenERC2771.t.sol
+++ b/test/TokenERC2771.t.sol
@@ -6,6 +6,7 @@ import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/ERC2771Helper.sol";
+import "./resources/FeeSettingsCreator.sol";
 import "@opengsn/contracts/src/forwarder/Forwarder.sol"; // chose specific version to avoid import error: yarn add @opengsn/contracts@2.2.5
 
 contract TokenERC2771Test is Test {
@@ -72,7 +73,14 @@ contract TokenERC2771Test is Test {
             0
         );
         vm.prank(platformAdmin);
-        feeSettings = new FeeSettings(fees, feeCollector, feeCollector, feeCollector);
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            fees,
+            feeCollector,
+            feeCollector,
+            feeCollector
+        );
 
         // deploy helper functions (only for testing with foundry)
         ERC2771helper = new ERC2771Helper();

--- a/test/TokenGasConsumption.t.sol
+++ b/test/TokenGasConsumption.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.23;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
-import "../contracts/FeeSettings.sol";
+import "./resources/FeeSettingsCreator.sol";
 
 contract tokenTest is Test {
     Token token;
@@ -28,7 +28,9 @@ contract tokenTest is Test {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        feeSettings = new FeeSettings(
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
             fees,
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner,

--- a/test/TokenProxyFactory.t.sol
+++ b/test/TokenProxyFactory.t.sol
@@ -5,6 +5,7 @@ import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/ERC2771Helper.sol";
+import "./resources/FeeSettingsCreator.sol";
 
 contract tokenProxyFactoryTest is Test {
     using ECDSA for bytes32;
@@ -30,7 +31,9 @@ contract tokenProxyFactoryTest is Test {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        feeSettings = new FeeSettings(
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            feeSettingsAndAllowListOwner,
             fees,
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner,
@@ -158,7 +161,9 @@ contract tokenProxyFactoryTest is Test {
         console.log("name: %s", name);
         console.log("symbol: %s", symbol);
 
-        FeeSettings _feeSettings = new FeeSettings(
+        FeeSettings _feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
             Fees(1, 100, 1, 100, 1, 100, 0),
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner,
@@ -223,7 +228,9 @@ contract tokenProxyFactoryTest is Test {
         vm.assume(rando != address(0));
         vm.assume(rando != _admin);
 
-        FeeSettings _feeSettings = new FeeSettings(
+        FeeSettings _feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
             Fees(1, 100, 1, 100, 1, 100, 0),
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner,
@@ -273,7 +280,9 @@ contract tokenProxyFactoryTest is Test {
         vm.assume(newPauser != address(0));
         vm.assume(newPauser != admin);
 
-        FeeSettings _feeSettings = new FeeSettings(
+        FeeSettings _feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
             Fees(1, 100, 1, 100, 1, 100, 0),
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner,

--- a/test/TokenProxyUpgrade.t.sol
+++ b/test/TokenProxyUpgrade.t.sol
@@ -5,6 +5,7 @@ import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/ERC2771Helper.sol";
+import "./resources/FeeSettingsCreator.sol";
 
 contract TokenV2 is Token {
     constructor(address _trustedForwarder) Token(_trustedForwarder) {}
@@ -42,7 +43,9 @@ contract tokenProxyUpgradeTest is Test {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
         Fees memory fees = Fees(1, 100, 1, 100, 1, 100, 0);
-        feeSettings = new FeeSettings(
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            feeSettingsAndAllowListOwner,
             fees,
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner,

--- a/test/TokenSnapshots.t.sol
+++ b/test/TokenSnapshots.t.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.23;
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/FeeSettings.sol";
+import "./resources/FeeSettingsCreator.sol";
+
 import "@openzeppelin/contracts/utils/Strings.sol";
 
 contract tokenTest is Test {
@@ -27,7 +29,9 @@ contract tokenTest is Test {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = new AllowList();
         Fees memory fees = Fees(0, 1, 0, 1, 0, 1, 0);
-        feeSettings = new FeeSettings(
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            feeSettingsAndAllowListOwner,
             fees,
             feeSettingsAndAllowListOwner,
             feeSettingsAndAllowListOwner,

--- a/test/VestingDemo.t.sol
+++ b/test/VestingDemo.t.sol
@@ -44,11 +44,10 @@ contract VestingDemoTest is Test {
         bool isMintable = true; // the tokens are minted on payout
 
         vm.startPrank(platformAdmin);
-        Fees memory fees = Fees(1, 100, 1, 200, 1, 200, 0);
         FeeSettings feeSettings = createFeeSettings(
             trustedForwarder,
             platformAdmin,
-            fees,
+            Fees(1, 100, 1, 200, 1, 200, 0),
             platformAdmin,
             platformAdmin,
             platformAdmin

--- a/test/VestingDemo.t.sol
+++ b/test/VestingDemo.t.sol
@@ -6,6 +6,7 @@ import "../contracts/factories/VestingCloneFactory.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/FeeSettings.sol";
 import "./resources/ERC20MintableByAnyone.sol";
+import "./resources/FeeSettingsCreator.sol";
 
 contract VestingDemoTest is Test {
     Vesting implementation;
@@ -43,8 +44,11 @@ contract VestingDemoTest is Test {
         bool isMintable = true; // the tokens are minted on payout
 
         vm.startPrank(platformAdmin);
-        FeeSettings feeSettings = new FeeSettings(
-            Fees(1, 100, 1, 200, 1, 200, 0),
+        Fees memory fees = Fees(1, 100, 1, 200, 1, 200, 0);
+        FeeSettings feeSettings = createFeeSettings(
+            trustedForwarder,
+            platformAdmin,
+            fees,
             platformAdmin,
             platformAdmin,
             platformAdmin

--- a/test/resources/FakeCrowdinvestingAndToken.sol
+++ b/test/resources/FakeCrowdinvestingAndToken.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.23;
+
+import "../../lib/forge-std/src/Test.sol";
+import "../../contracts/Token.sol";
+import "../../contracts/FeeSettings.sol";
+
+/*
+    fake crowdinvesting that allows polling fees
+*/
+contract FakeCrowdinvesting {
+    Token public token;
+
+    constructor(address _token) {
+        token = Token(_token);
+    }
+
+    function fee(uint256 amount) public view returns (uint256) {
+        IFeeSettingsV2 feeSettings = token.feeSettings();
+        return feeSettings.crowdinvestingFee(amount);
+    }
+}
+
+/**
+ * fake token that allows polling fees
+ */
+contract FakeToken {
+    IFeeSettingsV2 public feeSettings;
+
+    constructor(address _feeSettings) {
+        feeSettings = FeeSettings(_feeSettings);
+    }
+
+    function fee(uint256 amount) public view returns (uint256) {
+        return feeSettings.tokenFee(amount);
+    }
+}

--- a/test/resources/FakeCrowdinvestingAndToken.sol
+++ b/test/resources/FakeCrowdinvestingAndToken.sol
@@ -19,6 +19,11 @@ contract FakeCrowdinvesting {
         IFeeSettingsV2 feeSettings = token.feeSettings();
         return feeSettings.crowdinvestingFee(amount);
     }
+
+    function feeV1(uint256 amount) public view returns (uint256) {
+        IFeeSettingsV1 feeSettings = IFeeSettingsV1(address(token.feeSettings()));
+        return feeSettings.continuousFundraisingFee(amount);
+    }
 }
 
 /**

--- a/test/resources/FeeSettingsCreator.sol
+++ b/test/resources/FeeSettingsCreator.sol
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.23;
+
+import "../../lib/forge-std/src/Test.sol";
+import "../../contracts/factories/FeeSettingsCloneFactory.sol";
+
+function createFeeSettings(
+    address _trustedForwarder,
+    address _owner,
+    Fees memory _fees,
+    address _tokenFeeCollector,
+    address _crowdinvestingFeeCollector,
+    address _privateOfferFeeCollector
+) returns (FeeSettings) {
+    FeeSettings logicContract = new FeeSettings(_trustedForwarder);
+    FeeSettingsCloneFactory factory = new FeeSettingsCloneFactory(address(logicContract));
+    FeeSettings clone = FeeSettings(
+        factory.createFeeSettingsClone(
+            "someSalt",
+            _trustedForwarder,
+            _owner,
+            _fees,
+            _tokenFeeCollector,
+            _crowdinvestingFeeCollector,
+            _privateOfferFeeCollector
+        )
+    );
+
+    return clone;
+}

--- a/test/resources/WrongFeeSettings.sol
+++ b/test/resources/WrongFeeSettings.sol
@@ -8,10 +8,7 @@ import "../../contracts/FeeSettings.sol";
     fake currency to test the main contract with
 */
 contract FeeSettingsFailERC165Check0 is FeeSettings {
-    constructor(
-        Fees memory _fees,
-        address _feeCollector
-    ) FeeSettings(_fees, _feeCollector, _feeCollector, _feeCollector) {}
+    constructor(Fees memory _fees, address _feeCollector) FeeSettings(address(0)) {}
 
     function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
         if (interfaceId == 0x01ffc9a7) {
@@ -23,10 +20,7 @@ contract FeeSettingsFailERC165Check0 is FeeSettings {
 }
 
 contract FeeSettingsFailERC165Check1 is FeeSettings {
-    constructor(
-        Fees memory _fees,
-        address _feeCollector
-    ) FeeSettings(_fees, _feeCollector, _feeCollector, _feeCollector) {}
+    constructor(Fees memory _fees, address _feeCollector) FeeSettings(address(0)) {}
 
     function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
         if (interfaceId == 0x01ffc9a7) {
@@ -39,10 +33,7 @@ contract FeeSettingsFailERC165Check1 is FeeSettings {
 }
 
 contract FeeSettingsFailIFeeSettingsV2Check is FeeSettings {
-    constructor(
-        Fees memory _fees,
-        address _feeCollector
-    ) FeeSettings(_fees, _feeCollector, _feeCollector, _feeCollector) {}
+    constructor(Fees memory _fees, address _feeCollector) FeeSettings(address(0)) {}
 
     function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
         if (interfaceId == 0x01ffc9a7) {


### PR DESCRIPTION
Background: see #269 

This PR implements the changes and fixes existing unit tests, without adding new ones yet.

Several ugly, unintended side effects occurred:
1. Querying the fee a certain token would have to pay might yield wrong results, because `tokenFee()` assumes `_msgSender() == tokenAddress`.
2. Querying the fee a Crowdinvesting would have to pay reverts, because `crowdinvestingFee()` tries to access `(msg.sender).token()`, which is not possible for EOAs and most contracts

Both works when used with Token and Crowdinvesting, but not when querying with an EOA or something. This is a side effect of the interface being really unclean: the callbacks just assume the callers interface and identity.

Therefore, I suggest changing the fee calculation calls to work similar to the `privateOfferFee(amount, tokenAddress)`:
`tokenFee(amount)` should be `tokenFee(amount, tokenAddress)`
`crowdfundingFee(amount)` should be `crowdfundingFee(amount, tokenAddress)`

This of course requires further changes. But to implement the current approach properly, an interface for Crowdfunding would have to be implemented anyway.