### PR TITLE
make implementation address public

### DIFF
--- a/contracts/factories/Factory.sol
+++ b/contracts/factories/Factory.sol
@@ -10,7 +10,7 @@ pragma solidity 0.8.23;
 
 abstract contract Factory {
     /// The address of the implementation contract
-    address immutable implementation;
+    address public immutable implementation;
 
     constructor(address _implementation) {
         require(_implementation != address(0), "Factory: implementation can not be zero");


### PR DESCRIPTION
in order to make supply chain attacks like the factory creator using a implementation easier to detect