### PR TITLE
start implementing custom fee collectors

### DIFF
--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -540,12 +540,13 @@ contract FeeSettings is
     }
 
     /**
-     * @notice Returns the token fee collector
+     * @notice Returns the default token fee collector
      * @dev this is a compatibility function for IFeeSettingsV1. It enables older token contracts to use the new fee settings contract.
+     * @dev as IFeeSettingsV1 only supports a single fee collector, we can not inquire the token address. Therefore, we return the default fee collector.
      * @return The token fee collector
      */
     function feeCollector() external view override(IFeeSettingsV1) returns (address) {
-        return tokenFeeCollector(_msgSender());
+        return tokenFeeCollectorAddress;
     }
 
     /**

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -490,23 +490,14 @@ contract FeeSettings is
     }
 
     /**
-     * @notice Calculates the fee for a given currency amount in PrivateOffer.sol
-     * @param _currencyAmount The amount of currency to calculate the fee for
-     * @return The fee
-     */
-    function privateOfferFee(
-        uint256 _currencyAmount,
-        address _token
-    ) external view override(IFeeSettingsV2) returns (uint256) {
-        return _privateOfferFee(_currencyAmount, _token);
-    }
-
-    /**
      * Calculates the fee for a given currency amount in PrivateOffer (v5) or PersonalInvite (v4)
      * @param _currencyAmount how much currency is raised
      * @return the fee
      */
