### PR TITLE
Distributions for non-mintable vesting plans

### DIFF
--- a/contracts/Distribution.sol
+++ b/contracts/Distribution.sol
@@ -140,8 +140,10 @@ contract Distribution is ERC2771ContextUpgradeable, Ownable2StepUpgradeable {
      * @param _recipient address to receive the currency payout
      */
     function claim(Vesting _holder, uint64 _planId, address _recipient) external {
+        require(!_holder.isMintable(_planId), "mintable vesting plans are not eligible: tokens are not held by the contract at snapshot time");
         require(_msgSender() == _holder.beneficiary(_planId), "caller is not the plan beneficiary");
         uint256 amount = eligibleForPlan(_holder, _planId);
+        require(amount <= eligible(address(_holder)), "plan allocation exceeds vesting contract's snapshot balance");
         vestingPlanPaidOut[address(_holder)][_planId] += amount;
         paidOut[address(_holder)] += amount;
         currency.safeTransfer(_recipient, amount);

--- a/contracts/Distribution.sol
+++ b/contracts/Distribution.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "./Token.sol";
+import "./Vesting.sol";
 import "./interfaces/IFeeSettings.sol";
 
 struct DistributionInitializerArguments {
@@ -43,6 +44,8 @@ contract Distribution is ERC2771ContextUpgradeable, Ownable2StepUpgradeable {
     mapping(address => uint256) public paidOut;
     /// @notice Extra currency credit assigned to an address via reassign(), analogous to token reissuance after key loss
     mapping(address => uint256) public extraCredit;
+    /// @notice Tracks per-plan payouts for Vesting contracts, keyed by (vestingContract, planId)
+    mapping(address => mapping(uint64 => uint256)) public vestingPlanPaidOut;
     uint64 public reassignAfter;
 
     event Reassigned(address indexed from, address indexed to, uint256 amount);
@@ -126,6 +129,35 @@ contract Distribution is ERC2771ContextUpgradeable, Ownable2StepUpgradeable {
         _claim(address(_holder), _recipient);
     }
 
+    /**
+     * @notice Claims the distribution share for a single vesting plan.
+     * Uses Vesting.unreleasedAt to determine the plan's token balance at the snapshot, ensuring
+     * each beneficiary receives exactly their proportional share — no more, no less.
+     * Also increments paidOut[vestingContract] to prevent the owner from reassigning the same
+     * funds via the address-level path.
+     * @param _holder the Vesting contract holding the tokens
+     * @param _planId the vesting plan ID whose beneficiary is claiming
+     * @param _recipient address to receive the currency payout
+     */
+    function claim(Vesting _holder, uint64 _planId, address _recipient) external {
+        require(_msgSender() == _holder.beneficiary(_planId), "caller is not the plan beneficiary");
+        uint256 amount = eligibleForPlan(_holder, _planId);
+        vestingPlanPaidOut[address(_holder)][_planId] += amount;
+        paidOut[address(_holder)] += amount;
+        currency.safeTransfer(_recipient, amount);
+    }
+
+    /**
+     * @notice Returns the claimable currency amount for a single vesting plan.
+     * @param _holder the Vesting contract holding the tokens
+     * @param _planId the vesting plan ID to query
+     */
+    function eligibleForPlan(Vesting _holder, uint64 _planId) public view returns (uint256) {
+        return
+            (totalCurrencyAmount * _holder.unreleasedAt(_planId, snapshotId)) /
+            totalTokenAmount -
+            vestingPlanPaidOut[address(_holder)][_planId];
+    }
 
     function _claim(address _holder, address _recipient) internal {
         uint256 amount = eligible(_holder);

--- a/contracts/Vesting.sol
+++ b/contracts/Vesting.sol
@@ -9,12 +9,26 @@ import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import "@openzeppelin/contracts-upgradeable/utils/ArraysUpgradeable.sol";
 
 /**
  * @dev a token must implement this interface to be used with the Vesting contract and mintable vestings
  */
 interface ERC20Mintable {
     function mint(address, uint256) external;
+}
+
+/**
+ * @dev minimal interface for probing whether a token snapshot ID exists
+ */
+interface IERC20Snapshot {
+    function totalSupplyAt(uint256 snapshotId) external view returns (uint256);
+}
+
+/// Stores (snapshotId, value) pairs for a single plan field, mirroring ERC20Snapshot's Snapshots struct.
+struct PlanSnapshots {
+    uint256[] ids;
+    uint256[] values;
 }
 
 /// Struct that holds all information about a single vesting plan.
@@ -46,6 +60,8 @@ struct VestingPlan {
  * must happen before the tokens can be released.
  */
 contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable, ReentrancyGuardUpgradeable {
+    using ArraysUpgradeable for uint256[];
+
     event Commit(bytes32 hash);
     event ERC20Released(uint64 id, uint256 amount);
     event Revoke(bytes32 hash, uint64 endVestingTime);
@@ -66,6 +82,12 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
     mapping(bytes32 => uint64) public commitments;
     /// total amount of vesting plans created
     uint64 public ids;
+    /// per-plan checkpoint history of allocation values, recorded before each change
+    mapping(uint64 => PlanSnapshots) private _allocationSnapshots;
+    /// per-plan checkpoint history of released values, recorded before each change
+    mapping(uint64 => PlanSnapshots) private _releasedSnapshots;
+    /// the highest token snapshot ID that Vesting has observed so far
+    uint256 private _lastKnownTokenSnapshotId;
 
     /**
      * This contract will be used through clones, so the constructor only initializes
@@ -306,6 +328,9 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
         _duration = _duration > _cliff ? _duration : _cliff;
 
         id = ++ids;
+        // record allocation=0 for this new plan under the current snapshot, so queries
+        // for snapshots taken before this plan was created correctly return zero.
+        _updateAllocationSnapshot(id);
         vestings[id] = VestingPlan({
             allocation: _allocation,
             released: 0,
@@ -329,6 +354,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
         _endTime = _endTime < uint64(block.timestamp) ? uint64(block.timestamp) : _endTime;
         require(_endTime < start(_id) + duration(_id), "endTime must be before vesting end");
 
+        _updateAllocationSnapshot(_id);
         if (start(_id) + cliff(_id) > _endTime) {
             delete vestings[_id];
         } else {
@@ -390,6 +416,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
     function release(uint64 _id, uint256 _amount) public nonReentrant {
         require(_msgSender() == beneficiary(_id), "Only beneficiary can release tokens");
         _amount = releasable(_id) < _amount ? releasable(_id) : _amount;
+        _updateReleasedSnapshot(_id);
         vestings[_id].released += _amount;
         if (isMintable(_id)) {
             ERC20Mintable(token).mint(beneficiary(_id), _amount);
@@ -475,6 +502,86 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      */
     function _msgData() internal view override(ContextUpgradeable, ERC2771ContextUpgradeable) returns (bytes calldata) {
         return ERC2771ContextUpgradeable._msgData();
+    }
+
+    /**
+     * @dev Returns the allocation of a vesting plan at a given token snapshot.
+     * Mirrors ERC20Snapshot.balanceOfAt: returns the recorded value before the first modification
+     * after the snapshot, or the current value if no modifications occurred since then.
+     */
+    function allocationAt(uint64 _id, uint256 _snapshotId) public view returns (uint256) {
+        (bool snapshotted, uint256 value) = _valueAt(_snapshotId, _allocationSnapshots[_id]);
+        return snapshotted ? value : allocation(_id);
+    }
+
+    /**
+     * @dev Returns the released amount of a vesting plan at a given token snapshot.
+     */
+    function releasedAt(uint64 _id, uint256 _snapshotId) public view returns (uint256) {
+        (bool snapshotted, uint256 value) = _valueAt(_snapshotId, _releasedSnapshots[_id]);
+        return snapshotted ? value : released(_id);
+    }
+
+    /**
+     * @dev Returns the unreleased (locked) token amount for a vesting plan at a given snapshot.
+     * This is the value Distribution should use to attribute each beneficiary's share.
+     */
+    function unreleasedAt(uint64 _id, uint256 _snapshotId) public view returns (uint256) {
+        return allocationAt(_id, _snapshotId) - releasedAt(_id, _snapshotId);
+    }
+
+    /// Records the current allocation for plan _id under the current token snapshot ID,
+    /// if the snapshot has advanced since the last recorded entry. Must be called before
+    /// any change to vestings[_id].allocation.
+    function _updateAllocationSnapshot(uint64 _id) private {
+        _updatePlanSnapshot(_allocationSnapshots[_id], vestings[_id].allocation);
+    }
+
+    /// Records the current released amount for plan _id under the current token snapshot ID.
+    /// Must be called before any change to vestings[_id].released.
+    function _updateReleasedSnapshot(uint64 _id) private {
+        _updatePlanSnapshot(_releasedSnapshots[_id], vestings[_id].released);
+    }
+
+    function _updatePlanSnapshot(PlanSnapshots storage _snapshots, uint256 _currentValue) private {
+        _advanceTokenSnapshotId();
+        uint256 currentId = _lastKnownTokenSnapshotId;
+        // only record if at least one snapshot exists and the snapshot has advanced
+        if (currentId > 0 && _lastPlanSnapshotId(_snapshots.ids) < currentId) {
+            _snapshots.ids.push(currentId);
+            _snapshots.values.push(_currentValue);
+        }
+    }
+
+    /// Advances _lastKnownTokenSnapshotId by probing whether the next snapshot ID is populated.
+    /// Uses try/catch on totalSupplyAt so no changes to Token.sol are required.
+    function _advanceTokenSnapshotId() private {
+        while (true) {
+            try IERC20Snapshot(token).totalSupplyAt(_lastKnownTokenSnapshotId + 1) returns (uint256) {
+                _lastKnownTokenSnapshotId++;
+            } catch {
+                break;
+            }
+        }
+    }
+
+    /// Mirrors ERC20Snapshot._valueAt: binary-search for the value at or before _snapshotId.
+    function _valueAt(uint256 _snapshotId, PlanSnapshots storage _snapshots) private view returns (bool, uint256) {
+        require(_snapshotId > 0, "snapshotId must be positive");
+        // validates the snapshot exists — totalSupplyAt reverts on nonexistent IDs
+        IERC20Snapshot(token).totalSupplyAt(_snapshotId);
+
+        uint256 index = _snapshots.ids.findUpperBound(_snapshotId);
+        if (index == _snapshots.ids.length) {
+            // no entry at or after _snapshotId: value unchanged since snapshot
+            return (false, 0);
+        } else {
+            return (true, _snapshots.values[index]);
+        }
+    }
+
+    function _lastPlanSnapshotId(uint256[] storage ids) private view returns (uint256) {
+        return ids.length == 0 ? 0 : ids[ids.length - 1];
     }
 
     /**


### PR DESCRIPTION
## Executive summary

Non-mintable vestings and dividends result in problems where a solution isn't certain on-chain, even with lots of additional code. Therefore, I recommend NOT adding the complex code in this PR for a partial solution, but rely on mitigating the issue through manual reassignment should it ever really happen. Since we don't use non-mintable vestings afaik, the issue might never be relevant irl anyway.

## The problem                                                                                                                    
                                                                                                                               
  The Distribution contract attributes payouts based on token.balanceOfAt(holder, snapshotId). For non-mintable vestings, tokens  are held by the Vesting contract itself, not the beneficiary. A Vesting contract may hold tokens for multiple plans with       
  different beneficiaries, so the contract's snapshot balance is a lump sum that cannot be split correctly without knowing each
  plan's individual balance **at the time the snapshot was taken**.

  Simply using the current allocation - released at claim time is wrong: releases that happened after the snapshot but before the
   claim would undercount a beneficiary's share (those tokens are now in their wallet and already counted there).

  ## The partial solution: per-plan snapshots in Vesting

  Vesting.sol mirrors the lazy-checkpoint pattern of ERC20Snapshot. Before any modification to allocation (in stopVesting) or
  released (in release), if the token's snapshot counter has advanced since the last recorded checkpoint, the current value is
  written under the new snapshot ID. The token's snapshot counter is discovered by probing totalSupplyAt(lastKnown + 1) — no
  changes to Token.sol required.

  This produces unreleasedAt(planId, snapshotId): the exact number of tokens attributable to a plan at the moment the snapshot
  was taken, using the same ID space as the token.

  Distribution.eligibleForPlan(vesting, planId) then computes:

  totalCurrencyAmount × unreleasedAt(planId, snapshotId) / totalTokenAmount

  This gives every beneficiary their precise, trustless share.

## Remaining issues

### Who gets the dividend for tokens that don't belong to a vesting plan?

  unreleasedAt only covers tokens that belong to an active plan. A Vesting contract may also hold tokens that no plan can account for — tokens sent directly to the contract address, or tokens whose plan was deleted before the cliff (stopVesting → delete).
  These appear in token.balanceOfAt(vestingContract, snapshotId) but have no beneficiary to claim them via claim(Vesting, planId, ...).

  Those funds remain in eligible(vestingContract) indefinitely. The Vesting contract has no mechanism to call Distribution.claim
  on itself, so they cannot be unlocked automatically. After reassignAfter, the Distribution owner must use
  reassign(vestingContract, destination, amount) to redirect them — for example, back to a company treasury.

  This is intentional: the owner is the appropriate decision-maker for tokens whose intended recipient is ambiguous or lost, and
  the on-chain Reassigned event ensures the action is auditable.
  
  ### What if the vesting contract doesn't hold enough tokens for all plans?
  If that happens, a plan might not be able to claim. Scenario: 2 plans, eligible for 10 and 20 tokens. But the smart contract holds only 10 tokens. That means the snapshot allots only 10 tokens, so only plan 1 can claim - plan 2 will revert. Mostly unfixable even with manual reassignment, assuming the remaining 20 tokens have not been minted before the snapshot.