### PR TITLE
Feature/initialize allow list

### DIFF
--- a/contracts/AllowList.sol
+++ b/contracts/AllowList.sol
@@ -64,19 +64,58 @@ contract AllowList is Ownable2StepUpgradeable, ERC2771ContextUpgradeable {
     }
 
     /**
+     * Initializes a new AllowList clone.
+     * @param _owner the owner of the contract
+     */
+    function initialize(
+        address _owner,
+        address[] calldata _addresses,
+        uint256[] calldata _attributes
+    ) public initializer {
+        require(_owner != address(0), "owner can not be zero address");
+        _transferOwnership(_owner);
+        _set(_addresses, _attributes);
+    }
+
+    /**
      * @notice sets (or updates) the attributes for an address
      * @param _addr address to be set
      * @param _attributes new attributes
      */
-    function set(address _addr, uint256 _attributes) public onlyOwner {
+    function set(address _addr, uint256 _attributes) external onlyOwner {
+        _set(_addr, _attributes);
+    }
+
+    /**
+     * @notice sets (or updates) the attributes for an address
+     * @param _addr address to be set
+     * @param _attributes new attributes
+     */
+    function _set(address _addr, uint256 _attributes) internal {
         map[_addr] = _attributes;
         emit Set(_addr, _attributes);
     }
 
+    /**
+     * Sets (or updates) the attributes for multiple addresses.
+     * @dev both arrays need to be of equal length
+     * @param _addr array of addresses to be added to allowList
+     * @param _attributes array of attributes to be assigned to addresses
+     */
     function set(address[] calldata _addr, uint256[] calldata _attributes) external onlyOwner {
+        _set(_addr, _attributes);
+    }
+
+    /**
+     * Sets (or updates) the attributes for multiple addresses.
+     * @dev both arrays need to be of equal length
+     * @param _addr array of addresses to be added to allowList
+     * @param _attributes array of attributes to be assigned to addresses
+     */
+    function _set(address[] calldata _addr, uint256[] calldata _attributes) internal {
         require(_addr.length == _attributes.length, "lengths do not match");
         for (uint256 i = 0; i < _addr.length; i++) {
-            set(_addr[i], _attributes[i]);
+            _set(_addr[i], _attributes[i]);
         }
     }
 
@@ -85,9 +124,19 @@ contract AllowList is Ownable2StepUpgradeable, ERC2771ContextUpgradeable {
      * @dev this is a convenience function, it is equivalent to calling set(_addr, 0)
      * @param _addr address to be removed
      */
-    function remove(address _addr) external onlyOwner {
+    function remove(address _addr) public onlyOwner {
         delete map[_addr];
         emit Set(_addr, 0);
+    }
+
+    /**
+     * purges multiple addresses from the allowList
+     * @param _addr array of addresses to be removed from allowList
+     */
+    function remove(address[] calldata _addr) external onlyOwner {
+        for (uint256 i = 0; i < _addr.length; i++) {
+            remove(_addr[i]);
+        }
     }
 
     /**

--- a/contracts/AllowList.sol
+++ b/contracts/AllowList.sol
@@ -68,9 +68,16 @@ contract AllowList is Ownable2StepUpgradeable, ERC2771ContextUpgradeable {
      * @param _addr address to be set
      * @param _attributes new attributes
      */
-    function set(address _addr, uint256 _attributes) external onlyOwner {
+    function set(address _addr, uint256 _attributes) public onlyOwner {
         map[_addr] = _attributes;
         emit Set(_addr, _attributes);
+    }
+
+    function set(address[] calldata _addr, uint256[] calldata _attributes) external onlyOwner {
+        require(_addr.length == _attributes.length, "lengths do not match");
+        for (uint256 i = 0; i < _addr.length; i++) {
+            set(_addr[i], _attributes[i]);
+        }
     }
 
     /**

--- a/contracts/factories/AllowListCloneFactory.sol
+++ b/contracts/factories/AllowListCloneFactory.sol
@@ -38,6 +38,33 @@ contract AllowListCloneFactory is CloneFactory {
     }
 
     /**
+     * Create a clone and initialize it with the given addresses and attributes
+     * @dev addresses and attributes do not change the address of the clone
+     * @param _rawSalt this value influences the address of the clone, but not the initialization
+     * @param _trustedForwarder the trusted forwarder (ERC2771) can not be changed, but is checked for security
+     * @param _owner address that will own the new clone
+     * @return address of the new clone
+     */
+    function createAllowListClone(
+        bytes32 _rawSalt,
+        address _trustedForwarder,
+        address _owner,
+        address[] calldata _addresses,
+        uint256[] calldata _attributes
+    ) external returns (address) {
+        bytes32 salt = _generateSalt(_rawSalt, _trustedForwarder, _owner);
+        address clone = Clones.cloneDeterministic(implementation, salt);
+        AllowList cloneAllowList = AllowList(clone);
+        require(
+            cloneAllowList.isTrustedForwarder(_trustedForwarder),
+            "AllowListCloneFactory: Unexpected trustedForwarder"
+        );
+        cloneAllowList.initialize(_owner, _addresses, _attributes);
+        emit NewClone(clone);
+        return clone;
+    }
+
+    /**
      * Return the address a clone would have if it was created with these parameters.
      * @param _rawSalt this value influences the address of the clone, but not the initialization
      * @param _trustedForwarder the trusted forwarder (ERC2771) can not be changed, but is checked for security

--- a/test/AllowList.t.sol
+++ b/test/AllowList.t.sol
@@ -108,7 +108,31 @@ contract AllowListTest is Test {
         assertTrue(list.map(address(y)) == attributesY, "y not set");
     }
 
-    function testRandoSetsMultiple(address x, uint256 attributesX, address y, uint256 attributesY) public {
+    // function testSetMultipleRandom(address[] memory addresses, uint256[] memory attributes) public {
+    //     uint256 length = addresses.length < attributes.length ? addresses.length : attributes.length;
+    //     vm.prank(owner);
+    //     list.set(addresses[:length], attributes[:length]);
+    //     // assertTrue(list.map(address(x)) == attributesX, "x not set");
+    //     // assertTrue(list.map(address(y)) == attributesY, "y not set");
+    // }
+
+    function testSetMultipleWithUnequalArrays(address x, uint256 attributesX, address y) public {
+        vm.assume(x != address(0));
+        vm.assume(y != address(0));
+        vm.assume(x != y);
+        assertTrue(list.map(address(x)) == 0, "x already on list");
+        assertTrue(list.map(address(y)) == 0, "y already on list");
+        address[] memory addresses = new address[](2);
+        addresses[0] = address(x);
+        addresses[1] = address(y);
+        uint256[] memory attributes = new uint256[](1);
+        attributes[0] = attributesX;
+        vm.prank(owner);
+        vm.expectRevert("lengths do not match");
+        list.set(addresses, attributes);
+    }
+
+    function testRandoCanNotSetMultiple(address x, uint256 attributesX, address y, uint256 attributesY) public {
         vm.assume(x != address(0));
         vm.assume(x != owner);
         vm.assume(y != address(0));
@@ -124,6 +148,41 @@ contract AllowListTest is Test {
         list.set(addresses, attributes);
         assertTrue(list.map(address(x)) == 0, "x was set");
         assertTrue(list.map(address(y)) == 0, "y was set");
+    }
+
+    function testRemoveMultiple(address x, uint256 attributesX, address y, uint256 attributesY) public {
+        vm.assume(x != address(0));
+        vm.assume(y != address(0));
+        vm.assume(x != y);
+        address[] memory addresses = new address[](2);
+        addresses[0] = address(x);
+        addresses[1] = address(y);
+        uint256[] memory attributes = new uint256[](2);
+        attributes[0] = attributesX;
+        attributes[1] = attributesY;
+        vm.prank(owner);
+        list.set(addresses, attributes);
+        assertTrue(list.map(address(x)) == attributesX, "x not set");
+        assertTrue(list.map(address(y)) == attributesY, "y not set");
+
+        // now remove both
+        vm.prank(owner);
+        list.remove(addresses);
+        assertTrue(list.map(address(x)) == 0, "x not removed");
+        assertTrue(list.map(address(y)) == 0, "y not removed");
+    }
+
+    function testRandoCannotRemoveMultiple(address rando) public {
+        vm.assume(rando != address(0));
+        vm.assume(rando != owner);
+
+        address[] memory addresses = new address[](2);
+        addresses[0] = address(3);
+        addresses[1] = address(5);
+
+        vm.prank(rando);
+        vm.expectRevert("Ownable: caller is not the owner");
+        list.remove(addresses);
     }
 
     function testRemove(address x) public {

--- a/test/AllowList.t.sol
+++ b/test/AllowList.t.sol
@@ -90,6 +90,42 @@ contract AllowListTest is Test {
         assertTrue(list.map(address(0)) == x);
     }
 
+    function testSetMultiple(address x, uint256 attributesX, address y, uint256 attributesY) public {
+        vm.assume(x != address(0));
+        vm.assume(y != address(0));
+        vm.assume(x != y);
+        assertTrue(list.map(address(x)) == 0, "x already on list");
+        assertTrue(list.map(address(y)) == 0, "y already on list");
+        address[] memory addresses = new address[](2);
+        addresses[0] = address(x);
+        addresses[1] = address(y);
+        uint256[] memory attributes = new uint256[](2);
+        attributes[0] = attributesX;
+        attributes[1] = attributesY;
+        vm.prank(owner);
+        list.set(addresses, attributes);
+        assertTrue(list.map(address(x)) == attributesX, "x not set");
+        assertTrue(list.map(address(y)) == attributesY, "y not set");
+    }
+
+    function testRandoSetsMultiple(address x, uint256 attributesX, address y, uint256 attributesY) public {
+        vm.assume(x != address(0));
+        vm.assume(x != owner);
+        vm.assume(y != address(0));
+        vm.assume(x != y);
+        address[] memory addresses = new address[](2);
+        addresses[0] = address(x);
+        addresses[1] = address(y);
+        uint256[] memory attributes = new uint256[](2);
+        attributes[0] = attributesX;
+        attributes[1] = attributesY;
+        vm.prank(x);
+        vm.expectRevert("Ownable: caller is not the owner");
+        list.set(addresses, attributes);
+        assertTrue(list.map(address(x)) == 0, "x was set");
+        assertTrue(list.map(address(y)) == 0, "y was set");
+    }
+
     function testRemove(address x) public {
         if (x == address(0)) return;
         assertTrue(list.map(address(0)) == 0);

--- a/test/AllowListCloneFactory.t.sol
+++ b/test/AllowListCloneFactory.t.sol
@@ -78,4 +78,24 @@ contract AllowListCloneFactoryTest is Test {
         vm.expectRevert("ERC1167: create2 failed");
         factory.createAllowListClone(bytes32(uint256(0)), trustedForwarder, _owner);
     }
+
+    function testInitializeWithAddresses(address x, uint256 attributesX, address y, uint256 attributesY) public {
+        vm.assume(x != address(0));
+        vm.assume(y != address(0));
+        vm.assume(x != y);
+
+        address[] memory addresses = new address[](2);
+        addresses[0] = address(x);
+        addresses[1] = address(y);
+        uint256[] memory attributes = new uint256[](2);
+        attributes[0] = attributesX;
+        attributes[1] = attributesY;
+
+        AllowList list = AllowList(
+            factory.createAllowListClone(bytes32(uint256(0)), trustedForwarder, companyAdmin, addresses, attributes)
+        );
+
+        assertTrue(list.map(address(x)) == attributesX, "x not set");
+        assertTrue(list.map(address(y)) == attributesY, "y not set");
+    }
 }

--- a/test/AllowListERC2771.t.sol
+++ b/test/AllowListERC2771.t.sol
@@ -71,7 +71,7 @@ contract FeeSettingERC2771Test is Test {
         setUpAllowListWithForwarder(_forwarder);
 
         // 1. build request
-        bytes memory payload = abi.encodeWithSelector(allowList.set.selector, _dude, _attributes);
+        bytes memory payload = abi.encodeWithSignature("set(address,uint256)", _dude, _attributes);
 
         IForwarder.ForwardRequest memory request = IForwarder.ForwardRequest({
             from: companyAdmin,

--- a/test/TokenERC2771.t.sol
+++ b/test/TokenERC2771.t.sol
@@ -20,17 +20,6 @@ contract TokenERC2771Test is Test {
     //Forwarder trustedForwarder;
     ERC2771Helper ERC2771helper;
 
-    // copied from openGSN IForwarder
-    struct ForwardRequest {
-        address from;
-        address to;
-        uint256 value;
-        uint256 gas;
-        uint256 nonce;
-        bytes data;
-        uint256 validUntil;
-    }
-
     address public constant trustedForwarder = 0x9109709EcFA91A80626FF3989D68f67F5B1dD129;
 
     // DO NOT USE IN PRODUCTION! Key was generated online for testing only.


### PR DESCRIPTION
- set multiple addresses at once
- remove multiple addresses at once
- initialize list with addresses during creation

possible caveat: addresses and attributes added to the AllowList during creation do not change the AllowList's address. This reduces code changes and allows the companyAdmin to collect addresses while doing the paperwork for their token deployment, because the addresses do not change their token address either. But it also makes it possible for the deployer (e.g. us) to add any address with any attribute during deployment.
Letting the founder add addresses to the AllowList manually would be more secure and only requires one signature. 