-    function _privateOfferFee(uint256 _currencyAmount, address _token) internal view returns (uint256) {
+    function privateOfferFee(
+        uint256 _currencyAmount,
+        address _token
+    ) public view override(IFeeSettingsV2) returns (uint256) {
         uint256 baseFee = _fee(_currencyAmount, privateOfferFeeNumerator, privateOfferFeeDenominator);
         if (customFees[_token].validityDate > block.timestamp) {
             uint256 customFee = _fee(
@@ -574,7 +565,7 @@ contract FeeSettings is
      * @param _currencyAmount The amount of currency to calculate the fee for
      */
     function personalInviteFee(uint256 _currencyAmount) external view override(IFeeSettingsV1) returns (uint256) {
-        return _privateOfferFee(_currencyAmount, address(0));
+        return privateOfferFee(_currencyAmount, address(0));
     }
 
     /**

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -314,15 +314,10 @@ contract FeeSettings is
         return crowdinvestingFeeCollector(ICrowdinvestingLike(_msgSender()).token());
     }
 
-    function privateOfferFeeCollector(address _token) public view returns (address) {
+    function privateOfferFeeCollector(address _token) public view override(IFeeSettingsV2) returns (address) {
         if (customPrivateOfferFeeCollector[_token] != address(0)) {
             return customPrivateOfferFeeCollector[_token];
         }
-        return privateOfferFeeCollectorAddress;
-    }
-
-    /// fallback for old private offers
-    function privateOfferFeeCollector() external view override(IFeeSettingsV2) returns (address) {
         return privateOfferFeeCollectorAddress;
     }
 

--- a/contracts/PrivateOffer.sol
+++ b/contracts/PrivateOffer.sol
@@ -86,7 +86,11 @@ contract PrivateOffer {
         IFeeSettingsV2 feeSettings = _arguments.token.feeSettings();
         uint256 fee = feeSettings.privateOfferFee(currencyAmount, address(_arguments.token));
         if (fee != 0) {
-            _arguments.currency.safeTransferFrom(_arguments.currencyPayer, feeSettings.privateOfferFeeCollector(), fee);
+            _arguments.currency.safeTransferFrom(
+                _arguments.currencyPayer,
+                feeSettings.privateOfferFeeCollector(address(_arguments.token)),
+                fee
+            );
         }
         _arguments.currency.safeTransferFrom(
             _arguments.currencyPayer,

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -41,7 +41,7 @@ interface IFeeSettingsV2 {
 
     function privateOfferFee(uint256, address) external view returns (uint256);
 
-    function privateOfferFeeCollector() external view returns (address);
+    function privateOfferFeeCollector(address) external view returns (address);
 
     function owner() external view returns (address);
 

--- a/test/Crowdinvesting.t.sol
+++ b/test/Crowdinvesting.t.sol
@@ -356,12 +356,14 @@ contract CrowdinvestingTest is Test {
             "receiver has payment tokens"
         );
         assertTrue(
-            paymentToken.balanceOf(token.feeSettings().crowdinvestingFeeCollector()) ==
-                fakeCrowdinvesting.fee(costInPaymentToken),
+            paymentToken.balanceOf(
+                FeeSettings(address(token.feeSettings())).crowdinvestingFeeCollector(address(token))
+            ) == fakeCrowdinvesting.fee(costInPaymentToken),
             "fee collector has collected fee in payment tokens"
         );
         assertTrue(
-            token.balanceOf(token.feeSettings().tokenFeeCollector()) == localFeeSettings.tokenFee(tokenBuyAmount),
+            token.balanceOf(FeeSettings(address(token.feeSettings())).tokenFeeCollector(address(token))) ==
+                localFeeSettings.tokenFee(tokenBuyAmount),
             "fee collector has collected fee in tokens"
         );
         assertTrue(crowdinvesting.tokensSold() == tokenBuyAmount, "crowdinvesting has sold tokens");
@@ -572,12 +574,14 @@ contract CrowdinvestingTest is Test {
             "receiver received payment tokens"
         );
         assertEq(
-            token.balanceOf(token.feeSettings().tokenFeeCollector()),
+            token.balanceOf(FeeSettings(address(token.feeSettings())).tokenFeeCollector(address(token))),
             tokenFee,
             "fee collector has not collected fee in tokens"
         );
         assertEq(
-            paymentToken.balanceOf(token.feeSettings().crowdinvestingFeeCollector()),
+            paymentToken.balanceOf(
+                FeeSettings(address(token.feeSettings())).crowdinvestingFeeCollector(address(token))
+            ),
             paymentTokenFee,
             "fee collector has not collected fee in payment tokens"
         );

--- a/test/CrowdinvestingERC677.t.sol
+++ b/test/CrowdinvestingERC677.t.sol
@@ -236,13 +236,15 @@ contract CrowdinvestingTest is Test {
             "receiver has payment tokens"
         );
         assertTrue(
-            paymentToken.balanceOf(token.feeSettings().crowdinvestingFeeCollector()) ==
-                fakeCrowdinvesting.fee(costInPaymentToken),
+            paymentToken.balanceOf(
+                FeeSettings(address(token.feeSettings())).crowdinvestingFeeCollector(address(token))
+            ) == fakeCrowdinvesting.fee(costInPaymentToken),
             "fee collector has collected fee in payment tokens"
         );
 
         assertTrue(
-            token.balanceOf(token.feeSettings().tokenFeeCollector()) >= localFeeSettings.tokenFee(tokenBuyAmount),
+            token.balanceOf(FeeSettings(address(token.feeSettings())).tokenFeeCollector(address(token))) >=
+                localFeeSettings.tokenFee(tokenBuyAmount),
             "fee collector has collected fee in tokens"
         );
 

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -404,9 +404,9 @@ contract FeeSettingsTest is Test {
         vm.prank(admin);
         feeSettings.setFeeCollectors(newTokenFeeCollector, newCrowdinvestingFeeCollector, newPrivateOfferFeeCollector);
         assertEq(feeSettings.feeCollector(), newTokenFeeCollector); // IFeeSettingsV1
-        assertEq(feeSettings.tokenFeeCollector(), newTokenFeeCollector);
-        assertEq(feeSettings.crowdinvestingFeeCollector(), newCrowdinvestingFeeCollector);
-        assertEq(feeSettings.privateOfferFeeCollector(), newPrivateOfferFeeCollector);
+        assertEq(feeSettings.tokenFeeCollector(address(4)), newTokenFeeCollector);
+        assertEq(feeSettings.crowdinvestingFeeCollector(address(4)), newCrowdinvestingFeeCollector);
+        assertEq(feeSettings.privateOfferFeeCollector(address(4)), newPrivateOfferFeeCollector);
     }
 
     function tokenOrPrivateOfferFeeInValidRange(uint32 numerator, uint32 denominator) internal pure returns (bool) {

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -41,6 +41,8 @@ contract FeeSettingsTest is Test {
 
     uint256 public constant price = 10000000;
 
+    address public constant exampleTokenAddress = address(74);
+
     function setUp() public {
         FeeSettings logic = new FeeSettings(trustedForwarder);
         feeSettingsCloneFactory = new FeeSettingsCloneFactory(address(logic));
@@ -907,5 +909,279 @@ contract FeeSettingsTest is Test {
             "Crowdinvesting fee mismatch"
         );
         assertEq(_feeSettings.privateOfferFee(amount, address(fakeToken)), amount / 20, "Private offer fee mismatch");
+    }
+
+    function testAddingCustomTokenFeeCollector(address _feeCollector) public {
+        vm.assume(_feeCollector != address(0));
+        vm.assume(_feeCollector != admin);
+
+        assertEq(
+            feeSettings.customTokenFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+
+        assertEq(
+            feeSettings.tokenFeeCollector(exampleTokenAddress),
+            feeSettings.feeCollector(),
+            "Fee collector mismatch between V1 and V2"
+        );
+        assertEq(
+            feeSettings.tokenFeeCollector(exampleTokenAddress),
+            feeSettings.tokenFeeCollector(),
+            "Fee collector wrong without custom fee collector"
+        );
+        assertEq(feeSettings.tokenFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
+
+        vm.prank(admin);
+        feeSettings.setCustomTokenFeeCollector(exampleTokenAddress, _feeCollector);
+
+        assertEq(feeSettings.customTokenFeeCollector(exampleTokenAddress), _feeCollector, "Custom fee collector wrong");
+        assertEq(
+            feeSettings.tokenFeeCollector(exampleTokenAddress),
+            _feeCollector,
+            "Fee collector wrong with custom fee collector"
+        );
+        assertEq(admin, feeSettings.feeCollector(), "V1 fee collector should still be default value");
+    }
+
+    function testRemovingCustomTokenFeeCollector(address _feeCollector) public {
+        vm.assume(_feeCollector != address(0));
+        vm.assume(_feeCollector != admin);
+
+        vm.prank(admin);
+        feeSettings.setCustomTokenFeeCollector(exampleTokenAddress, _feeCollector);
+
+        assertEq(
+            feeSettings.tokenFeeCollector(exampleTokenAddress),
+            _feeCollector,
+            "Fee collector wrong with custom fee collector"
+        );
+
+        vm.prank(admin);
+        feeSettings.removeCustomTokenFeeCollector(exampleTokenAddress);
+
+        assertEq(
+            feeSettings.customTokenFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+
+        assertEq(
+            feeSettings.tokenFeeCollector(exampleTokenAddress),
+            feeSettings.feeCollector(),
+            "Fee collector mismatch between V1 and V2"
+        );
+        assertEq(
+            feeSettings.tokenFeeCollector(exampleTokenAddress),
+            feeSettings.tokenFeeCollector(),
+            "Fee collector wrong without custom fee collector"
+        );
+        assertEq(feeSettings.tokenFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
+    }
+
+    function testAddingCustomCrowdinvestingFeeCollector(address _feeCollector) public {
+        vm.assume(_feeCollector != address(0));
+        vm.assume(_feeCollector != admin);
+
+        assertEq(
+            feeSettings.customCrowdinvestingFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+
+        assertEq(feeSettings.crowdinvestingFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
+
+        vm.prank(admin);
+        feeSettings.setCustomCrowdinvestingFeeCollector(exampleTokenAddress, _feeCollector);
+
+        assertEq(
+            feeSettings.customCrowdinvestingFeeCollector(exampleTokenAddress),
+            _feeCollector,
+            "Custom fee collector wrong"
+        );
+        assertEq(
+            feeSettings.crowdinvestingFeeCollector(exampleTokenAddress),
+            _feeCollector,
+            "Fee collector wrong with custom fee collector"
+        );
+    }
+
+    function testRemovingCustomCrowdinvestingFeeCollector(address _feeCollector) public {
+        vm.assume(_feeCollector != address(0));
+        vm.assume(_feeCollector != admin);
+
+        vm.prank(admin);
+        feeSettings.setCustomCrowdinvestingFeeCollector(exampleTokenAddress, _feeCollector);
+
+        assertEq(
+            feeSettings.crowdinvestingFeeCollector(exampleTokenAddress),
+            _feeCollector,
+            "Fee collector wrong with custom fee collector"
+        );
+
+        vm.prank(admin);
+        feeSettings.removeCustomCrowdinvestingFeeCollector(exampleTokenAddress);
+
+        assertEq(
+            feeSettings.customCrowdinvestingFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+
+        assertEq(feeSettings.crowdinvestingFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
+    }
+
+    function testAddingCustomPrivateOfferFeeCollector(address _feeCollector) public {
+        vm.assume(_feeCollector != address(0));
+        vm.assume(_feeCollector != admin);
+
+        assertEq(
+            feeSettings.customPrivateOfferFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+
+        assertEq(feeSettings.privateOfferFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
+
+        vm.prank(admin);
+        feeSettings.setCustomPrivateOfferFeeCollector(exampleTokenAddress, _feeCollector);
+
+        assertEq(
+            feeSettings.customPrivateOfferFeeCollector(exampleTokenAddress),
+            _feeCollector,
+            "Custom fee collector wrong"
+        );
+        assertEq(
+            feeSettings.privateOfferFeeCollector(exampleTokenAddress),
+            _feeCollector,
+            "Fee collector wrong with custom fee collector"
+        );
+    }
+
+    function testRemovingCustomPrivateOfferFeeCollector(address _feeCollector) public {
+        vm.assume(_feeCollector != address(0));
+        vm.assume(_feeCollector != admin);
+
+        vm.prank(admin);
+        feeSettings.setCustomPrivateOfferFeeCollector(exampleTokenAddress, _feeCollector);
+
+        assertEq(
+            feeSettings.privateOfferFeeCollector(exampleTokenAddress),
+            _feeCollector,
+            "Fee collector wrong with custom fee collector"
+        );
+
+        vm.prank(admin);
+        feeSettings.removeCustomPrivateOfferFeeCollector(exampleTokenAddress);
+
+        assertEq(
+            feeSettings.customPrivateOfferFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+
+        assertEq(feeSettings.privateOfferFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
+    }
+
+    function testManagerCanSetAndRemoveCustomFeeCollector(address _manager, address _customFeeCollector) public {
+        vm.assume(_manager != address(0));
+        vm.assume(_manager != admin);
+        vm.assume(_customFeeCollector != address(0));
+        vm.assume(_customFeeCollector != admin);
+
+        vm.prank(admin);
+        feeSettings.addManager(_manager);
+
+        assertEq(
+            feeSettings.customTokenFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+        assertEq(
+            feeSettings.customCrowdinvestingFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+        assertEq(
+            feeSettings.customPrivateOfferFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+
+        vm.startPrank(_manager);
+        feeSettings.setCustomTokenFeeCollector(exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomCrowdinvestingFeeCollector(exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomPrivateOfferFeeCollector(exampleTokenAddress, _customFeeCollector);
+        vm.stopPrank();
+
+        assertEq(
+            feeSettings.customTokenFeeCollector(exampleTokenAddress),
+            _customFeeCollector,
+            "Custom fee collector wrong"
+        );
+        assertEq(
+            feeSettings.customCrowdinvestingFeeCollector(exampleTokenAddress),
+            _customFeeCollector,
+            "Custom fee collector wrong"
+        );
+        assertEq(
+            feeSettings.customPrivateOfferFeeCollector(exampleTokenAddress),
+            _customFeeCollector,
+            "Custom fee collector wrong"
+        );
+
+        vm.startPrank(_manager);
+        feeSettings.removeCustomTokenFeeCollector(exampleTokenAddress);
+        feeSettings.removeCustomCrowdinvestingFeeCollector(exampleTokenAddress);
+        feeSettings.removeCustomPrivateOfferFeeCollector(exampleTokenAddress);
+        vm.stopPrank();
+
+        assertEq(
+            feeSettings.customTokenFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+        assertEq(
+            feeSettings.customCrowdinvestingFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+        assertEq(
+            feeSettings.customPrivateOfferFeeCollector(exampleTokenAddress),
+            address(0),
+            "Should not be custom fee collector yet"
+        );
+    }
+
+    function testRandoCanNotSetOrRemoveCustomFeeCollectors(address _rando, address _customFeeCollector) public {
+        vm.assume(_rando != address(0));
+        vm.assume(_rando != admin);
+        vm.assume(_customFeeCollector != address(0));
+        vm.assume(_customFeeCollector != admin);
+
+        vm.expectRevert("Only managers can call this function");
+        vm.prank(_rando);
+        feeSettings.setCustomTokenFeeCollector(exampleTokenAddress, _customFeeCollector);
+
+        vm.expectRevert("Only managers can call this function");
+        vm.prank(_rando);
+        feeSettings.setCustomCrowdinvestingFeeCollector(exampleTokenAddress, _customFeeCollector);
+
+        vm.expectRevert("Only managers can call this function");
+        vm.prank(_rando);
+        feeSettings.setCustomPrivateOfferFeeCollector(exampleTokenAddress, _customFeeCollector);
+
+        vm.expectRevert("Only managers can call this function");
+        vm.prank(_rando);
+        feeSettings.removeCustomTokenFeeCollector(exampleTokenAddress);
+
+        vm.expectRevert("Only managers can call this function");
+        vm.prank(_rando);
+        feeSettings.removeCustomCrowdinvestingFeeCollector(exampleTokenAddress);
+
+        vm.expectRevert("Only managers can call this function");
+        vm.prank(_rando);
+        feeSettings.removeCustomPrivateOfferFeeCollector(exampleTokenAddress);
     }
 }

--- a/test/FeeSettingsIntegration.t.sol
+++ b/test/FeeSettingsIntegration.t.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.23;
+
+import "../lib/forge-std/src/Test.sol";
+import "../contracts/Token.sol";
+import "../contracts/factories/FeeSettingsCloneFactory.sol";
+import "../contracts/factories/CrowdinvestingCloneFactory.sol";
+import "../contracts/factories/TokenProxyFactory.sol";
+import "../contracts/factories/PrivateOfferFactory.sol";
+
+contract FeeSettingsIntegrationTest is Test {
+    FeeSettings feeSettings;
+    Fees customFees;
+    Token token;
+    Token currency;
+
+    uint256 MAX_INT = type(uint256).max;
+
+    address public constant platformAdmin = 0x0109709eCFa91a80626FF3989D68f67f5b1dD120;
+    address public constant investor = 0x1109709ecFA91a80626ff3989D68f67F5B1Dd121;
+    address public constant companyAdmin = 0x2109709EcFa91a80626Ff3989d68F67F5B1Dd122;
+    address public constant minter = 0x3109709ECfA91A80626fF3989D68f67F5B1Dd123;
+    address public constant owner = 0x6109709EcFA91A80626FF3989d68f67F5b1dd126;
+    address public constant receiver = 0x7109709eCfa91A80626Ff3989D68f67f5b1dD127;
+    address public constant paymentTokenProvider = 0x8109709ecfa91a80626fF3989d68f67F5B1dD128;
+    address public constant trustedForwarder = 0x9109709EcFA91A80626FF3989D68f67F5B1dD129;
+
+    uint256 public constant price = 10000000;
+
+    address public constant exampleTokenAddress = address(74);
+
+    function setUp() public {
+        FeeSettings feeSettingsLogic = new FeeSettings(trustedForwarder);
+        FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(address(feeSettingsLogic));
+        customFees = Fees(2, 1000, 3, 1000, 5, 1000, 101 * 365 days);
+        Fees memory fees = Fees(1, 101, 2, 102, 3, 103, 0);
+        vm.prank(platformAdmin);
+        feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                platformAdmin,
+                fees,
+                platformAdmin,
+                platformAdmin,
+                platformAdmin
+            )
+        );
+
+        AllowList allowList = new AllowList();
+
+        Token tokenLogic = new Token(trustedForwarder);
+        TokenProxyFactory tokenProxyFactory = new TokenProxyFactory(address(tokenLogic));
+        token = Token(
+            tokenProxyFactory.createTokenProxy(
+                "salt",
+                trustedForwarder,
+                feeSettings,
+                companyAdmin,
+                allowList,
+                0,
+                "Test Token",
+                "TST"
+            )
+        );
+
+        Crowdinvesting crowdinvestingLogic = new Crowdinvesting(trustedForwarder);
+        CrowdinvestingCloneFactory crowdinvestingCloneFactory = new CrowdinvestingCloneFactory(
+            address(crowdinvestingLogic)
+        );
+    }
+
+    function testMintUsesCustomFeeAndCollector(address customFeeCollector) public {
+        vm.assume(customFeeCollector != address(0));
+        vm.assume(customFeeCollector != platformAdmin);
+
+        vm.warp(100 * 365 days);
+
+        assertEq(token.balanceOf(investor), 0, "token.balanceOf(investor) != 0 before");
+        assertEq(token.balanceOf(customFeeCollector), 0, "token.balanceOf(customFeeCollector) != 0 before");
+
+        vm.startPrank(platformAdmin);
+        feeSettings.setCustomFee(address(token), customFees);
+        feeSettings.setCustomTokenFeeCollector(address(token), customFeeCollector);
+        vm.stopPrank();
+        uint256 amount = 1000e18;
+        vm.prank(companyAdmin);
+        token.mint(investor, amount);
+
+        assertEq(token.balanceOf(investor), amount, "token.balanceOf(investor) != 100e18 after");
+        assertEq(
+            token.balanceOf(customFeeCollector),
+            (amount * 2) / 1000,
+            "token.balanceOf(customFeeCollector) != 3e18 after"
+        );
+    }
+}

--- a/test/FeeSettingsIntegration.t.sol
+++ b/test/FeeSettingsIntegration.t.sol
@@ -7,25 +7,31 @@ import "../contracts/factories/FeeSettingsCloneFactory.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
+import "./resources/FakePaymentToken.sol";
 
 contract FeeSettingsIntegrationTest is Test {
     FeeSettings feeSettings;
     Fees customFees;
     Token token;
-    Token currency;
+    FakePaymentToken currency;
+    PrivateOfferFactory privateOfferFactory;
+    CrowdinvestingCloneFactory crowdinvestingCloneFactory;
 
     uint256 MAX_INT = type(uint256).max;
 
     address public constant platformAdmin = 0x0109709eCFa91a80626FF3989D68f67f5b1dD120;
     address public constant investor = 0x1109709ecFA91a80626ff3989D68f67F5B1Dd121;
     address public constant companyAdmin = 0x2109709EcFa91a80626Ff3989d68F67F5B1Dd122;
-    address public constant minter = 0x3109709ECfA91A80626fF3989D68f67F5B1Dd123;
+    address public constant paymentTokenAdmin = 0x3109709ECfA91A80626fF3989D68f67F5B1Dd123;
     address public constant owner = 0x6109709EcFA91A80626FF3989d68f67F5b1dd126;
     address public constant receiver = 0x7109709eCfa91A80626Ff3989D68f67f5b1dD127;
     address public constant paymentTokenProvider = 0x8109709ecfa91a80626fF3989d68f67F5B1dD128;
     address public constant trustedForwarder = 0x9109709EcFA91A80626FF3989D68f67F5B1dD129;
 
-    uint256 public constant price = 10000000;
+    uint256 public constant price = 3e18;
+
+    uint256 public constant tokenAmount = 1000e18;
+    uint256 public constant currencyAmount = 3000e18;
 
     address public constant exampleTokenAddress = address(74);
 
@@ -65,33 +71,176 @@ contract FeeSettingsIntegrationTest is Test {
         );
 
         Crowdinvesting crowdinvestingLogic = new Crowdinvesting(trustedForwarder);
-        CrowdinvestingCloneFactory crowdinvestingCloneFactory = new CrowdinvestingCloneFactory(
-            address(crowdinvestingLogic)
-        );
+        crowdinvestingCloneFactory = new CrowdinvestingCloneFactory(address(crowdinvestingLogic));
+
+        // using a fake vesting clone factory here because we don't need this functionality for this test
+        privateOfferFactory = new PrivateOfferFactory(VestingCloneFactory(address(294)));
+
+        vm.startPrank(paymentTokenProvider);
+        currency = new FakePaymentToken(currencyAmount, 18);
+        currency.transfer(investor, currencyAmount);
+        vm.stopPrank();
     }
 
-    function testMintUsesCustomFeeAndCollector(address customFeeCollector) public {
-        vm.assume(customFeeCollector != address(0));
-        vm.assume(customFeeCollector != platformAdmin);
+    function testMintUsesCustomFeeAndCollector(address _customFeeCollector) public {
+        vm.assume(_customFeeCollector != address(0));
+        vm.assume(_customFeeCollector != platformAdmin);
 
         vm.warp(100 * 365 days);
 
         assertEq(token.balanceOf(investor), 0, "token.balanceOf(investor) != 0 before");
-        assertEq(token.balanceOf(customFeeCollector), 0, "token.balanceOf(customFeeCollector) != 0 before");
+        assertEq(token.balanceOf(_customFeeCollector), 0, "token.balanceOf(customFeeCollector) != 0 before");
 
         vm.startPrank(platformAdmin);
         feeSettings.setCustomFee(address(token), customFees);
-        feeSettings.setCustomTokenFeeCollector(address(token), customFeeCollector);
+        feeSettings.setCustomTokenFeeCollector(address(token), _customFeeCollector);
         vm.stopPrank();
-        uint256 amount = 1000e18;
         vm.prank(companyAdmin);
-        token.mint(investor, amount);
+        token.mint(investor, tokenAmount);
 
-        assertEq(token.balanceOf(investor), amount, "token.balanceOf(investor) != 100e18 after");
+        assertEq(token.balanceOf(investor), tokenAmount, "token.balanceOf(investor) != 100e18 after");
         assertEq(
-            token.balanceOf(customFeeCollector),
-            (amount * 2) / 1000,
+            token.balanceOf(_customFeeCollector),
+            (tokenAmount * 2) / 1000,
             "token.balanceOf(customFeeCollector) != 3e18 after"
+        );
+    }
+
+    function testPrivateOfferUsesCustomFeeAndCollector(address _customFeeCollector) public {
+        vm.assume(_customFeeCollector != address(0));
+        vm.assume(_customFeeCollector != platformAdmin);
+
+        vm.warp(100 * 365 days);
+
+        vm.startPrank(platformAdmin);
+        feeSettings.setCustomFee(address(token), customFees);
+        feeSettings.setCustomPrivateOfferFeeCollector(address(token), _customFeeCollector);
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(investor), 0, "token.balanceOf(investor) != 0 before");
+        assertEq(currency.balanceOf(_customFeeCollector), 0, "currency.balanceOf(customFeeCollector) != 0 before");
+
+        // get private offer address
+        address expectedPrivateOfferAddress = privateOfferFactory.predictPrivateOfferAddress(
+            "salt",
+            PrivateOfferArguments(
+                investor,
+                investor,
+                companyAdmin,
+                tokenAmount,
+                price,
+                block.timestamp + 1000,
+                currency,
+                token
+            )
+        );
+
+        // grant allowances
+        vm.prank(companyAdmin);
+        token.increaseMintingAllowance(expectedPrivateOfferAddress, tokenAmount);
+
+        vm.prank(investor);
+        currency.increaseAllowance(expectedPrivateOfferAddress, currencyAmount);
+
+        // create private offer
+        privateOfferFactory.deployPrivateOffer(
+            "salt",
+            PrivateOfferArguments(
+                investor,
+                investor,
+                companyAdmin,
+                tokenAmount,
+                price,
+                block.timestamp + 1000,
+                currency,
+                token
+            )
+        );
+
+        // check balances
+        console.log("token.balanceOf(investor)", token.balanceOf(investor));
+        assertEq(token.balanceOf(investor), tokenAmount, "token.balanceOf(investor) != 1000e18 after");
+        console.log("token.balanceOf(platformAdmin)", token.balanceOf(platformAdmin));
+        // hint: token fees are paid to platform admin because we do not set a custom token fee receiver
+        assertEq(
+            token.balanceOf(platformAdmin),
+            (tokenAmount * 2) / 1000,
+            "token.balanceOf(customFeeCollector) != 2e18 after"
+        );
+
+        console.log("currency.balanceOf(investor)", currency.balanceOf(investor));
+        assertEq(currency.balanceOf(investor), 0, "currency.balanceOf(investor) != 0 after");
+        console.log("currency.balanceOf(_customFeeCollector)", currency.balanceOf(_customFeeCollector));
+        assertEq(
+            currency.balanceOf(_customFeeCollector),
+            (currencyAmount * 5) / 1000,
+            "currency.balanceOf(customFeeCollector) wrong after"
+        );
+    }
+
+    function testCrowdinvestingUsesCustomFeeAndCollector(address _customFeeCollector) public {
+        vm.assume(_customFeeCollector != address(0));
+        vm.assume(_customFeeCollector != platformAdmin);
+
+        vm.warp(100 * 365 days);
+
+        vm.startPrank(platformAdmin);
+        feeSettings.setCustomFee(address(token), customFees);
+        feeSettings.setCustomCrowdinvestingFeeCollector(address(token), _customFeeCollector);
+        vm.stopPrank();
+
+        assertEq(token.balanceOf(investor), 0, "token.balanceOf(investor) != 0 before");
+        assertEq(currency.balanceOf(_customFeeCollector), 0, "token.balanceOf(customFeeCollector) != 0 before");
+
+        // set up crowdinvesting
+        CrowdinvestingInitializerArguments memory arguments = CrowdinvestingInitializerArguments(
+            companyAdmin,
+            companyAdmin,
+            0,
+            type(uint256).max,
+            price,
+            price,
+            price,
+            type(uint256).max,
+            IERC20(address(currency)),
+            token,
+            101 * 365 days,
+            address(0)
+        );
+
+        Crowdinvesting crowdinvesting = Crowdinvesting(
+            crowdinvestingCloneFactory.createCrowdinvestingClone("salt", trustedForwarder, arguments)
+        );
+
+        // grant allowances
+        vm.prank(companyAdmin);
+        token.increaseMintingAllowance(address(crowdinvesting), tokenAmount);
+
+        vm.prank(investor);
+        currency.increaseAllowance(address(crowdinvesting), currencyAmount);
+
+        // buy
+        vm.prank(investor);
+        crowdinvesting.buy(tokenAmount, investor);
+
+        // check balances
+        console.log("token.balanceOf(investor)", token.balanceOf(investor));
+        assertEq(token.balanceOf(investor), tokenAmount, "token.balanceOf(investor) != 1000e18 after");
+        console.log("token.balanceOf(platformAdmin)", token.balanceOf(platformAdmin));
+        // hint: token fees are paid to platform admin because we do not set a custom token fee receiver
+        assertEq(
+            token.balanceOf(platformAdmin),
+            (tokenAmount * 2) / 1000,
+            "token.balanceOf(customFeeCollector) != 2e18 after"
+        );
+
+        console.log("currency.balanceOf(investor)", currency.balanceOf(investor));
+        assertEq(currency.balanceOf(investor), 0, "currency.balanceOf(investor) != 0 after");
+        console.log("currency.balanceOf(_customFeeCollector)", currency.balanceOf(_customFeeCollector));
+        assertEq(
+            currency.balanceOf(_customFeeCollector),
+            (currencyAmount * 3) / 1000,
+            "currency.balanceOf(customFeeCollector) wrong after"
         );
     }
 }

--- a/test/IFeeSettings.t.sol
+++ b/test/IFeeSettings.t.sol
@@ -28,7 +28,7 @@ contract IFeeSettingsTest is Test {
         bytes4 expected = getFunctionSelector("crowdinvestingFee(uint256)");
         expected = expected ^ getFunctionSelector("crowdinvestingFeeCollector()");
         expected = expected ^ getFunctionSelector("privateOfferFee(uint256,address)");
-        expected = expected ^ getFunctionSelector("privateOfferFeeCollector()");
+        expected = expected ^ getFunctionSelector("privateOfferFeeCollector(address)");
         expected = expected ^ getFunctionSelector("tokenFee(uint256)");
         expected = expected ^ getFunctionSelector("tokenFeeCollector()");
         expected = expected ^ getFunctionSelector("owner()");
@@ -39,7 +39,7 @@ contract IFeeSettingsTest is Test {
         console.logBytes4(actual);
 
         // hardcoding this here so this test throws when search and replace changes the interface
-        bytes4 fixedValue = 0xc8408cdb;
+        bytes4 fixedValue = 0x38921194;
 
         assertEq(actual, fixedValue, "interface ID mismatch: did search and replace change the interface?");
 

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -235,7 +235,7 @@ contract MainnetCurrencies is Test {
             "receiver should have received currency"
         );
         assertEq(
-            _currency.balanceOf(token.feeSettings().crowdinvestingFeeCollector()),
+            _currency.balanceOf(FeeSettings(address(token.feeSettings())).crowdinvestingFeeCollector(address(token))),
             FeeSettings(address(token.feeSettings())).crowdinvestingFee(currencyCost, address(token)),
             "fee receiver should have received currency"
         );

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -118,7 +118,7 @@ contract PrivateOfferTest is Test {
         assertEq(currency.balanceOf(currencyReceiver), 0);
         assertEq(token.balanceOf(tokenReceiver), 0);
         assertEq(
-            currency.balanceOf(FeeSettings(address(token.feeSettings())).privateOfferFeeCollector()),
+            currency.balanceOf(FeeSettings(address(token.feeSettings())).privateOfferFeeCollector(address(token))),
             0,
             "privateOfferFeeCollector currency balance is not correct"
         );
@@ -160,7 +160,7 @@ contract PrivateOfferTest is Test {
         );
 
         assertEq(
-            currency.balanceOf(FeeSettings(address(token.feeSettings())).privateOfferFeeCollector()),
+            currency.balanceOf(FeeSettings(address(token.feeSettings())).privateOfferFeeCollector(address(token))),
             feeCollectorCurrencyBalanceBefore +
                 FeeSettings(address(token.feeSettings())).privateOfferFee(currencyAmount, address(token)),
             "feeCollector currency balance is not correct"
@@ -391,7 +391,7 @@ contract PrivateOfferTest is Test {
         assertEq(currency.balanceOf(tokenReceiver), 0);
         assertEq(token.balanceOf(tokenReceiver), 0);
         assertEq(
-            currency.balanceOf(token.feeSettings().privateOfferFeeCollector()),
+            currency.balanceOf(token.feeSettings().privateOfferFeeCollector(address(token))),
             0,
             "privateOfferFeeCollector currency balance is not correct"
         );
@@ -421,7 +421,7 @@ contract PrivateOfferTest is Test {
         );
 
         assertEq(
-            currency.balanceOf(token.feeSettings().privateOfferFeeCollector()),
+            currency.balanceOf(token.feeSettings().privateOfferFeeCollector(address(token))),
             token.feeSettings().privateOfferFee(currencyAmount, address(token)),
             "feeCollector currency balance is not correct"
         );

--- a/test/PrivateOfferTimeLock.t.sol
+++ b/test/PrivateOfferTimeLock.t.sol
@@ -137,7 +137,7 @@ contract PrivateOfferTimeLockTest is Test {
 
         console.log(
             "feeCollector currency balance before deployment: %s",
-            currency.balanceOf(token.feeSettings().privateOfferFeeCollector())
+            currency.balanceOf(token.feeSettings().privateOfferFeeCollector(address(token)))
         );
         // measure and log gas
         uint256 gasBefore = gasleft();
@@ -173,7 +173,7 @@ contract PrivateOfferTimeLockTest is Test {
         );
 
         assertEq(
-            currency.balanceOf(token.feeSettings().privateOfferFeeCollector()),
+            currency.balanceOf(token.feeSettings().privateOfferFeeCollector(address(token))),
             token.feeSettings().privateOfferFee(currencyAmount, address(token)),
             "feeCollector currency balance is not correct"
         );
@@ -185,7 +185,7 @@ contract PrivateOfferTimeLockTest is Test {
         );
 
         assertEq(
-            token.balanceOf(token.feeSettings().privateOfferFeeCollector()),
+            token.balanceOf(token.feeSettings().privateOfferFeeCollector(address(token))),
             token.feeSettings().tokenFee(arguments.tokenAmount),
             "feeCollector token balance is not correct"
         );


### PR DESCRIPTION
Changes:
- rename variables in order to reuse the old getter functions' names
- write getters so they check for a custom collector
- add mappings
- set and delete custom collectors

Todo:

- [x]  end date for custom collector? If so, store all 3 addresses in struct with validityDate? -> not needed
- [x]  update PrivateOffer to call `privateOfferFeeCollector(tokenAddress)`
- [x]  implement only one setter instead of 3? -> nope
- [x]  TESTS! -> see https://github.com/corpus-io/tokenize.it-smart-contracts/issues/273