### PR TITLE
update salt generation to include parameters of vesting plan

### DIFF
--- a/contracts/factories/PrivateOfferFactory.sol
+++ b/contracts/factories/PrivateOfferFactory.sol
@@ -53,19 +53,10 @@ contract PrivateOfferFactory {
         address _vestingContractOwner,
         address trustedForwarder
     ) external returns (address) {
-        bytes32 salt = _getSalt(
-            _rawSalt,
-            _arguments,
-            _vestingStart,
-            _vestingCliff,
-            _vestingDuration,
-            _vestingContractOwner
-        );
-
         // deploy the vesting contract
         Vesting vesting = Vesting(
             vestingCloneFactory.createVestingCloneWithLockupPlan(
-                salt,
+                _rawSalt,
                 trustedForwarder,
                 _vestingContractOwner,
                 address(_arguments.token),
@@ -110,19 +101,16 @@ contract PrivateOfferFactory {
         address _vestingContractOwner,
         address trustedForwarder
     ) public view returns (address, address) {
-        bytes32 salt = _getSalt(
+        address vestingAddress = vestingCloneFactory.predictCloneAddressWithLockupPlan(
             _rawSalt,
-            _arguments,
+            trustedForwarder,
+            _vestingContractOwner,
+            address(_arguments.token),
+            _arguments.tokenAmount,
+            _arguments.tokenReceiver,
             _vestingStart,
             _vestingCliff,
-            _vestingDuration,
-            _vestingContractOwner
-        );
-        address vestingAddress = vestingCloneFactory.predictCloneAddress(
-            salt,
-            trustedForwarder,
-            address(vestingCloneFactory),
-            address(_arguments.token)
+            _vestingDuration
         );
 
         // since the vesting contracts address will be used as the token receiver, we need to use it for the prediction

--- a/contracts/factories/VestingCloneFactory.sol
+++ b/contracts/factories/VestingCloneFactory.sol
@@ -139,6 +139,10 @@ contract VestingCloneFactory is CloneFactory {
         uint64 _cliff,
         uint64 _duration
     ) external view returns (address) {
+        require(
+            Vesting(implementation).isTrustedForwarder(_trustedForwarder),
+            "VestingCloneFactory: Unexpected trustedForwarder"
+        );
         bytes32 salt = keccak256(
             abi.encode(
                 _rawSalt,

--- a/test/PrivateOfferFactory.t.sol
+++ b/test/PrivateOfferFactory.t.sol
@@ -143,6 +143,9 @@ contract PrivateOfferFactoryTest is Test {
             trustedForwarder
         );
 
+        console.log("expectedPrivateOffer", expectedPrivateOffer);
+        console.log("expectedVesting", expectedVesting);
+
         // make sure no contract lives here yet
         assertFalse(Address.isContract(expectedPrivateOffer), "Private Offer address already contains contract");
         assertFalse(Address.isContract(expectedVesting), "Vesting address already contains contract");

--- a/test/PrivateOfferOffchainPaymentTimeLock.t.sol
+++ b/test/PrivateOfferOffchainPaymentTimeLock.t.sol
@@ -66,7 +66,7 @@ contract PrivateOfferOffchainPaymentTimeLockTest is Test {
      * @param attemptTime try to release tokens after this amount of time
      * @param releaseDuration how long the releasing of tokens should take
      */
-    function testPrivateOfferWithTimeLock(
+    function testPrivateOfferOffchainPaymentTimeLock(
         bytes32 salt,
         uint64 releaseStartTime,
         uint64 releaseDuration,
@@ -90,11 +90,16 @@ contract PrivateOfferOffchainPaymentTimeLockTest is Test {
         // as the payment happens off-chain, we just assume it happened
 
         // predict addresses
-        address expectedTimeLockAddress = vestingCloneFactory.predictCloneAddress(
+        address expectedTimeLockAddress = vestingCloneFactory.predictCloneAddressWithLockupPlan(
             salt,
             trustedForwarder,
-            address(vestingCloneFactory),
-            address(token)
+            address(0), // no owner
+            address(token),
+            tokenAmount,
+            tokenReceiver,
+            releaseStartTime,
+            releaseDuration,
+            releaseDuration
         );
 
         // add time lock and token receiver to the allow list

--- a/test/VestingCloneFactory.t.sol
+++ b/test/VestingCloneFactory.t.sol
@@ -54,11 +54,11 @@ contract VestingCloneFactoryTest is Test {
                 _trustedForwarder != address(factory)
         );
         vm.assume(_token != address(0) && _token != address(1));
-        vm.assume(_allocation != 0 && _allocation < type(uint256).max);
+        vm.assume(_allocation != 0 && _allocation != 1);
         vm.assume(_beneficiary != address(0) && _beneficiary != address(1));
-        vm.assume(_start != 0 && _start < type(uint64).max);
-        vm.assume(_cliff != 0 && _cliff < type(uint64).max);
-        vm.assume(_duration != 0 && _duration < type(uint64).max);
+        vm.assume(_start != 0 && _start != 1);
+        vm.assume(_cliff != 0 && _cliff != 1);
+        vm.assume(_duration != 0 && _duration != 1);
         vm.assume(_rawSalt != bytes32("a"));
         Vesting _implementation = new Vesting(_trustedForwarder);
         VestingCloneFactory _factory = new VestingCloneFactory(address(_implementation));
@@ -152,7 +152,7 @@ contract VestingCloneFactoryTest is Test {
             _trustedForwarder,
             _owner,
             _token,
-            _allocation + 1,
+            1,
             _beneficiary,
             _start,
             _cliff,
@@ -182,7 +182,7 @@ contract VestingCloneFactoryTest is Test {
             _token,
             _allocation,
             _beneficiary,
-            _start + 1,
+            1,
             _cliff,
             _duration
         );
@@ -197,7 +197,7 @@ contract VestingCloneFactoryTest is Test {
             _allocation,
             _beneficiary,
             _start,
-            _cliff + 1,
+            1,
             _duration
         );
         assertNotEq(actual, changedAddress, "address prediction failed: cliff");
@@ -212,7 +212,7 @@ contract VestingCloneFactoryTest is Test {
             _beneficiary,
             _start,
             _cliff,
-            _duration + 1
+            1
         );
         assertNotEq(actual, changedAddress, "address prediction failed: duration");
     }

--- a/test/VestingCloneFactory.t.sol
+++ b/test/VestingCloneFactory.t.sol
@@ -104,8 +104,9 @@ contract VestingCloneFactoryTest is Test {
         );
         assertNotEq(actual, changedAddress, "address prediction failed: salt");
 
-        // test changing the trustedForwarder changes the address
-        changedAddress = _factory.predictCloneAddressWithLockupPlan(
+        // ensure changing the trustedForwarder reverts
+        vm.expectRevert("VestingCloneFactory: Unexpected trustedForwarder");
+        _factory.predictCloneAddressWithLockupPlan(
             _rawSalt,
             address(1),
             _owner,
@@ -116,7 +117,6 @@ contract VestingCloneFactoryTest is Test {
             _cliff,
             _duration
         );
-        assertNotEq(actual, changedAddress, "address prediction failed: trustedForwarder");
 
         // test changing the owner changes the address
         changedAddress = _factory.predictCloneAddressWithLockupPlan(


### PR DESCRIPTION
before this change, it would have been possible to deploy a lock up with a different beneficiary to the same address. 