### PR TITLE
Feature/add safety boundaries

### DIFF
--- a/contracts/Crowdinvesting.sol
+++ b/contracts/Crowdinvesting.sol
@@ -274,12 +274,19 @@ contract Crowdinvesting is
 
     /**
      * @notice Buy `amount` tokens and mint them to `_tokenReceiver`.
-     * @param _amount amount of tokens to buy, in bits (smallest subunit of token)
+     * @param _tokenAmount amount of tokens to buy, in bits (smallest subunit of token)
+     * @param _maxCurrencyAmount maximum amount of currency to spend, in bits (smallest subunit of currency)
      * @param _tokenReceiver address the tokens should be minted to
      */
-    function buy(uint256 _amount, address _tokenReceiver) public whenNotPaused nonReentrant {
+    function buy(
+        uint256 _tokenAmount,
+        uint256 _maxCurrencyAmount,
+        address _tokenReceiver
+    ) public whenNotPaused nonReentrant {
         // rounding up to the next whole number. Investor is charged up to one currency bit more in case of a fractional currency bit.
-        uint256 currencyAmount = Math.ceilDiv(_amount * getPrice(), 10 ** token.decimals());
+        uint256 currencyAmount = Math.ceilDiv(_tokenAmount * getPrice(), 10 ** token.decimals());
+
+        require(currencyAmount <= _maxCurrencyAmount, "Purchase more expensive than _maxCurrencyAmount");
 
         IERC20 _currency = currency;
 
@@ -289,9 +296,9 @@ contract Crowdinvesting is
         }
 
         _currency.safeTransferFrom(_msgSender(), currencyReceiver, currencyAmount - fee);
-        _checkAndDeliver(_amount, _tokenReceiver);
+        _checkAndDeliver(_tokenAmount, _tokenReceiver);
 
-        emit TokensBought(_msgSender(), _amount, currencyAmount);
+        emit TokensBought(_msgSender(), _tokenAmount, currencyAmount);
     }
 
     /**

--- a/contracts/Crowdinvesting.sol
+++ b/contracts/Crowdinvesting.sol
@@ -328,7 +328,7 @@ contract Crowdinvesting is
         }
         uint256 amount = (_currencyAmount * 10 ** token.decimals()) / getPrice();
 
-        // if a minimum amount was provided in data, use it as minimum.
+        // if a minimum amount was provided in data, enforce it.
         if (_data.length >= 64) {
             require(amount >= abi.decode(_data[32:64], (uint256)), "Purchase yields less tokens than demanded.");
         }

--- a/docs/price.md
+++ b/docs/price.md
@@ -53,7 +53,7 @@ The error introduced by rounding is less than or equal to one currency bit. For 
   ```
   The unit is omitted, so the price will be 2\*10^8
 - investor wants to buy 150 tokens
-- they call Crowdinvesting.buy(150 \* 10\*\*18)
+- they call Crowdinvesting.buy(150 \* 10\*\*18, 150 \* 200 \* 10\*\*6, tokenReceiver)
 - so \_amount is 150 \* 10\*\*18
 - 150 \* 10^18 \* 2 \* 10^8 = 300 \* 10^26 = 3 \* 10^28
 - calculate amount due in USDC bits: 3 \* 10^28/10^18 = 3 \* 10^10

--- a/docs/using_the_contracts.md
+++ b/docs/using_the_contracts.md
@@ -127,7 +127,7 @@ factory.createCrowdinvestingClone(
 
 The contract needs to be given a minting allowance in the company token contract by calling `increaseMintingAllowance` from an address which has the role of the MintAllower. The allowance should be set to `_maxAmountOfTokenToBeSold` tokens.
 
-An investor can buy tokens by calling the `buy(uint _amount)` function.
+An investor can buy tokens by calling the `buy(uint256 _tokenAmount, uint256 _maxCurrencyAmount,address _tokenReceiver)` function.
 `_amount` ist the amount of tokens they are buying, in [bits](https://docs.openzeppelin.com/contracts/2.x/crowdsales#crowdsale-rate).
 
 The investor needs to give a sufficient allowance in the currency contract to the Crowdinvesting contract for the deal to be successful.

--- a/test/Crowdinvesting.t.sol
+++ b/test/Crowdinvesting.t.sol
@@ -331,7 +331,7 @@ contract CrowdinvestingTest is Test {
         uint256 buyAmount = _maxMintAmount / 100000;
         vm.prank(buyer);
         vm.expectRevert("ReentrancyGuard: reentrant call");
-        _crowdinvesting.buy(buyAmount, buyer);
+        _crowdinvesting.buy(buyAmount, type(uint256).max, buyer);
     }
 
     function testBuyHappyCase(uint256 tokenBuyAmount) public {
@@ -348,7 +348,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(buyer);
         vm.expectEmit(true, true, true, true, address(crowdinvesting));
         emit TokensBought(buyer, tokenBuyAmount, costInPaymentToken);
-        crowdinvesting.buy(tokenBuyAmount, buyer);
+        crowdinvesting.buy(tokenBuyAmount, type(uint256).max, buyer);
         assertTrue(paymentToken.balanceOf(buyer) == paymentTokenBalanceBefore - costInPaymentToken, "buyer has paid");
         assertTrue(token.balanceOf(buyer) == tokenBuyAmount, "buyer has tokens");
         assertTrue(
@@ -375,7 +375,7 @@ contract CrowdinvestingTest is Test {
 
         vm.prank(buyer);
         vm.expectRevert("Total amount of bought tokens needs to be lower than or equal to maxAmount");
-        crowdinvesting.buy(maxAmountPerBuyer + 10 ** 18, buyer); //+ 10**token.decimals());
+        crowdinvesting.buy(maxAmountPerBuyer + 10 ** 18, type(uint256).max, buyer); //+ 10**token.decimals());
         assertTrue(paymentToken.balanceOf(buyer) == paymentTokenBalanceBefore);
         assertTrue(token.balanceOf(buyer) == 0);
         assertTrue(paymentToken.balanceOf(receiver) == 0);
@@ -403,7 +403,7 @@ contract CrowdinvestingTest is Test {
 
         // execute buy, with addressForTokens as recipient
         vm.prank(addressWithFunds);
-        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, addressForTokens);
+        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, type(uint256).max, addressForTokens);
 
         // check state after
         console.log("addressWithFunds balance: ", paymentToken.balanceOf(addressWithFunds));
@@ -438,12 +438,12 @@ contract CrowdinvestingTest is Test {
         paymentToken.approve(address(crowdinvesting), paymentTokenAmount);
 
         vm.prank(buyer);
-        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, buyer);
+        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, type(uint256).max, buyer);
         vm.prank(person1);
-        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, person1);
+        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, type(uint256).max, person1);
         vm.prank(person2);
         vm.expectRevert("Not enough tokens to sell left");
-        crowdinvesting.buy(10 ** 18, person2);
+        crowdinvesting.buy(10 ** 18, type(uint256).max, person2);
     }
 
     function testMultipleAddressesBuyForOneReceiver() public {
@@ -464,10 +464,10 @@ contract CrowdinvestingTest is Test {
         paymentToken.approve(address(crowdinvesting), paymentTokenAmount);
 
         vm.prank(buyer);
-        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, buyer);
+        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, type(uint256).max, buyer);
         vm.prank(person1);
         vm.expectRevert("Total amount of bought tokens needs to be lower than or equal to maxAmount");
-        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, buyer);
+        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, type(uint256).max, buyer);
     }
 
     function testCorrectAccounting() public {
@@ -494,11 +494,11 @@ contract CrowdinvestingTest is Test {
         assertTrue(crowdinvesting.tokensBought(person2) == 0);
 
         vm.prank(buyer);
-        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, buyer);
+        crowdinvesting.buy(maxAmountOfTokenToBeSold / 2, type(uint256).max, buyer);
         vm.prank(buyer);
-        crowdinvesting.buy(maxAmountOfTokenToBeSold / 4, person1);
+        crowdinvesting.buy(maxAmountOfTokenToBeSold / 4, type(uint256).max, person1);
         vm.prank(buyer);
-        crowdinvesting.buy(maxAmountOfTokenToBeSold / 8, person2);
+        crowdinvesting.buy(maxAmountOfTokenToBeSold / 8, type(uint256).max, person2);
 
         // check all entries are correct after
         assertTrue(crowdinvesting.tokensSold() == (maxAmountOfTokenToBeSold * 7) / 8);
@@ -521,7 +521,7 @@ contract CrowdinvestingTest is Test {
 
         vm.prank(buyer);
         vm.expectRevert("MintingAllowance too low");
-        crowdinvesting.buy(maxAmountPerBuyer, buyer); //+ 10**token.decimals());
+        crowdinvesting.buy(maxAmountPerBuyer, type(uint256).max, buyer); //+ 10**token.decimals());
         assertTrue(token.balanceOf(buyer) == 0);
         assertTrue(paymentToken.balanceOf(receiver) == 0);
         assertTrue(crowdinvesting.tokensSold() == 0);
@@ -538,7 +538,7 @@ contract CrowdinvestingTest is Test {
 
         vm.prank(buyer);
         vm.expectRevert("Buyer needs to buy at least minAmount");
-        crowdinvesting.buy(minAmountPerBuyer / 2, buyer);
+        crowdinvesting.buy(minAmountPerBuyer / 2, type(uint256).max, buyer);
         assertTrue(paymentToken.balanceOf(buyer) == paymentTokenBalanceBefore);
         assertTrue(token.balanceOf(buyer) == 0);
         assertTrue(paymentToken.balanceOf(receiver) == 0);
@@ -552,11 +552,11 @@ contract CrowdinvestingTest is Test {
         uint256 paymentTokenBalanceBefore = paymentToken.balanceOf(buyer);
 
         vm.prank(buyer);
-        crowdinvesting.buy(minAmountPerBuyer, buyer);
+        crowdinvesting.buy(minAmountPerBuyer, type(uint256).max, buyer);
 
         // buy less than minAmount -> should be okay because minAmount has already been bought.
         vm.prank(buyer);
-        crowdinvesting.buy(minAmountPerBuyer / 2, buyer);
+        crowdinvesting.buy(minAmountPerBuyer / 2, type(uint256).max, buyer);
 
         assertTrue(
             paymentToken.balanceOf(buyer) == paymentTokenBalanceBefore - (costInPaymentTokenForMinAmount * 3) / 2,
@@ -612,7 +612,7 @@ contract CrowdinvestingTest is Test {
         uint256 paymentTokenBalanceBefore = paymentToken.balanceOf(buyer);
 
         vm.prank(buyer);
-        crowdinvesting.buy(tokenBuyAmount, buyer);
+        crowdinvesting.buy(tokenBuyAmount, type(uint256).max, buyer);
 
         console.log("paymentTokenBalanceBefore", paymentTokenBalanceBefore);
         console.log("paymentToken.balanceOf(buyer)", paymentToken.balanceOf(buyer));
@@ -647,7 +647,7 @@ contract CrowdinvestingTest is Test {
     */
     function testFailOverflow() public {
         vm.prank(buyer);
-        crowdinvesting.buy(maxAmountPerBuyer + 1, buyer);
+        crowdinvesting.buy(maxAmountPerBuyer + 1, type(uint256).max, buyer);
     }
 
     /*
@@ -655,7 +655,7 @@ contract CrowdinvestingTest is Test {
     */
     function testFailUnderflow() public {
         vm.prank(buyer);
-        crowdinvesting.buy(minAmountPerBuyer - 1, buyer);
+        crowdinvesting.buy(minAmountPerBuyer - 1, type(uint256).max, buyer);
     }
 
     /*
@@ -665,7 +665,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(owner);
         crowdinvesting.pause();
         vm.prank(buyer);
-        crowdinvesting.buy(minAmountPerBuyer, buyer);
+        crowdinvesting.buy(minAmountPerBuyer, type(uint256).max, buyer);
     }
 
     /*
@@ -1180,7 +1180,7 @@ contract CrowdinvestingTest is Test {
 
         vm.expectRevert(); //("Arithmetic over/underflow"); //("Division or modulo by 0");
         vm.prank(buyer);
-        crowdinvesting.buy(_tokenBuyAmount, buyer);
+        crowdinvesting.buy(_tokenBuyAmount, type(uint256).max, buyer);
     }
 
     function testRoundsUp(uint256 _tokenBuyAmount, uint256 _price) public {
@@ -1232,7 +1232,7 @@ contract CrowdinvestingTest is Test {
         paymentToken.increaseAllowance(address(crowdinvesting), maxCurrencyAmount);
 
         vm.prank(buyer);
-        crowdinvesting.buy(_tokenBuyAmount, buyer);
+        crowdinvesting.buy(_tokenBuyAmount, type(uint256).max, buyer);
 
         // check that the buyer got the correct amount of tokens
         assertTrue(token.balanceOf(buyer) == _tokenBuyAmount, "buyer got wrong amount of tokens");
@@ -1286,12 +1286,12 @@ contract CrowdinvestingTest is Test {
         if (testDate > _lastBuyDate) {
             vm.expectRevert("Last buy date has passed: not selling tokens anymore.");
             vm.prank(buyer);
-            crowdinvesting.buy(tokenBuyAmount, buyer);
+            crowdinvesting.buy(tokenBuyAmount, type(uint256).max, buyer);
         } else {
             vm.prank(buyer);
             vm.expectEmit(true, true, true, true, address(crowdinvesting));
             emit TokensBought(buyer, tokenBuyAmount, costInPaymentToken);
-            crowdinvesting.buy(tokenBuyAmount, buyer);
+            crowdinvesting.buy(tokenBuyAmount, type(uint256).max, buyer);
         }
     }
 
@@ -1330,7 +1330,7 @@ contract CrowdinvestingTest is Test {
             vm.startPrank(buyer);
             paymentToken.approve(address(_crowdinvesting), type(uint256).max);
             vm.expectRevert("Last buy date has passed: not selling tokens anymore.");
-            _crowdinvesting.buy(tokenBuyAmount, buyer);
+            _crowdinvesting.buy(tokenBuyAmount, type(uint256).max, buyer);
             vm.stopPrank();
         } else {
             // auto-pause should not trigger
@@ -1341,7 +1341,7 @@ contract CrowdinvestingTest is Test {
             paymentToken.approve(address(_crowdinvesting), type(uint256).max);
             vm.expectEmit(true, true, true, true, address(_crowdinvesting));
             emit TokensBought(buyer, tokenBuyAmount, costInPaymentToken);
-            _crowdinvesting.buy(tokenBuyAmount, buyer);
+            _crowdinvesting.buy(tokenBuyAmount, type(uint256).max, buyer);
             vm.stopPrank();
         }
     }

--- a/test/Crowdinvesting.t.sol
+++ b/test/Crowdinvesting.t.sol
@@ -387,6 +387,10 @@ contract CrowdinvestingTest is Test {
             emit TokensBought(buyer, tokenBuyAmount, costInPaymentToken);
             crowdinvesting.buy(tokenBuyAmount, maxCurrencyAmount, buyer);
             assertTrue(
+                paymentTokenBalanceBefore - paymentToken.balanceOf(buyer) <= maxCurrencyAmount,
+                "buyer has paid too much!"
+            );
+            assertTrue(
                 paymentToken.balanceOf(buyer) == paymentTokenBalanceBefore - costInPaymentToken,
                 "buyer has paid"
             );

--- a/test/CrowdinvestingCloneFactory.t.sol
+++ b/test/CrowdinvestingCloneFactory.t.sol
@@ -412,7 +412,7 @@ contract tokenTest is Test {
         // can't buy when paused
         vm.prank(rando);
         vm.expectRevert("Pausable: paused");
-        crowdinvesting.buy(1, address(this));
+        crowdinvesting.buy(1, type(uint256).max, address(this));
 
         vm.warp(block.timestamp + 1 days + 1);
         vm.prank(_admin);

--- a/test/CrowdinvestingDynamicPricing.t.sol
+++ b/test/CrowdinvestingDynamicPricing.t.sol
@@ -209,7 +209,7 @@ contract CrowdinvestingTest is Test {
         assertEq(token.balanceOf(buyer), 0, "Buyer should have 0 tokens before");
         uint256 buyerPaymentTokenBalanceBefore = paymentToken.balanceOf(buyer);
         vm.prank(buyer);
-        crowdinvesting.buy(1e18, buyer);
+        crowdinvesting.buy(1e18, type(uint256).max, buyer);
         assertTrue(token.balanceOf(buyer) == 1e18, "Buyer should have 1 token");
         assertEq(
             paymentToken.balanceOf(buyer),

--- a/test/CrowdinvestingERC2771.t.sol
+++ b/test/CrowdinvestingERC2771.t.sol
@@ -25,17 +25,6 @@ contract CrowdinvestingTest is Test {
 
     CrowdinvestingInitializerArguments arguments;
 
-    // copied from openGSN IForwarder
-    struct ForwardRequest {
-        address from;
-        address to;
-        uint256 value;
-        uint256 gas;
-        uint256 nonce;
-        bytes data;
-        uint256 validUntil;
-    }
-
     address public constant trustedForwarder = 0x9109709EcFA91A80626FF3989D68f67F5B1dD129;
     address public constant admin = 0x0109709eCFa91a80626FF3989D68f67f5b1dD120;
     address public constant mintAllower = 0x2109709EcFa91a80626Ff3989d68F67F5B1Dd122;
@@ -153,7 +142,12 @@ contract CrowdinvestingTest is Test {
         // todo: get nonce from forwarder
 
         // build request
-        bytes memory payload = abi.encodeWithSelector(crowdinvesting.buy.selector, tokenBuyAmount, buyer);
+        bytes memory payload = abi.encodeWithSelector(
+            crowdinvesting.buy.selector,
+            tokenBuyAmount,
+            type(uint256).max,
+            buyer
+        );
 
         IForwarder.ForwardRequest memory request = IForwarder.ForwardRequest({
             from: buyer,

--- a/test/CrowdinvestingERC2771.t.sol
+++ b/test/CrowdinvestingERC2771.t.sol
@@ -184,7 +184,7 @@ contract CrowdinvestingTest is Test {
         require(digest.recover(signature) == request.from, "FWD: signature mismatch");
 
         // // encode buy call and sign it https://book.getfoundry.sh/cheatcodes/sign
-        // bytes memory buyCallData = abi.encodeWithSignature("buy(uint256)", tokenBuyAmount);
+        // bytes memory buyCallData = abi.encodeWithSignature("buy(uint256)", type(uint256).max, tokenBuyAmount);
 
         /*
             execute request and check results

--- a/test/CrowdinvestingERC677.t.sol
+++ b/test/CrowdinvestingERC677.t.sol
@@ -189,7 +189,7 @@ contract CrowdinvestingTest is Test {
         uint256 buyAmount = _maxMintAmount / 100000;
         vm.prank(buyer);
         vm.expectRevert("ReentrancyGuard: reentrant call");
-        _crowdinvesting.buy(buyAmount, buyer);
+        _crowdinvesting.buy(buyAmount, type(uint256).max, buyer);
     }
 
     function testERC677BuyHappyCase(uint256 tokenBuyAmount) public {
@@ -383,9 +383,9 @@ contract CrowdinvestingTest is Test {
         assertTrue(crowdinvesting.tokensBought(person1) == 0, "person1 has bought tokens");
 
         vm.prank(buyer);
-        crowdinvesting.buy(tokenAmount1, buyer);
+        crowdinvesting.buy(tokenAmount1, type(uint256).max, buyer);
         vm.prank(buyer);
-        crowdinvesting.buy(tokenAmount2, person1);
+        crowdinvesting.buy(tokenAmount2, type(uint256).max, person1);
 
         // check all entries are correct after
         assertTrue(

--- a/test/CrowdinvestingIntegration.t.sol
+++ b/test/CrowdinvestingIntegration.t.sol
@@ -206,7 +206,7 @@ contract CrowdinvestingTest is Test {
         assertTrue(paymentToken.balanceOf(investor) == _paymentTokenAmount);
         // they should be able to buy 33 CT for 999 FPT
         vm.prank(investor);
-        _crowdinvesting.buy(tokenAmount, investor);
+        _crowdinvesting.buy(tokenAmount, type(uint256).max, investor);
         // buyer should have 10 FPT left
         assertTrue(paymentToken.balanceOf(investor) == 10 * 10 ** _paymentTokenDecimals);
         // buyer should have the 33 CT they bought
@@ -325,7 +325,7 @@ contract CrowdinvestingTest is Test {
             assertTrue(paymentToken.balanceOf(investor) == _paymentTokenAmount);
             // they should be able to buy 33 CT for 999 FPT
             vm.prank(investor);
-            _crowdinvesting.buy(tokenAmount, investor);
+            _crowdinvesting.buy(tokenAmount, type(uint256).max, investor);
             // buyer should have 10 FPT left
             assertTrue(paymentToken.balanceOf(investor) == 10 * 10 ** _paymentTokenDecimals);
             // buyer should have the 33 CT they bought

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -267,7 +267,7 @@ contract TokenERC2771Test is Test {
         require(digest.recover(signature) == request.from, "FWD: signature mismatch");
 
         // // encode buy call and sign it https://book.getfoundry.sh/cheatcodes/sign
-        // bytes memory buyCallData = abi.encodeWithSignature("buy(uint256)", tokenBuyAmount);
+        // bytes memory buyCallData = abi.encodeWithSignature("buy(uint256)", type(uint256).max, tokenBuyAmount);
 
         /*
             execute request and check results

--- a/test/FeeSettingsIntegration.t.sol
+++ b/test/FeeSettingsIntegration.t.sol
@@ -222,7 +222,7 @@ contract FeeSettingsIntegrationTest is Test {
 
         // buy
         vm.prank(investor);
-        crowdinvesting.buy(tokenAmount, investor);
+        crowdinvesting.buy(tokenAmount, type(uint256).max, investor);
 
         // check balances
         console.log("token.balanceOf(investor)", token.balanceOf(investor));

--- a/test/FeeSettingsIntegration.t.sol
+++ b/test/FeeSettingsIntegration.t.sol
@@ -86,6 +86,7 @@ contract FeeSettingsIntegrationTest is Test {
     function testMintUsesCustomFeeAndCollector(address _customFeeCollector) public {
         vm.assume(_customFeeCollector != address(0));
         vm.assume(_customFeeCollector != platformAdmin);
+        vm.assume(_customFeeCollector != investor);
 
         vm.warp(100 * 365 days);
 

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -147,7 +147,7 @@ contract MainnetCurrencies is Test {
 
         // buy tokens
         vm.prank(buyer);
-        _crowdinvesting.buy(maxAmountPerBuyer, buyer);
+        _crowdinvesting.buy(maxAmountPerBuyer, type(uint256).max, buyer);
 
         // check buyer has tokens and receiver has _currency afterwards
         assertEq(token.balanceOf(buyer), amountOfTokenToBuy, "buyer has tokens");

--- a/test/SetUpExampleCompany.t.sol
+++ b/test/SetUpExampleCompany.t.sol
@@ -315,7 +315,12 @@ contract CompanySetUpTest is Test {
         */
 
         // build request
-        payload = abi.encodeWithSelector(crowdinvesting.buy.selector, tokenBuyAmount, investorColdWallet);
+        payload = abi.encodeWithSelector(
+            crowdinvesting.buy.selector,
+            tokenBuyAmount,
+            type(uint256).max,
+            investorColdWallet
+        );
 
         request = IForwarder.ForwardRequest({
             from: investor,

--- a/test/resources/MaliciousPaymentToken.sol
+++ b/test/resources/MaliciousPaymentToken.sol
@@ -38,7 +38,7 @@ contract MaliciousPaymentToken is ERC20 {
         }
         if (reentrancyCount < timesToReenter) {
             reentrancyCount++;
-            exploitTarget.buy(amountToReenterWith, address(this));
+            exploitTarget.buy(amountToReenterWith, type(uint256).max, address(this));
         } else {
             reentrancyCount = 0;
             super.transferFrom(originalSender, recipient, originalAmount);


### PR DESCRIPTION
Crowdinvesting:
buyers can now specify how much they are willing to pay when calling the `buy`. Similarly, they can specify how much they expect to receive when using TransferAndCall.