### PR TITLE
Feature/explicitly provide token address

### DIFF
--- a/contracts/Crowdinvesting.sol
+++ b/contracts/Crowdinvesting.sol
@@ -266,7 +266,10 @@ contract Crowdinvesting is
 
     function _getFeeAndFeeReceiver(uint256 _currencyAmount) internal view returns (uint256, address) {
         IFeeSettingsV2 feeSettings = token.feeSettings();
-        return (feeSettings.crowdinvestingFee(_currencyAmount), feeSettings.crowdinvestingFeeCollector());
+        return (
+            feeSettings.crowdinvestingFee(_currencyAmount, address(token)),
+            feeSettings.crowdinvestingFeeCollector(address(token))
+        );
     }
 
     /**

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -8,13 +8,6 @@ import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol
 import "./interfaces/IFeeSettings.sol";
 
 /**
- * interface a crowdinvesting contract provides to retrieve the token address
- */
-interface ICrowdinvestingLike {
-    function token() external view returns (address);
-}
-
-/**
  * @title FeeSettings
  * @author malteish, cjentzsch
  * @notice The FeeSettings contract is used to manage fees paid to the tokenize.it platfom

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -281,10 +281,10 @@ contract Token is
         _checkIfAllowedToTransact(_to);
         _mint(_to, _amount);
         // collect fees
-        uint256 fee = feeSettings.tokenFee(_amount);
+        uint256 fee = feeSettings.tokenFee(_amount, address(this));
         if (fee != 0) {
             // the fee collector is always allowed to receive tokens
-            _mint(feeSettings.tokenFeeCollector(), fee);
+            _mint(feeSettings.tokenFeeCollector(address(this)), fee);
         }
     }
 

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -31,13 +31,13 @@ interface IFeeSettingsV1 {
  * From v4 to v5, the contract names have changed and instead of one fee collector, there are now three.
  */
 interface IFeeSettingsV2 {
-    function tokenFee(uint256) external view returns (uint256);
+    function tokenFee(uint256, address) external view returns (uint256);
 
-    function tokenFeeCollector() external view returns (address);
+    function tokenFeeCollector(address) external view returns (address);
 
-    function crowdinvestingFee(uint256) external view returns (uint256);
+    function crowdinvestingFee(uint256, address) external view returns (uint256);
 
-    function crowdinvestingFeeCollector() external view returns (address);
+    function crowdinvestingFeeCollector(address) external view returns (address);
 
     function privateOfferFee(uint256, address) external view returns (uint256);
 

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -539,7 +539,11 @@ contract FeeSettingsTest is Test {
             feeSettings.personalInviteFee(_amount),
             "Private offer fee mismatch"
         );
-        assertEq(feeSettings.feeCollector(), feeSettings.tokenFeeCollector(), "Fee collector mismatch");
+        assertEq(
+            feeSettings.feeCollector(),
+            feeSettings.tokenFeeCollector(address(_fakeToken)),
+            "Fee collector mismatch"
+        );
     }
 
     function testIFeeSettingsV2IsAvailable() public {
@@ -928,11 +932,6 @@ contract FeeSettingsTest is Test {
             feeSettings.feeCollector(),
             "Fee collector mismatch between V1 and V2"
         );
-        assertEq(
-            feeSettings.tokenFeeCollector(exampleTokenAddress),
-            feeSettings.tokenFeeCollector(),
-            "Fee collector wrong without custom fee collector"
-        );
         assertEq(feeSettings.tokenFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
 
         vm.prank(admin);
@@ -973,11 +972,6 @@ contract FeeSettingsTest is Test {
             feeSettings.tokenFeeCollector(exampleTokenAddress),
             feeSettings.feeCollector(),
             "Fee collector mismatch between V1 and V2"
-        );
-        assertEq(
-            feeSettings.tokenFeeCollector(exampleTokenAddress),
-            feeSettings.tokenFeeCollector(),
-            "Fee collector wrong without custom fee collector"
         );
         assertEq(feeSettings.tokenFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
     }

--- a/test/IFeeSettings.t.sol
+++ b/test/IFeeSettings.t.sol
@@ -25,12 +25,12 @@ contract IFeeSettingsTest is Test {
 
     function testManuallyVerifyInterfaceIDV2() public {
         // see https://medium.com/@chiqing/ethereum-standard-erc165-explained-63b54ca0d273
-        bytes4 expected = getFunctionSelector("crowdinvestingFee(uint256)");
-        expected = expected ^ getFunctionSelector("crowdinvestingFeeCollector()");
+        bytes4 expected = getFunctionSelector("crowdinvestingFee(uint256,address)");
+        expected = expected ^ getFunctionSelector("crowdinvestingFeeCollector(address)");
         expected = expected ^ getFunctionSelector("privateOfferFee(uint256,address)");
         expected = expected ^ getFunctionSelector("privateOfferFeeCollector(address)");
-        expected = expected ^ getFunctionSelector("tokenFee(uint256)");
-        expected = expected ^ getFunctionSelector("tokenFeeCollector()");
+        expected = expected ^ getFunctionSelector("tokenFee(uint256,address)");
+        expected = expected ^ getFunctionSelector("tokenFeeCollector(address)");
         expected = expected ^ getFunctionSelector("owner()");
         expected = expected ^ getFunctionSelector("supportsInterface(bytes4)");
         bytes4 actual = type(IFeeSettingsV2).interfaceId;
@@ -39,7 +39,7 @@ contract IFeeSettingsTest is Test {
         console.logBytes4(actual);
 
         // hardcoding this here so this test throws when search and replace changes the interface
-        bytes4 fixedValue = 0x38921194;
+        bytes4 fixedValue = 0x302be8a8;
 
         assertEq(actual, fixedValue, "interface ID mismatch: did search and replace change the interface?");
 

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -123,7 +123,7 @@ contract PrivateOfferTest is Test {
             "privateOfferFeeCollector currency balance is not correct"
         );
         assertEq(
-            token.balanceOf(FeeSettings(address(token.feeSettings())).tokenFeeCollector()),
+            token.balanceOf(FeeSettings(address(token.feeSettings())).tokenFeeCollector(address(token))),
             0,
             "tokenFeeCollector currency balance is not correct"
         );
@@ -169,8 +169,8 @@ contract PrivateOfferTest is Test {
         assertEq(token.balanceOf(tokenReceiver), amount);
 
         assertEq(
-            token.balanceOf(FeeSettings(address(token.feeSettings())).tokenFeeCollector()),
-            FeeSettings(address(token.feeSettings())).tokenFee(amount)
+            token.balanceOf(FeeSettings(address(token.feeSettings())).tokenFeeCollector(address(token))),
+            FeeSettings(address(token.feeSettings())).tokenFee(amount, address(token))
         );
     }
 
@@ -396,7 +396,7 @@ contract PrivateOfferTest is Test {
             "privateOfferFeeCollector currency balance is not correct"
         );
         assertEq(
-            token.balanceOf(token.feeSettings().tokenFeeCollector()),
+            token.balanceOf(token.feeSettings().tokenFeeCollector(address(token))),
             0,
             "tokenFeeCollector token balance is not correct"
         );
@@ -428,6 +428,9 @@ contract PrivateOfferTest is Test {
 
         assertEq(token.balanceOf(tokenReceiver), tokenAmount);
 
-        assertEq(token.balanceOf(token.feeSettings().tokenFeeCollector()), token.feeSettings().tokenFee(tokenAmount));
+        assertEq(
+            token.balanceOf(token.feeSettings().tokenFeeCollector(address(token))),
+            token.feeSettings().tokenFee(tokenAmount, address(token))
+        );
     }
 }

--- a/test/PrivateOfferTimeLock.t.sol
+++ b/test/PrivateOfferTimeLock.t.sol
@@ -186,7 +186,7 @@ contract PrivateOfferTimeLockTest is Test {
 
         assertEq(
             token.balanceOf(token.feeSettings().privateOfferFeeCollector(address(token))),
-            token.feeSettings().tokenFee(arguments.tokenAmount),
+            token.feeSettings().tokenFee(arguments.tokenAmount, address(token)),
             "feeCollector token balance is not correct"
         );
 

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -286,7 +286,7 @@ contract tokenTest is Test {
         );
         assertEq(
             feeCollectorBalanceAfterMint - feeCollectorBalanceBeforeMint,
-            token.feeSettings().tokenFee(_amount),
+            token.feeSettings().tokenFee(_amount, address(token)),
             "fee collector has received wrong token amount"
         );
     }

--- a/test/resources/FakeCrowdinvestingAndToken.sol
+++ b/test/resources/FakeCrowdinvestingAndToken.sol
@@ -17,7 +17,7 @@ contract FakeCrowdinvesting {
 
     function fee(uint256 amount) public view returns (uint256) {
         IFeeSettingsV2 feeSettings = token.feeSettings();
-        return feeSettings.crowdinvestingFee(amount);
+        return feeSettings.crowdinvestingFee(amount, address(token));
     }
 
     function feeV1(uint256 amount) public view returns (uint256) {
@@ -37,6 +37,6 @@ contract FakeToken {
     }
 
     function fee(uint256 amount) public view returns (uint256) {
-        return feeSettings.tokenFee(amount);
+        return feeSettings.tokenFee(amount, address(this));
     }
 }


### PR DESCRIPTION
We did some interface hacking to integrate custom fees and collectors without touching `Token` and `Crowdinvesting`. This reduced code quality. I do not like that and fixed it by changing the 2 lines each in `Token` and `Crowdinvesting`. The result is a much cleaner interface and less code overall, but especially in `FeeSettings`.