### PR TITLE
introduce dynamic fee types

### DIFF
--- a/contracts/Distribution.sol
+++ b/contracts/Distribution.sol
@@ -71,14 +71,19 @@ contract Distribution is ERC2771ContextUpgradeable, Ownable2StepUpgradeable {
             token.allowList().map(address(_arguments.currency)) & TRUSTED_CURRENCY == TRUSTED_CURRENCY,
             "currency needs to be on the allowlist with TRUSTED_CURRENCY attribute"
         );
-        IFeeSettingsV2 feeSettings = _arguments.token.feeSettings();
-        uint256 fee = feeSettings.privateOfferFee(_arguments.totalCurrencyAmount, address(_arguments.token));
+        IFeeSettingsV2 feeSettingsV2 = _arguments.token.feeSettings();
+        uint256 fee;
+        address feeCollector;
+        if (feeSettingsV2.supportsInterface(type(IFeeSettingsV3).interfaceId)) {
+            IFeeSettingsV3 feeSettings = IFeeSettingsV3(address(feeSettingsV2));
+            fee = feeSettings.fee(FeeTypes.PRIVATE_OFFER_FEE, _arguments.totalCurrencyAmount, address(_arguments.token));
+            feeCollector = feeSettings.feeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(_arguments.token));
+        } else {
+            fee = feeSettingsV2.privateOfferFee(_arguments.totalCurrencyAmount, address(_arguments.token));
+            feeCollector = feeSettingsV2.privateOfferFeeCollector(address(_arguments.token));
+        }
         if (fee != 0) {
-            _arguments.currency.safeTransferFrom(
-                _currencyProvider,
-                feeSettings.privateOfferFeeCollector(address(_arguments.token)),
-                fee
-            );
+            _arguments.currency.safeTransferFrom(_currencyProvider, feeCollector, fee);
         }
         totalCurrencyAmount = _arguments.totalCurrencyAmount - fee;
         reassignAfter = _arguments.reassignAfter;

--- a/contracts/Distribution.sol
+++ b/contracts/Distribution.sol
@@ -76,12 +76,8 @@ contract Distribution is ERC2771ContextUpgradeable, Ownable2StepUpgradeable {
         address feeCollector;
         if (feeSettingsV2.supportsInterface(type(IFeeSettingsV3).interfaceId)) {
             IFeeSettingsV3 feeSettings = IFeeSettingsV3(address(feeSettingsV2));
-            fee = feeSettings.fee(
-                FeeTypes.DISTRIBUTION_FEE,
-                _arguments.totalCurrencyAmount,
-                address(_arguments.token)
-            );
-            feeCollector = feeSettings.feeCollector(FeeTypes.DISTRIBUTION_FEE, address(_arguments.token));
+            fee = feeSettings.fee(FeeTypes.DISTRIBUTION, _arguments.totalCurrencyAmount, address(_arguments.token));
+            feeCollector = feeSettings.feeCollector(FeeTypes.DISTRIBUTION, address(_arguments.token));
         } else {
             fee = feeSettingsV2.privateOfferFee(_arguments.totalCurrencyAmount, address(_arguments.token));
             feeCollector = feeSettingsV2.privateOfferFeeCollector(address(_arguments.token));

--- a/contracts/Distribution.sol
+++ b/contracts/Distribution.sol
@@ -76,7 +76,11 @@ contract Distribution is ERC2771ContextUpgradeable, Ownable2StepUpgradeable {
         address feeCollector;
         if (feeSettingsV2.supportsInterface(type(IFeeSettingsV3).interfaceId)) {
             IFeeSettingsV3 feeSettings = IFeeSettingsV3(address(feeSettingsV2));
-            fee = feeSettings.fee(FeeTypes.PRIVATE_OFFER_FEE, _arguments.totalCurrencyAmount, address(_arguments.token));
+            fee = feeSettings.fee(
+                FeeTypes.PRIVATE_OFFER_FEE,
+                _arguments.totalCurrencyAmount,
+                address(_arguments.token)
+            );
             feeCollector = feeSettings.feeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(_arguments.token));
         } else {
             fee = feeSettingsV2.privateOfferFee(_arguments.totalCurrencyAmount, address(_arguments.token));

--- a/contracts/Distribution.sol
+++ b/contracts/Distribution.sol
@@ -77,11 +77,11 @@ contract Distribution is ERC2771ContextUpgradeable, Ownable2StepUpgradeable {
         if (feeSettingsV2.supportsInterface(type(IFeeSettingsV3).interfaceId)) {
             IFeeSettingsV3 feeSettings = IFeeSettingsV3(address(feeSettingsV2));
             fee = feeSettings.fee(
-                FeeTypes.PRIVATE_OFFER_FEE,
+                FeeTypes.DISTRIBUTION_FEE,
                 _arguments.totalCurrencyAmount,
                 address(_arguments.token)
             );
-            feeCollector = feeSettings.feeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(_arguments.token));
+            feeCollector = feeSettings.feeCollector(FeeTypes.DISTRIBUTION_FEE, address(_arguments.token));
         } else {
             fee = feeSettingsV2.privateOfferFee(_arguments.totalCurrencyAmount, address(_arguments.token));
             feeCollector = feeSettingsV2.privateOfferFeeCollector(address(_arguments.token));

--- a/contracts/Exit.sol
+++ b/contracts/Exit.sol
@@ -99,10 +99,19 @@ contract Exit is ERC2771ContextUpgradeable, Ownable2StepUpgradeable {
         require(block.timestamp >= claimStart, "exit not yet started");
         IERC20(address(token)).safeTransferFrom(_holder, address(this), _tokenAmount);
         uint256 currencyAmount = (_tokenAmount * pricePerToken) / 10 ** token.decimals();
-        IFeeSettingsV2 feeSettings = token.feeSettings();
-        uint256 fee = feeSettings.privateOfferFee(currencyAmount, address(token));
+        IFeeSettingsV2 feeSettingsV2 = token.feeSettings();
+        uint256 fee;
+        address feeCollector;
+        if (feeSettingsV2.supportsInterface(type(IFeeSettingsV3).interfaceId)) {
+            IFeeSettingsV3 feeSettings = IFeeSettingsV3(address(feeSettingsV2));
+            fee = feeSettings.fee(FeeTypes.PRIVATE_OFFER_FEE, currencyAmount, address(token));
+            feeCollector = feeSettings.feeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(token));
+        } else {
+            fee = feeSettingsV2.privateOfferFee(currencyAmount, address(token));
+            feeCollector = feeSettingsV2.privateOfferFeeCollector(address(token));
+        }
         if (fee != 0) {
-            currency.safeTransfer(feeSettings.privateOfferFeeCollector(address(token)), fee);
+            currency.safeTransfer(feeCollector, fee);
         }
         currency.safeTransfer(_recipient, currencyAmount - fee);
     }

--- a/contracts/Exit.sol
+++ b/contracts/Exit.sol
@@ -104,8 +104,8 @@ contract Exit is ERC2771ContextUpgradeable, Ownable2StepUpgradeable {
         address feeCollector;
         if (feeSettingsV2.supportsInterface(type(IFeeSettingsV3).interfaceId)) {
             IFeeSettingsV3 feeSettings = IFeeSettingsV3(address(feeSettingsV2));
-            fee = feeSettings.fee(FeeTypes.EXIT_FEE, currencyAmount, address(token));
-            feeCollector = feeSettings.feeCollector(FeeTypes.EXIT_FEE, address(token));
+            fee = feeSettings.fee(FeeTypes.EXIT, currencyAmount, address(token));
+            feeCollector = feeSettings.feeCollector(FeeTypes.EXIT, address(token));
         } else {
             fee = feeSettingsV2.privateOfferFee(currencyAmount, address(token));
             feeCollector = feeSettingsV2.privateOfferFeeCollector(address(token));

--- a/contracts/Exit.sol
+++ b/contracts/Exit.sol
@@ -104,8 +104,8 @@ contract Exit is ERC2771ContextUpgradeable, Ownable2StepUpgradeable {
         address feeCollector;
         if (feeSettingsV2.supportsInterface(type(IFeeSettingsV3).interfaceId)) {
             IFeeSettingsV3 feeSettings = IFeeSettingsV3(address(feeSettingsV2));
-            fee = feeSettings.fee(FeeTypes.PRIVATE_OFFER_FEE, currencyAmount, address(token));
-            feeCollector = feeSettings.feeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(token));
+            fee = feeSettings.fee(FeeTypes.EXIT_FEE, currencyAmount, address(token));
+            feeCollector = feeSettings.feeCollector(FeeTypes.EXIT_FEE, address(token));
         } else {
             fee = feeSettingsV2.privateOfferFee(currencyAmount, address(token));
             feeCollector = feeSettingsV2.privateOfferFeeCollector(address(token));

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -43,11 +43,24 @@ contract FeeSettings is
      * @notice Configuration for a registered fee type.
      * @param maxNumerator     Hard cap — fees above this are rejected.
      * @param defaultNumerator The default numerator used when no active custom fee applies.
-     * @param exists           Guards against reads on unregistered keys.
      */
     struct FeeTypeConfig {
         uint32 maxNumerator;
         uint32 defaultNumerator;
+    }
+
+    /**
+     * @notice Initialization data for a single fee type, used in initialize().
+     * @param feeType          bytes32 identifier (e.g. FeeTypes.TOKEN_FEE)
+     * @param maxNumerator     Hard cap for this fee type
+     * @param defaultNumerator Initial default numerator; must be <= maxNumerator
+     * @param collector        Default fee collector address for this type
+     */
+    struct FeeTypeInit {
+        bytes32 feeType;
+        uint32 maxNumerator;
+        uint32 defaultNumerator;
+        address collector;
     }
 
     /**
@@ -99,7 +112,7 @@ contract FeeSettings is
     /// @notice A manager has been removed
     event ManagerRemoved(address indexed manager);
 
-    /// @notice A new fee type has been registered (or its max cap raised)
+    /// @notice A new fee type has been registered
     event FeeTypeRegistered(bytes32 indexed feeType, uint32 maxNumerator, uint32 defaultNumerator);
 
     /// @notice A default fee change has been proposed
@@ -133,54 +146,21 @@ contract FeeSettings is
     }
 
     /**
-     * @notice Initializes a new FeeSettings clone with the four standard fee types.
-     *      SECONDARY_MARKET_FEE is initialized with the same numerator and collector as PRIVATE_OFFER_FEE.
-     * @param _owner                      Owner of this clone
-     * @param _fees                       Initial fee numerators for the three fee types
-     * @param _tokenFeeCollector          Default collector for token fees
-     * @param _crowdinvestingFeeCollector Default collector for crowdinvesting fees
-     * @param _privateOfferFeeCollector   Default collector for private offer fees
+     * @notice Initializes a new FeeSettings clone with an arbitrary set of fee types.
+     * @param _owner     Owner of this clone
+     * @param _feeTypes  Array of fee type configurations to register on deployment
      */
-    function initialize(
-        address _owner,
-        Fees memory _fees,
-        address _tokenFeeCollector,
-        address _crowdinvestingFeeCollector,
-        address _privateOfferFeeCollector
-    ) external initializer {
+    function initialize(address _owner, FeeTypeInit[] memory _feeTypes) external initializer {
         require(_owner != address(0), "owner can not be zero address");
         managers[_owner] = true;
         _transferOwnership(_owner);
 
-        require(_fees.tokenFeeNumerator <= MAX_TOKEN_FEE_NUMERATOR, "Token fee must be <= 5%");
-        require(
-            _fees.crowdinvestingFeeNumerator <= MAX_CROWDINVESTING_FEE_NUMERATOR,
-            "Crowdinvesting fee must be <= 10%"
-        );
-        require(_fees.privateOfferFeeNumerator <= MAX_PRIVATE_OFFER_FEE_NUMERATOR, "PrivateOffer fee must be <= 5%");
-
-        _registerFeeType(FeeTypes.TOKEN_FEE, MAX_TOKEN_FEE_NUMERATOR, _fees.tokenFeeNumerator);
-        _registerFeeType(
-            FeeTypes.CROWDINVESTING_FEE,
-            MAX_CROWDINVESTING_FEE_NUMERATOR,
-            _fees.crowdinvestingFeeNumerator
-        );
-        _registerFeeType(FeeTypes.PRIVATE_OFFER_FEE, MAX_PRIVATE_OFFER_FEE_NUMERATOR, _fees.privateOfferFeeNumerator);
-        _registerFeeType(
-            FeeTypes.SECONDARY_MARKET_FEE,
-            MAX_PRIVATE_OFFER_FEE_NUMERATOR,
-            _fees.privateOfferFeeNumerator
-        );
-
-        require(_tokenFeeCollector != address(0), "Fee collector cannot be 0x0");
-        feeCollectors[FeeTypes.TOKEN_FEE][address(0)] = _tokenFeeCollector;
-
-        require(_crowdinvestingFeeCollector != address(0), "Fee collector cannot be 0x0");
-        feeCollectors[FeeTypes.CROWDINVESTING_FEE][address(0)] = _crowdinvestingFeeCollector;
-
-        require(_privateOfferFeeCollector != address(0), "Fee collector cannot be 0x0");
-        feeCollectors[FeeTypes.PRIVATE_OFFER_FEE][address(0)] = _privateOfferFeeCollector;
-        feeCollectors[FeeTypes.SECONDARY_MARKET_FEE][address(0)] = _privateOfferFeeCollector;
+        for (uint256 i = 0; i < _feeTypes.length; i++) {
+            FeeTypeInit memory feeType = _feeTypes[i];
+            require(feeType.collector != address(0), "Fee collector cannot be 0x0");
+            _registerFeeType(feeType.feeType, feeType.maxNumerator, feeType.defaultNumerator);
+            feeCollectors[feeType.feeType][address(0)] = feeType.collector;
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -216,13 +196,14 @@ contract FeeSettings is
      * @param _defaultNumerator Initial default numerator; must be <= _maxNumerator
      */
     function registerFeeType(bytes32 _feeType, uint32 _maxNumerator, uint32 _defaultNumerator) external onlyOwner {
-        require(_feeType != bytes32(0), "feeType cannot be 0");
-        require(feeTypeConfigs[_feeType].maxNumerator == 0, "fee type already registered");
-        require(_defaultNumerator <= _maxNumerator, "default exceeds max");
         _registerFeeType(_feeType, _maxNumerator, _defaultNumerator);
     }
 
     function _registerFeeType(bytes32 _feeType, uint32 _maxNumerator, uint32 _defaultNumerator) internal {
+        require(_feeType != bytes32(0), "feeType cannot be 0");
+        require(_maxNumerator > 0, "maxNumerator cannot be 0");
+        require(feeTypeConfigs[_feeType].maxNumerator == 0, "fee type already registered");
+        require(_defaultNumerator <= _maxNumerator, "default exceeds max");
         feeTypeConfigs[_feeType] = FeeTypeConfig({maxNumerator: _maxNumerator, defaultNumerator: _defaultNumerator});
         emit FeeTypeRegistered(_feeType, _maxNumerator, _defaultNumerator);
     }

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -133,9 +133,8 @@ contract FeeSettings is
     }
 
     /**
-     * @notice Initializes a new FeeSettings clone with the three V2-era fee types.
-     *      Additional fee types (e.g. SECONDARY_MARKET_FEE) must be registered afterwards
-     *      via registerFeeType / setDefaultFeeCollector.
+     * @notice Initializes a new FeeSettings clone with the four standard fee types.
+     *      SECONDARY_MARKET_FEE is initialized with the same numerator and collector as PRIVATE_OFFER_FEE.
      * @param _owner                      Owner of this clone
      * @param _fees                       Initial fee numerators for the three fee types
      * @param _tokenFeeCollector          Default collector for token fees
@@ -163,6 +162,7 @@ contract FeeSettings is
         _registerFeeType(FeeTypes.TOKEN_FEE, MAX_TOKEN_FEE_NUMERATOR, _fees.tokenFeeNumerator);
         _registerFeeType(FeeTypes.CROWDINVESTING_FEE, MAX_CROWDINVESTING_FEE_NUMERATOR, _fees.crowdinvestingFeeNumerator);
         _registerFeeType(FeeTypes.PRIVATE_OFFER_FEE, MAX_PRIVATE_OFFER_FEE_NUMERATOR, _fees.privateOfferFeeNumerator);
+        _registerFeeType(FeeTypes.SECONDARY_MARKET_FEE, MAX_PRIVATE_OFFER_FEE_NUMERATOR, _fees.privateOfferFeeNumerator);
 
         require(_tokenFeeCollector != address(0), "Fee collector cannot be 0x0");
         feeCollectors[FeeTypes.TOKEN_FEE][address(0)] = _tokenFeeCollector;
@@ -172,6 +172,7 @@ contract FeeSettings is
 
         require(_privateOfferFeeCollector != address(0), "Fee collector cannot be 0x0");
         feeCollectors[FeeTypes.PRIVATE_OFFER_FEE][address(0)] = _privateOfferFeeCollector;
+        feeCollectors[FeeTypes.SECONDARY_MARKET_FEE][address(0)] = _privateOfferFeeCollector;
     }
 
     // -------------------------------------------------------------------------
@@ -235,6 +236,10 @@ contract FeeSettings is
         require(_numerator <= config.maxNumerator, "exceeds max numerator");
         if (_numerator > config.defaultNumerator) {
             require(_activationDate > block.timestamp + 12 weeks, "fee increase needs 12 week delay");
+        }
+        // activationDate=0 means "immediately" — store block.timestamp so executeFeeChange sentinel works
+        if (_activationDate == 0) {
+            _activationDate = uint64(block.timestamp);
         }
         proposedFeeChanges[_feeType] = ProposedFeeChange({numerator: _numerator, activationDate: _activationDate});
         emit FeeChangeProposed(_feeType, _numerator, _activationDate);

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -377,6 +377,15 @@ contract FeeSettings is
         return feeCollector(keccak256(bytes(_feeType)), _token);
     }
 
+    /**
+     * @notice Converts a human-readable fee type name to its bytes32 key.
+     *      Useful for block explorer users who need the hash to query mappings directly.
+     * @param _feeType The fee type name (e.g. "TOKEN", "CROWDINVESTING")
+     */
+    function feeTypeId(string calldata _feeType) external pure returns (bytes32) {
+        return keccak256(bytes(_feeType));
+    }
+
     // -------------------------------------------------------------------------
     // IFeeSettingsV2 named accessors (backwards-compat wrappers over V3 generics)
     // -------------------------------------------------------------------------

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -25,13 +25,6 @@ contract FeeSettings is
     // Constants
     // -------------------------------------------------------------------------
 
-    /// max token fee is 5%
-    uint32 public constant MAX_TOKEN_NUMERATOR = 500;
-    /// max crowdinvesting fee is 10%
-    uint32 public constant MAX_CROWDINVESTING_NUMERATOR = 1000;
-    /// max private offer fee is 5%
-    uint32 public constant MAX_PRIVATE_OFFER_NUMERATOR = 500;
-
     /// Denominator to calculate all fees
     uint32 public constant FEE_DENOMINATOR = 10000;
 

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -347,16 +347,6 @@ contract FeeSettings is
     }
 
     /**
-     * @notice Convenience overload — accepts a human-readable fee type name and hashes it internally.
-     * @param _feeType The fee type name (e.g. "TOKEN", "CROWDINVESTING")
-     * @param _amount  The base amount
-     * @param _token   The token address
-     */
-    function fee(string calldata _feeType, uint256 _amount, address _token) external view returns (uint256) {
-        return fee(keccak256(bytes(_feeType)), _amount, _token);
-    }
-
-    /**
      * @notice Returns the fee collector for a given fee type and token.
      *      Falls back to the type-level default (key = address(0)) if no per-token entry exists.
      * @param _feeType The fee type key
@@ -366,15 +356,6 @@ contract FeeSettings is
         address custom = feeCollectors[_feeType][_token];
         if (custom != address(0)) return custom;
         return feeCollectors[_feeType][address(0)];
-    }
-
-    /**
-     * @notice Convenience overload — accepts a human-readable fee type name and hashes it internally.
-     * @param _feeType The fee type name (e.g. "TOKEN", "CROWDINVESTING")
-     * @param _token   The token address
-     */
-    function feeCollector(string calldata _feeType, address _token) external view returns (address) {
-        return feeCollector(keccak256(bytes(_feeType)), _token);
     }
 
     /**

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -150,8 +150,8 @@ contract FeeSettings is
 
         for (uint256 i = 0; i < _feeTypes.length; i++) {
             FeeTypeInit memory feeType = _feeTypes[i];
-            require(feeType.collector != address(0), "Fee collector cannot be 0x0");
             _registerFeeType(feeType.feeType, feeType.maxNumerator, feeType.defaultNumerator);
+            require(feeType.collector != address(0), "Fee collector cannot be 0x0");
             feeCollectors[feeType.feeType][address(0)] = feeType.collector;
         }
     }
@@ -195,6 +195,7 @@ contract FeeSettings is
     function _registerFeeType(bytes32 _feeType, uint32 _maxNumerator, uint32 _defaultNumerator) internal {
         require(_feeType != bytes32(0), "feeType cannot be 0");
         require(_maxNumerator > 0, "maxNumerator cannot be 0");
+        require(_maxNumerator < FEE_DENOMINATOR, "maxNumerator too large");
         require(feeTypeConfigs[_feeType].maxNumerator == 0, "fee type already registered");
         require(_defaultNumerator <= _maxNumerator, "default exceeds max");
         feeTypeConfigs[_feeType] = FeeTypeConfig({maxNumerator: _maxNumerator, defaultNumerator: _defaultNumerator});

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -124,7 +124,7 @@ contract FeeSettings is
     event FeeCollectorSet(bytes32 indexed feeType, address indexed token, address indexed collector);
 
     /// @notice A custom fee collector has been removed for a token (reverts to type default)
-    event FeeCollectorRemoved(bytes32 indexed feeType, address indexed token);
+    event CustomFeeCollectorRemoved(bytes32 indexed feeType, address indexed token);
 
     // -------------------------------------------------------------------------
     // Constructor & initializer
@@ -150,9 +150,7 @@ contract FeeSettings is
 
         for (uint256 i = 0; i < _feeTypes.length; i++) {
             FeeTypeInit memory feeType = _feeTypes[i];
-            _registerFeeType(feeType.feeType, feeType.maxNumerator, feeType.defaultNumerator);
-            require(feeType.defaultCollector != address(0), "Fee collector cannot be 0x0");
-            collectors[feeType.feeType][address(0)] = feeType.defaultCollector;
+            _registerFeeType(feeType.feeType, feeType.maxNumerator, feeType.defaultNumerator, feeType.defaultCollector);
         }
     }
 
@@ -188,17 +186,29 @@ contract FeeSettings is
      * @param _maxNumerator     Hard cap enforced on all numerators for this type
      * @param _defaultNumerator Initial default numerator; must be <= _maxNumerator
      */
-    function registerFeeType(bytes32 _feeType, uint32 _maxNumerator, uint32 _defaultNumerator) external onlyOwner {
-        _registerFeeType(_feeType, _maxNumerator, _defaultNumerator);
+    function registerFeeType(
+        bytes32 _feeType,
+        uint32 _maxNumerator,
+        uint32 _defaultNumerator,
+        address _collector
+    ) external onlyOwner {
+        _registerFeeType(_feeType, _maxNumerator, _defaultNumerator, _collector);
     }
 
-    function _registerFeeType(bytes32 _feeType, uint32 _maxNumerator, uint32 _defaultNumerator) internal {
+    function _registerFeeType(
+        bytes32 _feeType,
+        uint32 _maxNumerator,
+        uint32 _defaultNumerator,
+        address _collector
+    ) internal {
         require(_feeType != bytes32(0), "feeType cannot be 0");
         require(_maxNumerator > 0, "maxNumerator cannot be 0");
         require(_maxNumerator < FEE_DENOMINATOR, "maxNumerator too large");
         require(feeTypeConfigs[_feeType].maxNumerator == 0, "fee type already registered");
         require(_defaultNumerator <= _maxNumerator, "default exceeds max");
+        require(_collector != address(0), "Fee collector cannot be 0x0");
         feeTypeConfigs[_feeType] = FeeTypeConfig({maxNumerator: _maxNumerator, defaultNumerator: _defaultNumerator});
+        collectors[_feeType][address(0)] = _collector;
         emit FeeTypeRegistered(_feeType, _maxNumerator, _defaultNumerator);
     }
 
@@ -315,7 +325,7 @@ contract FeeSettings is
     function removeCustomFeeCollector(bytes32 _feeType, address _token) external onlyManager {
         require(_token != address(0), "token cannot be 0x0");
         delete collectors[_feeType][_token];
-        emit FeeCollectorRemoved(_feeType, _token);
+        emit CustomFeeCollectorRemoved(_feeType, _token);
     }
 
     // -------------------------------------------------------------------------

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -347,6 +347,16 @@ contract FeeSettings is
     }
 
     /**
+     * @notice Convenience overload — accepts a human-readable fee type name and hashes it internally.
+     * @param _feeType The fee type name (e.g. "TOKEN", "CROWDINVESTING")
+     * @param _amount  The base amount
+     * @param _token   The token address
+     */
+    function fee(string calldata _feeType, uint256 _amount, address _token) external view returns (uint256) {
+        return fee(keccak256(bytes(_feeType)), _amount, _token);
+    }
+
+    /**
      * @notice Returns the fee collector for a given fee type and token.
      *      Falls back to the type-level default (key = address(0)) if no per-token entry exists.
      * @param _feeType The fee type key
@@ -356,6 +366,15 @@ contract FeeSettings is
         address custom = feeCollectors[_feeType][_token];
         if (custom != address(0)) return custom;
         return feeCollectors[_feeType][address(0)];
+    }
+
+    /**
+     * @notice Convenience overload — accepts a human-readable fee type name and hashes it internally.
+     * @param _feeType The fee type name (e.g. "TOKEN", "CROWDINVESTING")
+     * @param _token   The token address
+     */
+    function feeCollector(string calldata _feeType, address _token) external view returns (address) {
+        return feeCollector(keccak256(bytes(_feeType)), _token);
     }
 
     // -------------------------------------------------------------------------

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -26,11 +26,11 @@ contract FeeSettings is
     // -------------------------------------------------------------------------
 
     /// max token fee is 5%
-    uint32 public constant MAX_TOKEN_FEE_NUMERATOR = 500;
+    uint32 public constant MAX_TOKEN_NUMERATOR = 500;
     /// max crowdinvesting fee is 10%
-    uint32 public constant MAX_CROWDINVESTING_FEE_NUMERATOR = 1000;
+    uint32 public constant MAX_CROWDINVESTING_NUMERATOR = 1000;
     /// max private offer fee is 5%
-    uint32 public constant MAX_PRIVATE_OFFER_FEE_NUMERATOR = 500;
+    uint32 public constant MAX_PRIVATE_OFFER_NUMERATOR = 500;
 
     /// Denominator to calculate all fees
     uint32 public constant FEE_DENOMINATOR = 10000;
@@ -51,7 +51,7 @@ contract FeeSettings is
 
     /**
      * @notice Initialization data for a single fee type, used in initialize().
-     * @param feeType          bytes32 identifier (e.g. FeeTypes.TOKEN_FEE)
+     * @param feeType          bytes32 identifier (e.g. FeeTypes.TOKEN)
      * @param maxNumerator     Hard cap for this fee type
      * @param defaultNumerator Initial default numerator; must be <= maxNumerator
      * @param collector        Default fee collector address for this type
@@ -364,12 +364,12 @@ contract FeeSettings is
 
     /// @dev V2 wrapper
     function tokenFee(uint256 _tokenAmount, address _token) public view override(IFeeSettingsV2) returns (uint256) {
-        return fee(FeeTypes.TOKEN_FEE, _tokenAmount, _token);
+        return fee(FeeTypes.TOKEN, _tokenAmount, _token);
     }
 
     /// @dev V2 wrapper
     function tokenFeeCollector(address _token) public view override(IFeeSettingsV2) returns (address) {
-        return feeCollector(FeeTypes.TOKEN_FEE, _token);
+        return feeCollector(FeeTypes.TOKEN, _token);
     }
 
     /// @dev V2 wrapper
@@ -377,12 +377,12 @@ contract FeeSettings is
         uint256 _currencyAmount,
         address _token
     ) public view override(IFeeSettingsV2) returns (uint256) {
-        return fee(FeeTypes.CROWDINVESTING_FEE, _currencyAmount, _token);
+        return fee(FeeTypes.CROWDINVESTING, _currencyAmount, _token);
     }
 
     /// @dev V2 wrapper
     function crowdinvestingFeeCollector(address _token) public view override(IFeeSettingsV2) returns (address) {
-        return feeCollector(FeeTypes.CROWDINVESTING_FEE, _token);
+        return feeCollector(FeeTypes.CROWDINVESTING, _token);
     }
 
     /// @dev V2 wrapper
@@ -390,12 +390,12 @@ contract FeeSettings is
         uint256 _currencyAmount,
         address _token
     ) public view override(IFeeSettingsV2) returns (uint256) {
-        return fee(FeeTypes.PRIVATE_OFFER_FEE, _currencyAmount, _token);
+        return fee(FeeTypes.PRIVATE_OFFER, _currencyAmount, _token);
     }
 
     /// @dev V2 wrapper
     function privateOfferFeeCollector(address _token) public view override(IFeeSettingsV2) returns (address) {
-        return feeCollector(FeeTypes.PRIVATE_OFFER_FEE, _token);
+        return feeCollector(FeeTypes.PRIVATE_OFFER, _token);
     }
 
     // -------------------------------------------------------------------------
@@ -407,7 +407,7 @@ contract FeeSettings is
      * @dev V1 compat — V1 has no concept of per-token collectors, so we return the type default.
      */
     function feeCollector() external view override(IFeeSettingsV1) returns (address) {
-        return feeCollectors[FeeTypes.TOKEN_FEE][address(0)];
+        return feeCollectors[FeeTypes.TOKEN][address(0)];
     }
 
     /**

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -10,15 +10,21 @@ import "./interfaces/IFeeSettings.sol";
 /**
  * @title FeeSettings
  * @author malteish, cjentzsch
- * @notice The FeeSettings contract is used to manage fees paid to the tokenize.it platfom
+ * @notice The FeeSettings contract is used to manage fees paid to the tokenize.it platform.
+ *      Fee types are registered dynamically, so new fee types can be added without a contract upgrade.
  */
 contract FeeSettings is
     Ownable2StepUpgradeable,
     ERC165Upgradeable,
     ERC2771ContextUpgradeable,
+    IFeeSettingsV1,
     IFeeSettingsV2,
-    IFeeSettingsV1
+    IFeeSettingsV3
 {
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
     /// max token fee is 5%
     uint32 public constant MAX_TOKEN_FEE_NUMERATOR = 500;
     /// max crowdinvesting fee is 10%
@@ -29,107 +35,94 @@ contract FeeSettings is
     /// Denominator to calculate all fees
     uint32 public constant FEE_DENOMINATOR = 10000;
 
-    /**
-     * special fees for specific customers. If a customer has a custom fee, the custom
-     * fee is used instead of the default fee.
-     * Custom fees can only reduce the fee, not increase it.
-     * The key is the customer's token address, e.g. customers are identified by their token.
-     * The `time` field is the time up to which the custom fee is valid.
-     * Afterwards, standard fees are used.
-     */
-    mapping(address => Fees) public fees;
+    // -------------------------------------------------------------------------
+    // Structs
+    // -------------------------------------------------------------------------
 
     /**
-     * if `tokenFeeCollectors[tokenAddress]` is 0x0, the fees must be paid to `tokenFeeCollectors[address(0)]`
-     * otherwise, the fees must be paid to `tokenFeeCollectors[tokenAddress]`
+     * @notice Configuration for a registered fee type.
+     * @param maxNumerator     Hard cap — fees above this are rejected.
+     * @param defaultNumerator The default numerator used when no active custom fee applies.
+     * @param exists           Guards against reads on unregistered keys.
      */
-    mapping(address => address) public tokenFeeCollectors;
-    /**
-     * if `crowdinvestingFeeCollectors[tokenAddress]` is 0x0, the fees must be paid to `crowdinvestingFeeCollectors[address(0)]`
-     * otherwise, the fees must be paid to `crowdinvestingFeeCollectors[tokenAddress]`
-     */
-    mapping(address => address) public crowdinvestingFeeCollectors;
-    /**
-     * if `privateOfferFeeCollectors[tokenAddress]` is 0x0, the fees must be paid to `privateOfferFeeCollectors[address(0)]`
-     * otherwise, the fees must be paid to `privateOfferFeeCollectors[tokenAddress]`
-     */
-    mapping(address => address) public privateOfferFeeCollectors;
+    struct FeeTypeConfig {
+        uint32 maxNumerator;
+        uint32 defaultNumerator;
+    }
 
-    /// new fee settings that can be activated (after a delay in case of fee increase)
-    Fees public proposedDefaultFees;
+    /**
+     * @notice A pending custom discount for a specific token.
+     * @param numerator    The discounted fee numerator.
+     * @param validityDate Unix timestamp up to which the discount is valid.
+     */
+    struct CustomFee {
+        uint32 numerator;
+        uint64 validityDate;
+    }
 
-    /// stores who is a manager. Managers can change fees and fee collectors for specific tokens
+    /**
+     * @notice A proposed change to a fee type's default numerator.
+     * @param numerator      The proposed new default numerator.
+     * @param activationDate Unix timestamp after which the change can be executed.
+     */
+    struct ProposedFeeChange {
+        uint32 numerator;
+        uint64 activationDate;
+    }
+
+    // -------------------------------------------------------------------------
+    // Storage
+    // -------------------------------------------------------------------------
+
+    /// stores who is a manager. Managers can set custom fees and custom fee collectors for specific tokens.
     mapping(address => bool) public managers;
 
-    /**
-     * @notice Default fees have been changed
-     * @param tokenFeeNumerator a in fraction a/b that defines the fee paid in Token: fee = amount * a / b
-     * @param crowdinvestingFeeNumerator a in fraction a/b that defines the fee paid in currency for crowdinvesting: fee = amount * a / b
-     * @param privateOfferFeeNumerator a in fraction a/b that defines the fee paid in currency for private offers: fee = amount * a / b
-     */
-    event SetFee(uint32 tokenFeeNumerator, uint32 crowdinvestingFeeNumerator, uint32 privateOfferFeeNumerator);
+    /// registry of all fee types:  feeType => config
+    mapping(bytes32 => FeeTypeConfig) public feeTypeConfigs;
 
-    /**
-     * @notice Default fees have been changed
-     * @param tokenFeeNumerator a in fraction a/b that defines the fee paid in Token: fee = amount * a / b
-     * @param crowdinvestingFeeNumerator a in fraction a/b that defines the fee paid in currency for crowdinvesting: fee = amount * a / b
-     * @param privateOfferFeeNumerator a in fraction a/b that defines the fee paid in currency for private offers: fee = amount * a / b
-     * @param time The time when the custom fee expires
-     */
-    event SetCustomFee(
-        address indexed token,
-        uint32 tokenFeeNumerator,
-        uint32 crowdinvestingFeeNumerator,
-        uint32 privateOfferFeeNumerator,
-        uint256 time
-    );
+    /// per-token custom discounts:  feeType => token => discount
+    mapping(bytes32 => mapping(address => CustomFee)) public customFees;
 
-    /// custom fee settings for the given token have been removed
-    event RemoveCustomFee(address indexed token);
+    /// fee collectors:  feeType => token => collector  (address(0) key = default collector for that type)
+    mapping(bytes32 => mapping(address => address)) public feeCollectors;
 
-    /// token fees for `token` must now be paid to `feeCollector`
-    event SetCustomTokenFeeCollector(address indexed token, address indexed feeCollector);
-    /// crowdinvesting fees for `token` must now be paid to `feeCollector`
-    event SetCustomCrowdinvestingFeeCollector(address indexed token, address indexed feeCollector);
-    /// private offer fees for `token` must now be paid to `feeCollector`
-    event SetCustomPrivateOfferFeeCollector(address indexed token, address indexed feeCollector);
+    /// pending default-fee changes:  feeType => proposal
+    mapping(bytes32 => ProposedFeeChange) public proposedFeeChanges;
 
-    /// token fees for `token` must now be paid to the default fee collector
-    event RemoveCustomTokenFeeCollector(address indexed token);
-    /// crowdinvesting fees for `token` must now be paid to the default fee collector
-    event RemoveCustomCrowdinvestingFeeCollector(address indexed token);
-    /// private offer fees for `token` must now be paid to the default fee collector
-    event RemoveCustomPrivateOfferFeeCollector(address indexed token);
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
 
-    /**
-     * @notice The fee collectors have changed
-     * @param newTokenFeeCollector The new fee collector for token fees
-     * @param newCrowdinvestingFeeCollector The new fee collector for crowdinvesting fees
-     * @param newPrivateOfferFeeCollector The new fee collector for private offer fees
-     */
-    event FeeCollectorsChanged(
-        address indexed newTokenFeeCollector,
-        address indexed newCrowdinvestingFeeCollector,
-        address indexed newPrivateOfferFeeCollector
-    );
-
-    /**
-     * @notice A fee change has been proposed
-     * @param proposal The new fee settings that have been proposed
-     */
-    event ChangeProposed(Fees proposal);
-
-    /**
-     * @notice A manager has been added
-     * @param manager The address of the manager that was added
-     */
+    /// @notice A manager has been added
     event ManagerAdded(address indexed manager);
 
-    /**
-     * @notice A manager has been removed
-     * @param manager The address of the manager that was removed
-     */
+    /// @notice A manager has been removed
     event ManagerRemoved(address indexed manager);
+
+    /// @notice A new fee type has been registered (or its max cap raised)
+    event FeeTypeRegistered(bytes32 indexed feeType, uint32 maxNumerator, uint32 defaultNumerator);
+
+    /// @notice A default fee change has been proposed
+    event FeeChangeProposed(bytes32 indexed feeType, uint32 numerator, uint64 activationDate);
+
+    /// @notice A proposed default fee change has been executed
+    event FeeChanged(bytes32 indexed feeType, uint32 numerator);
+
+    /// @notice A custom fee discount has been set for a token
+    event CustomFeeSet(bytes32 indexed feeType, address indexed token, uint32 numerator, uint64 validityDate);
+
+    /// @notice A custom fee discount has been removed for a token
+    event CustomFeeRemoved(bytes32 indexed feeType, address indexed token);
+
+    /// @notice A new fee collector has been set (either for a specific token or as default)
+    event FeeCollectorSet(bytes32 indexed feeType, address indexed token, address indexed collector);
+
+    /// @notice A custom fee collector has been removed for a token (reverts to type default)
+    event FeeCollectorRemoved(bytes32 indexed feeType, address indexed token);
+
+    // -------------------------------------------------------------------------
+    // Constructor & initializer
+    // -------------------------------------------------------------------------
 
     /**
      * This constructor deploys a logic contract with no owner, that can be used for cloning.
@@ -140,11 +133,14 @@ contract FeeSettings is
     }
 
     /**
-     * @notice Initializes the contract with the given fee denominators and fee collector
-     * @param _fees The initial fee denominators
-     * @param _tokenFeeCollector The initial fee collector
-     * @param _crowdinvestingFeeCollector The initial crowdinvesting fee collector
-     * @param _privateOfferFeeCollector The initial private offer fee collector
+     * @notice Initializes a new FeeSettings clone with the three V2-era fee types.
+     *      Additional fee types (e.g. SECONDARY_MARKET_FEE) must be registered afterwards
+     *      via registerFeeType / setDefaultFeeCollector.
+     * @param _owner                      Owner of this clone
+     * @param _fees                       Initial fee numerators for the three fee types
+     * @param _tokenFeeCollector          Default collector for token fees
+     * @param _crowdinvestingFeeCollector Default collector for crowdinvesting fees
+     * @param _privateOfferFeeCollector   Default collector for private offer fees
      */
     function initialize(
         address _owner,
@@ -157,18 +153,30 @@ contract FeeSettings is
         managers[_owner] = true;
         _transferOwnership(_owner);
 
-        checkFeeLimits(_fees);
-        fees[address(0)] = _fees;
+        require(_fees.tokenFeeNumerator <= MAX_TOKEN_FEE_NUMERATOR, "Token fee must be <= 5%");
+        require(
+            _fees.crowdinvestingFeeNumerator <= MAX_CROWDINVESTING_FEE_NUMERATOR,
+            "Crowdinvesting fee must be <= 10%"
+        );
+        require(_fees.privateOfferFeeNumerator <= MAX_PRIVATE_OFFER_FEE_NUMERATOR, "PrivateOffer fee must be <= 5%");
+
+        _registerFeeType(FeeTypes.TOKEN_FEE, MAX_TOKEN_FEE_NUMERATOR, _fees.tokenFeeNumerator);
+        _registerFeeType(FeeTypes.CROWDINVESTING_FEE, MAX_CROWDINVESTING_FEE_NUMERATOR, _fees.crowdinvestingFeeNumerator);
+        _registerFeeType(FeeTypes.PRIVATE_OFFER_FEE, MAX_PRIVATE_OFFER_FEE_NUMERATOR, _fees.privateOfferFeeNumerator);
 
         require(_tokenFeeCollector != address(0), "Fee collector cannot be 0x0");
-        tokenFeeCollectors[address(0)] = _tokenFeeCollector;
+        feeCollectors[FeeTypes.TOKEN_FEE][address(0)] = _tokenFeeCollector;
 
         require(_crowdinvestingFeeCollector != address(0), "Fee collector cannot be 0x0");
-        crowdinvestingFeeCollectors[address(0)] = _crowdinvestingFeeCollector;
+        feeCollectors[FeeTypes.CROWDINVESTING_FEE][address(0)] = _crowdinvestingFeeCollector;
 
         require(_privateOfferFeeCollector != address(0), "Fee collector cannot be 0x0");
-        privateOfferFeeCollectors[address(0)] = _privateOfferFeeCollector;
+        feeCollectors[FeeTypes.PRIVATE_OFFER_FEE][address(0)] = _privateOfferFeeCollector;
     }
+
+    // -------------------------------------------------------------------------
+    // Manager management. Managers can set custom fees for specific tokens.
+    // -------------------------------------------------------------------------
 
     /**
      * @notice Adds a manager
@@ -188,296 +196,252 @@ contract FeeSettings is
         emit ManagerRemoved(_manager);
     }
 
-    /**
-     * @notice Prepares a fee change. Fee increases are subject to a minimum delay of 12 weeks, while fee reductions can be executed immediately.
-     * @dev reducing fees = increasing the denominator
-     * @param _fees The new fee denominators
-     */
-    function planFeeChange(Fees memory _fees) external onlyOwner {
-        checkFeeLimits(_fees);
+    // -------------------------------------------------------------------------
+    // Fee type registry
+    // -------------------------------------------------------------------------
 
-        // if at least one fee increases, enforce minimum delay
-        if (
-            _fees.tokenFeeNumerator > fees[address(0)].tokenFeeNumerator ||
-            _fees.crowdinvestingFeeNumerator > fees[address(0)].crowdinvestingFeeNumerator ||
-            _fees.privateOfferFeeNumerator > fees[address(0)].privateOfferFeeNumerator
-        ) {
-            require(
-                _fees.validityDate > block.timestamp + 12 weeks,
-                "Fee change must be at least 12 weeks in the future"
-            );
+    /**
+     * @notice Registers a new fee type. Reverts if the fee type is already registered.
+     * @param _feeType          bytes32 identifier (e.g. keccak256("MY_FEE"))
+     * @param _maxNumerator     Hard cap enforced on all numerators for this type
+     * @param _defaultNumerator Initial default numerator; must be <= _maxNumerator
+     */
+    function registerFeeType(bytes32 _feeType, uint32 _maxNumerator, uint32 _defaultNumerator) external onlyOwner {
+        require(_feeType != bytes32(0), "feeType cannot be 0");
+        require(feeTypeConfigs[_feeType].maxNumerator == 0, "fee type already registered");
+        require(_defaultNumerator <= _maxNumerator, "default exceeds max");
+        _registerFeeType(_feeType, _maxNumerator, _defaultNumerator);
+    }
+
+    function _registerFeeType(bytes32 _feeType, uint32 _maxNumerator, uint32 _defaultNumerator) internal {
+        feeTypeConfigs[_feeType] = FeeTypeConfig({maxNumerator: _maxNumerator, defaultNumerator: _defaultNumerator});
+        emit FeeTypeRegistered(_feeType, _maxNumerator, _defaultNumerator);
+    }
+
+    // -------------------------------------------------------------------------
+    // Default fee change (with 12-week delay on increases)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Proposes a new default numerator for a fee type.
+     *      If the numerator increases, the activation date must be at least 12 weeks in the future.
+     * @param _feeType        The fee type to change
+     * @param _numerator      The new default numerator
+     * @param _activationDate Unix timestamp after which executeFeeChange can be called
+     */
+    function planFeeChange(bytes32 _feeType, uint32 _numerator, uint64 _activationDate) external onlyOwner {
+        FeeTypeConfig storage config = feeTypeConfigs[_feeType];
+        require(config.maxNumerator > 0, "unknown fee type");
+        require(_numerator <= config.maxNumerator, "exceeds max numerator");
+        if (_numerator > config.defaultNumerator) {
+            require(_activationDate > block.timestamp + 12 weeks, "fee increase needs 12 week delay");
         }
-        proposedDefaultFees = _fees;
-        emit ChangeProposed(_fees);
+        proposedFeeChanges[_feeType] = ProposedFeeChange({numerator: _numerator, activationDate: _activationDate});
+        emit FeeChangeProposed(_feeType, _numerator, _activationDate);
     }
 
     /**
-     * @notice Executes a fee change that has been planned before
+     * @notice Executes a previously planned default fee change.
+     * @param _feeType The fee type to update
      */
-    function executeFeeChange() external onlyOwner {
-        require(
-            block.timestamp >= proposedDefaultFees.validityDate,
-            "Fee change must be executed after the change time"
-        );
-        fees[address(0)] = proposedDefaultFees;
-        emit SetFee(
-            proposedDefaultFees.tokenFeeNumerator,
-            proposedDefaultFees.crowdinvestingFeeNumerator,
-            proposedDefaultFees.privateOfferFeeNumerator
-        );
-        delete proposedDefaultFees;
+    function executeFeeChange(bytes32 _feeType) external onlyOwner {
+        ProposedFeeChange memory proposal = proposedFeeChanges[_feeType];
+        require(proposal.activationDate != 0, "no proposed fee change");
+        require(block.timestamp >= proposal.activationDate, "activation date not reached");
+        feeTypeConfigs[_feeType].defaultNumerator = proposal.numerator;
+        delete proposedFeeChanges[_feeType];
+        emit FeeChanged(_feeType, proposal.numerator);
+    }
+
+    // -------------------------------------------------------------------------
+    // Custom fees (per-token discounts), manager-only
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Sets a custom fee discount for a specific token on a fee type.
+     *      Custom fees can only reduce the effective fee (the min of custom and default is used).
+     * @param _feeType      The fee type
+     * @param _token        The token address (must not be address(0))
+     * @param _numerator    The discounted numerator
+     * @param _validityDate Unix timestamp until which the discount is valid
+     */
+    function setCustomFee(
+        bytes32 _feeType,
+        address _token,
+        uint32 _numerator,
+        uint64 _validityDate
+    ) external onlyManager {
+        require(feeTypeConfigs[_feeType].maxNumerator > 0, "unknown fee type");
+        require(_token != address(0), "token cannot be 0x0");
+        require(_validityDate > block.timestamp, "validity date must be in the future");
+        customFees[_feeType][_token] = CustomFee({numerator: _numerator, validityDate: _validityDate});
+        emit CustomFeeSet(_feeType, _token, _numerator, _validityDate);
     }
 
     /**
-     * @notice Sets a new fee collector
-     * @param _tokenFeeCollector The new fee collector
+     * @notice Removes a custom fee discount for a token, reverting to the type default.
+     * @param _feeType The fee type
+     * @param _token   The token address
      */
-    function setFeeCollectors(
-        address _tokenFeeCollector,
-        address _crowdinvestingFeeCollector,
-        address _personalOfferFeeCollector
-    ) external onlyOwner {
-        require(_tokenFeeCollector != address(0), "Fee collector cannot be 0x0");
-        tokenFeeCollectors[address(0)] = _tokenFeeCollector;
-        require(_crowdinvestingFeeCollector != address(0), "Fee collector cannot be 0x0");
-        crowdinvestingFeeCollectors[address(0)] = _crowdinvestingFeeCollector;
-        require(_personalOfferFeeCollector != address(0), "Fee collector cannot be 0x0");
-        privateOfferFeeCollectors[address(0)] = _personalOfferFeeCollector;
-        emit FeeCollectorsChanged(_tokenFeeCollector, _crowdinvestingFeeCollector, _personalOfferFeeCollector);
+    function removeCustomFee(bytes32 _feeType, address _token) external onlyManager {
+        require(_token != address(0), "token cannot be 0x0");
+        delete customFees[_feeType][_token];
+        emit CustomFeeRemoved(_feeType, _token);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fee collectors, manager-only
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Sets the default fee collector for a fee type. Owner only.
+     * @param _feeType   The fee type
+     * @param _collector The collector address (must not be address(0))
+     */
+    function setDefaultFeeCollector(bytes32 _feeType, address _collector) external onlyOwner {
+        require(feeTypeConfigs[_feeType].maxNumerator > 0, "unknown fee type");
+        require(_collector != address(0), "collector cannot be 0x0");
+        feeCollectors[_feeType][address(0)] = _collector;
+        emit FeeCollectorSet(_feeType, address(0), _collector);
     }
 
     /**
-     * @notice Checks if the given fee settings are valid
-     * @param _fees The fees to check
+     * @notice Sets a per-token fee collector override for a fee type. Manager only.
+     * @param _feeType   The fee type
+     * @param _token     The token address (must not be address(0))
+     * @param _collector The collector address (must not be address(0))
      */
-    function checkFeeLimits(Fees memory _fees) internal pure {
-        require(_fees.tokenFeeNumerator <= MAX_TOKEN_FEE_NUMERATOR, "Token fee must be <= 5%");
-        require(
-            _fees.crowdinvestingFeeNumerator <= MAX_CROWDINVESTING_FEE_NUMERATOR,
-            "Crowdinvesting fee must be <= 10%"
-        );
-        require(_fees.privateOfferFeeNumerator <= MAX_PRIVATE_OFFER_FEE_NUMERATOR, "PrivateOffer fee must be <= 5%");
+    function setCustomFeeCollector(bytes32 _feeType, address _token, address _collector) external onlyManager {
+        require(feeTypeConfigs[_feeType].maxNumerator > 0, "unknown fee type");
+        require(_token != address(0), "token cannot be 0x0");
+        require(_collector != address(0), "collector cannot be 0x0");
+        feeCollectors[_feeType][_token] = _collector;
+        emit FeeCollectorSet(_feeType, _token, _collector);
     }
 
     /**
-     * @notice Sets a custom fee for a specific token
-     * @param _token The token for which the custom fee should be set
-     * @param _fees The custom fee
+     * @notice Removes the per-token fee collector override, reverting to the type default.
+     * @param _feeType The fee type
+     * @param _token   The token address (must not be address(0))
      */
-    function setCustomFee(address _token, Fees memory _fees) external onlyManager {
-        checkFeeLimits(_fees);
-        require(_token != address(0), "Token cannot be 0x0");
-        require(_fees.validityDate > block.timestamp, "Custom fee expiry time must be in the future");
-        fees[_token] = _fees;
-        emit SetCustomFee(
-            _token,
-            _fees.tokenFeeNumerator,
-            _fees.crowdinvestingFeeNumerator,
-            _fees.privateOfferFeeNumerator,
-            _fees.validityDate
-        );
+    function removeCustomFeeCollector(bytes32 _feeType, address _token) external onlyManager {
+        require(_token != address(0), "token cannot be 0x0");
+        delete feeCollectors[_feeType][_token];
+        emit FeeCollectorRemoved(_feeType, _token);
+    }
+
+    // -------------------------------------------------------------------------
+    // IFeeSettingsV3 generic accessors
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Calculates the fee for a given amount and fee type.
+     *      If a non-expired custom discount is set for `_token`, the lower of default and custom is used.
+     * @param _feeType The fee type key
+     * @param _amount  The base amount
+     * @param _token   The token address (used to look up custom discounts)
+     */
+    function fee(
+        bytes32 _feeType,
+        uint256 _amount,
+        address _token
+    ) public view override(IFeeSettingsV3) returns (uint256) {
+        FeeTypeConfig storage config = feeTypeConfigs[_feeType];
+        require(config.maxNumerator > 0, "unknown fee type");
+        CustomFee storage custom = customFees[_feeType][_token];
+        return _applyCustomFee(_amount, config.defaultNumerator, custom.numerator, custom.validityDate);
     }
 
     /**
-     * @notice removes a custom fee entry for a specific token
-     * @param _token The token for which the custom fee should be removed
+     * @notice Returns the fee collector for a given fee type and token.
+     *      Falls back to the type-level default (key = address(0)) if no per-token entry exists.
+     * @param _feeType The fee type key
+     * @param _token   The token address
      */
-    function removeCustomFee(address _token) external onlyManager {
-        require(_token != address(0), "Token cannot be 0x0");
-        delete fees[_token];
-        emit RemoveCustomFee(_token);
+    function feeCollector(bytes32 _feeType, address _token) public view override(IFeeSettingsV3) returns (address) {
+        address custom = feeCollectors[_feeType][_token];
+        if (custom != address(0)) return custom;
+        return feeCollectors[_feeType][address(0)];
     }
 
-    /**
-     * set `_feeCollector` as the token fee collector for `_token`
-     * @param _token the token for which the fee collector is set
-     * @param _feeCollector the address that will receive the token fees
-     */
-    function setCustomTokenFeeCollector(address _token, address _feeCollector) external onlyManager {
-        require(_feeCollector != address(0), "Fee collector cannot be 0x0");
-        require(_token != address(0), "Token cannot be 0x0");
-        tokenFeeCollectors[_token] = _feeCollector;
-        emit SetCustomTokenFeeCollector(_token, _feeCollector);
-    }
+    // -------------------------------------------------------------------------
+    // IFeeSettingsV2 named accessors (backwards-compat wrappers over V3 generics)
+    // -------------------------------------------------------------------------
 
-    /**
-     *  set `_feeCollector` as the crowdinvesting fee collector for `_token`
-     * @param _token the token for which the fee collector is set
-     * @param _feeCollector the address that will receive the crowdinvesting fees
-     */
-    function setCustomCrowdinvestingFeeCollector(address _token, address _feeCollector) external onlyManager {
-        require(_feeCollector != address(0), "Fee collector cannot be 0x0");
-        require(_token != address(0), "Token cannot be 0x0");
-        crowdinvestingFeeCollectors[_token] = _feeCollector;
-        emit SetCustomCrowdinvestingFeeCollector(_token, _feeCollector);
-    }
-
-    /**
-     * set `_feeCollector` as the private offer fee collector for `_token`
-     * @param _token the token for which the fee collector is set
-     * @param _feeCollector the address that will receive the private offer fees
-     */
-    function setCustomPrivateOfferFeeCollector(address _token, address _feeCollector) external onlyManager {
-        require(_feeCollector != address(0), "Fee collector cannot be 0x0");
-        require(_token != address(0), "Token cannot be 0x0");
-        privateOfferFeeCollectors[_token] = _feeCollector;
-        emit SetCustomPrivateOfferFeeCollector(_token, _feeCollector);
-    }
-
-    /**
-     * Reset the token fee collector for `_token` to the default fee collector
-     * @param _token the token for which the custom fee collector is removed
-     */
-    function removeCustomTokenFeeCollector(address _token) external onlyManager {
-        require(_token != address(0), "Token cannot be 0x0");
-        delete tokenFeeCollectors[_token];
-        emit RemoveCustomTokenFeeCollector(_token);
-    }
-
-    /**
-     * Reset the crowdinvesting fee collector for `_token` to the default fee collector
-     * @param _token the token for which the custom fee collector is removed
-     */
-    function removeCustomCrowdinvestingFeeCollector(address _token) external onlyManager {
-        require(_token != address(0), "Token cannot be 0x0");
-        delete crowdinvestingFeeCollectors[_token];
-        emit RemoveCustomCrowdinvestingFeeCollector(_token);
-    }
-
-    /**
-     * Reset the private offer fee collector for `_token` to the default fee collector
-     * @param _token the token for which the custom fee collector is removed
-     */
-    function removeCustomPrivateOfferFeeCollector(address _token) external onlyManager {
-        require(_token != address(0), "Token cannot be 0x0");
-        delete privateOfferFeeCollectors[_token];
-        emit RemoveCustomPrivateOfferFeeCollector(_token);
-    }
-
-    /**
-     * @notice Returns the token fee collector for a given token
-     * @param _token The token to return the token fee collector for
-     * @return The fee collector
-     */
-    function tokenFeeCollector(address _token) public view override(IFeeSettingsV2) returns (address) {
-        if (tokenFeeCollectors[_token] != address(0)) {
-            return tokenFeeCollectors[_token];
-        }
-        return tokenFeeCollectors[address(0)];
-    }
-
-    /**
-     * @notice Returns the crowdinvesting fee collector for a given token
-     * @param _token The token to return the crowdinvesting fee collector for
-     * @return The fee collector
-     */
-    function crowdinvestingFeeCollector(address _token) public view override(IFeeSettingsV2) returns (address) {
-        if (crowdinvestingFeeCollectors[_token] != address(0)) {
-            return crowdinvestingFeeCollectors[_token];
-        }
-        return crowdinvestingFeeCollectors[address(0)];
-    }
-
-    /**
-     * @notice Returns the private offer fee collector for a given token
-     * @param _token The token to return the private offer fee collector for
-     * @return The fee collector
-     */
-    function privateOfferFeeCollector(address _token) public view override(IFeeSettingsV2) returns (address) {
-        if (privateOfferFeeCollectors[_token] != address(0)) {
-            return privateOfferFeeCollectors[_token];
-        }
-        return privateOfferFeeCollectors[address(0)];
-    }
-
-    /**
-     * General linear fee calculation function
-     * @param amount how many erc20 tokens are transferred
-     * @param numerator fee numerator
-     */
-    function _fee(uint256 amount, uint32 numerator) internal pure returns (uint256) {
-        return (amount * numerator) / FEE_DENOMINATOR;
-    }
-
-    /**
-     * Calculates the fee for a given amount of tokens.
-     * @param amount how many erc20 tokens are transferred
-     * @param defaultNumerator default fee numerator
-     * @param customNumerator custom fee numerator
-     * @param customValidityDate custom fee validity date
-     */
-    function _customFee(
-        uint256 amount,
-        uint32 defaultNumerator,
-        uint32 customNumerator,
-        uint64 customValidityDate
-    ) internal view returns (uint256) {
-        if (customValidityDate < uint64(block.timestamp)) {
-            return _fee(amount, defaultNumerator);
-        }
-        uint256 defaultFee = _fee(amount, defaultNumerator);
-        uint256 customFee = _fee(amount, customNumerator);
-        if (customFee < defaultFee) {
-            return customFee;
-        }
-        return defaultFee;
-    }
-
-    /**
-     * calculates the token fee in tokens for the given token amount
-     * @param _tokenAmount number of tokens that are minted
-     * @param _token address of the token contract minting the tokens
-     */
+    /// @dev V2 wrapper
     function tokenFee(uint256 _tokenAmount, address _token) public view override(IFeeSettingsV2) returns (uint256) {
-        return
-            _customFee(
-                _tokenAmount,
-                fees[address(0)].tokenFeeNumerator,
-                fees[_token].tokenFeeNumerator,
-                fees[_token].validityDate
-            );
+        return fee(FeeTypes.TOKEN_FEE, _tokenAmount, _token);
     }
 
-    /**
-     * Calculates the fee for a given currency amount in Crowdinvesting (v5) or ContinuousFundraising (v4)
-     * @param _currencyAmount how much currency is raised
-     * @param _token the token that is sold through the crowdinvesting
-     * @return the fee
-     */
+    /// @dev V2 wrapper
+    function tokenFeeCollector(address _token) public view override(IFeeSettingsV2) returns (address) {
+        return feeCollector(FeeTypes.TOKEN_FEE, _token);
+    }
+
+    /// @dev V2 wrapper
     function crowdinvestingFee(
         uint256 _currencyAmount,
         address _token
     ) public view override(IFeeSettingsV2) returns (uint256) {
-        return
-            _customFee(
-                _currencyAmount,
-                fees[address(0)].crowdinvestingFeeNumerator,
-                fees[_token].crowdinvestingFeeNumerator,
-                fees[_token].validityDate
-            );
+        return fee(FeeTypes.CROWDINVESTING_FEE, _currencyAmount, _token);
     }
 
-    /**
-     * Calculates the fee for a given currency amount in PrivateOffer (v5) or PersonalInvite (v4)
-     * @param _currencyAmount how much currency is raised
-     * @return the fee
-     */
+    /// @dev V2 wrapper
+    function crowdinvestingFeeCollector(address _token) public view override(IFeeSettingsV2) returns (address) {
+        return feeCollector(FeeTypes.CROWDINVESTING_FEE, _token);
+    }
+
+    /// @dev V2 wrapper
     function privateOfferFee(
         uint256 _currencyAmount,
         address _token
     ) public view override(IFeeSettingsV2) returns (uint256) {
-        return
-            _customFee(
-                _currencyAmount,
-                fees[address(0)].privateOfferFeeNumerator,
-                fees[_token].privateOfferFeeNumerator,
-                fees[_token].validityDate
-            );
+        return fee(FeeTypes.PRIVATE_OFFER_FEE, _currencyAmount, _token);
+    }
+
+    /// @dev V2 wrapper
+    function privateOfferFeeCollector(address _token) public view override(IFeeSettingsV2) returns (address) {
+        return feeCollector(FeeTypes.PRIVATE_OFFER_FEE, _token);
+    }
+
+    // -------------------------------------------------------------------------
+    // IFeeSettingsV1 named accessors (backwards-compat, no token address needed)
+    // -------------------------------------------------------------------------
+
+    /**
+     * @notice Returns the default token fee collector.
+     * @dev V1 compat — V1 has no concept of per-token collectors, so we return the type default.
+     */
+    function feeCollector() external view override(IFeeSettingsV1) returns (address) {
+        return feeCollectors[FeeTypes.TOKEN_FEE][address(0)];
     }
 
     /**
+     * @notice Returns the fee for a given token amount.
+     * @dev V1 compat — caller is assumed to be the token contract.
+     */
+    function tokenFee(uint256 _tokenAmount) external view override(IFeeSettingsV1) returns (uint256) {
+        return tokenFee(_tokenAmount, _msgSender());
+    }
+
+    /// @dev V1 compat
+    function continuousFundraisingFee(
+        uint256 _currencyAmount
+    ) external view override(IFeeSettingsV1) returns (uint256) {
+        return crowdinvestingFee(_currencyAmount, address(0));
+    }
+
+    /// @dev V1 compat
+    function personalInviteFee(uint256 _currencyAmount) external view override(IFeeSettingsV1) returns (uint256) {
+        return privateOfferFee(_currencyAmount, address(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // Misc
+    // -------------------------------------------------------------------------
+
+    /**
      * @dev Specify where the implementation of owner() is located
-     * @return The owner of the contract
      */
     function owner() public view override(OwnableUpgradeable, IFeeSettingsV1, IFeeSettingsV2) returns (address) {
         return OwnableUpgradeable.owner();
@@ -489,56 +453,42 @@ contract FeeSettings is
     }
 
     /**
-     * @notice This contract implements the ERC165 interface in order to enable other contracts to query which interfaces this contract implements.
-     * @dev See https://eips.ethereum.org/EIPS/eip-165
-     * @return `true` for supported interfaces, otherwise `false`
+     * @notice ERC165 interface detection.
      */
     function supportsInterface(
         bytes4 interfaceId
-    ) public view virtual override(ERC165Upgradeable, IFeeSettingsV1, IFeeSettingsV2) returns (bool) {
+    ) public view virtual override(ERC165Upgradeable, IFeeSettingsV1, IFeeSettingsV2, IFeeSettingsV3) returns (bool) {
         return
-            interfaceId == type(IFeeSettingsV1).interfaceId || // we implement IFeeSettingsV1 for backwards compatibility
-            interfaceId == type(IFeeSettingsV2).interfaceId || // we implement IFeeSettingsV2
-            ERC165Upgradeable.supportsInterface(interfaceId); // default implementation that enables further querying
+            interfaceId == type(IFeeSettingsV1).interfaceId ||
+            interfaceId == type(IFeeSettingsV2).interfaceId ||
+            interfaceId == type(IFeeSettingsV3).interfaceId ||
+            ERC165Upgradeable.supportsInterface(interfaceId);
+    }
+
+    // -------------------------------------------------------------------------
+    // Internal fee math
+    // -------------------------------------------------------------------------
+
+    function _fee(uint256 amount, uint32 numerator) internal pure returns (uint256) {
+        return (amount * numerator) / FEE_DENOMINATOR;
     }
 
     /**
-     * @notice Returns the default token fee collector
-     * @dev this is a compatibility function for IFeeSettingsV1. It enables older token contracts to use the new fee settings contract.
-     * @dev as IFeeSettingsV1 only supports a single fee collector, we can not inquire the token address. Therefore, we return the default fee collector.
-     * @return The token fee collector
+     * Returns the lower of the default fee and the custom fee, if the custom fee is still valid.
+     * Custom fees can only discount, never increase.
      */
-    function feeCollector() external view override(IFeeSettingsV1) returns (address) {
-        return tokenFeeCollectors[address(0)];
-    }
-
-    /**
-     * @notice Returns the fee for a given token amount
-     * @dev Custom fees are only applied correctly when this function is called from the token contract itself.
-     * To calculate fees when calling from a different address, use `tokenFee(uint256, address)` instead.
-     */
-    function tokenFee(uint256 _tokenAmount) external view override(IFeeSettingsV1) returns (uint256) {
-        return tokenFee(_tokenAmount, _msgSender());
-    }
-
-    /**
-     * @notice calculate the fee for a given currency amount in Crowdinvesting (formerly ContinuousFundraising)
-     * @dev this is a compatibility function for IFeeSettingsV1. It enables older token contracts to use the new fee settings contract.
-     * @param _currencyAmount The amount of currency to calculate the fee for
-     */
-    function continuousFundraisingFee(
-        uint256 _currencyAmount
-    ) external view override(IFeeSettingsV1) returns (uint256) {
-        return crowdinvestingFee(_currencyAmount, address(0));
-    }
-
-    /**
-     * @notice calculate the fee for a given currency amount in PrivateOffer (formerly PersonalInvite)
-     * @dev this is a compatibility function for IFeeSettingsV1. It enables older token contracts to use the new fee settings contract.
-     * @param _currencyAmount The amount of currency to calculate the fee for
-     */
-    function personalInviteFee(uint256 _currencyAmount) external view override(IFeeSettingsV1) returns (uint256) {
-        return privateOfferFee(_currencyAmount, address(0));
+    function _applyCustomFee(
+        uint256 amount,
+        uint32 defaultNumerator,
+        uint32 customNumerator,
+        uint64 customValidityDate
+    ) internal view returns (uint256) {
+        if (customValidityDate < uint64(block.timestamp)) {
+            return _fee(amount, defaultNumerator);
+        }
+        uint256 defaultFee = _fee(amount, defaultNumerator);
+        uint256 customFee = _fee(amount, customNumerator);
+        return customFee < defaultFee ? customFee : defaultFee;
     }
 
     /**

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -47,13 +47,13 @@ contract FeeSettings is
      * @param feeType          bytes32 identifier (e.g. FeeTypes.TOKEN)
      * @param maxNumerator     Hard cap for this fee type
      * @param defaultNumerator Initial default numerator; must be <= maxNumerator
-     * @param collector        Default fee collector address for this type
+     * @param defaultCollector Default fee collector address for this type
      */
     struct FeeTypeInit {
         bytes32 feeType;
         uint32 maxNumerator;
         uint32 defaultNumerator;
-        address collector;
+        address defaultCollector;
     }
 
     /**
@@ -89,8 +89,8 @@ contract FeeSettings is
     /// per-token custom discounts:  feeType => token => discount
     mapping(bytes32 => mapping(address => CustomFee)) public customFees;
 
-    /// fee collectors:  feeType => token => collector  (address(0) key = default collector for that type)
-    mapping(bytes32 => mapping(address => address)) public feeCollectors;
+    /// per-token custom collectors:  feeType => token => collector  (address(0) key = default collector for that type)
+    mapping(bytes32 => mapping(address => address)) public collectors;
 
     /// pending default-fee changes:  feeType => proposal
     mapping(bytes32 => ProposedFeeChange) public proposedFeeChanges;
@@ -151,8 +151,8 @@ contract FeeSettings is
         for (uint256 i = 0; i < _feeTypes.length; i++) {
             FeeTypeInit memory feeType = _feeTypes[i];
             _registerFeeType(feeType.feeType, feeType.maxNumerator, feeType.defaultNumerator);
-            require(feeType.collector != address(0), "Fee collector cannot be 0x0");
-            feeCollectors[feeType.feeType][address(0)] = feeType.collector;
+            require(feeType.defaultCollector != address(0), "Fee collector cannot be 0x0");
+            collectors[feeType.feeType][address(0)] = feeType.defaultCollector;
         }
     }
 
@@ -289,7 +289,7 @@ contract FeeSettings is
     function setDefaultFeeCollector(bytes32 _feeType, address _collector) external onlyOwner {
         require(feeTypeConfigs[_feeType].maxNumerator > 0, "unknown fee type");
         require(_collector != address(0), "collector cannot be 0x0");
-        feeCollectors[_feeType][address(0)] = _collector;
+        collectors[_feeType][address(0)] = _collector;
         emit FeeCollectorSet(_feeType, address(0), _collector);
     }
 
@@ -303,7 +303,7 @@ contract FeeSettings is
         require(feeTypeConfigs[_feeType].maxNumerator > 0, "unknown fee type");
         require(_token != address(0), "token cannot be 0x0");
         require(_collector != address(0), "collector cannot be 0x0");
-        feeCollectors[_feeType][_token] = _collector;
+        collectors[_feeType][_token] = _collector;
         emit FeeCollectorSet(_feeType, _token, _collector);
     }
 
@@ -314,7 +314,7 @@ contract FeeSettings is
      */
     function removeCustomFeeCollector(bytes32 _feeType, address _token) external onlyManager {
         require(_token != address(0), "token cannot be 0x0");
-        delete feeCollectors[_feeType][_token];
+        delete collectors[_feeType][_token];
         emit FeeCollectorRemoved(_feeType, _token);
     }
 
@@ -347,9 +347,9 @@ contract FeeSettings is
      * @param _token   The token address
      */
     function feeCollector(bytes32 _feeType, address _token) public view override(IFeeSettingsV3) returns (address) {
-        address custom = feeCollectors[_feeType][_token];
+        address custom = collectors[_feeType][_token];
         if (custom != address(0)) return custom;
-        return feeCollectors[_feeType][address(0)];
+        return collectors[_feeType][address(0)];
     }
 
     /**
@@ -410,7 +410,7 @@ contract FeeSettings is
      * @dev V1 compat — V1 has no concept of per-token collectors, so we return the type default.
      */
     function feeCollector() external view override(IFeeSettingsV1) returns (address) {
-        return feeCollectors[FeeTypes.TOKEN][address(0)];
+        return collectors[FeeTypes.TOKEN][address(0)];
     }
 
     /**

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -160,9 +160,17 @@ contract FeeSettings is
         require(_fees.privateOfferFeeNumerator <= MAX_PRIVATE_OFFER_FEE_NUMERATOR, "PrivateOffer fee must be <= 5%");
 
         _registerFeeType(FeeTypes.TOKEN_FEE, MAX_TOKEN_FEE_NUMERATOR, _fees.tokenFeeNumerator);
-        _registerFeeType(FeeTypes.CROWDINVESTING_FEE, MAX_CROWDINVESTING_FEE_NUMERATOR, _fees.crowdinvestingFeeNumerator);
+        _registerFeeType(
+            FeeTypes.CROWDINVESTING_FEE,
+            MAX_CROWDINVESTING_FEE_NUMERATOR,
+            _fees.crowdinvestingFeeNumerator
+        );
         _registerFeeType(FeeTypes.PRIVATE_OFFER_FEE, MAX_PRIVATE_OFFER_FEE_NUMERATOR, _fees.privateOfferFeeNumerator);
-        _registerFeeType(FeeTypes.SECONDARY_MARKET_FEE, MAX_PRIVATE_OFFER_FEE_NUMERATOR, _fees.privateOfferFeeNumerator);
+        _registerFeeType(
+            FeeTypes.SECONDARY_MARKET_FEE,
+            MAX_PRIVATE_OFFER_FEE_NUMERATOR,
+            _fees.privateOfferFeeNumerator
+        );
 
         require(_tokenFeeCollector != address(0), "Fee collector cannot be 0x0");
         feeCollectors[FeeTypes.TOKEN_FEE][address(0)] = _tokenFeeCollector;

--- a/contracts/TokenSwapBase.sol
+++ b/contracts/TokenSwapBase.sol
@@ -104,15 +104,25 @@ abstract contract TokenSwapBase is
 
     /**
      * @notice Retrieves the fee amount and the fee receiver for a token swap transaction.
+     * @dev Uses IFeeSettingsV3.fee(FeeTypes.SECONDARY_MARKET_FEE, ...) when the fee settings
+     *      contract supports V3; falls back to privateOfferFee for V2-only deployments.
      * @param _currencyAmount The total currency amount involved in the swap transaction, in bits (smallest subunit of currency)
-     * @return fee The fee amount to be collected, in bits (smallest subunit of currency)
-     * @return feeCollector The address that will receive the collected fees
+     * @return The fee amount to be collected, in bits (smallest subunit of currency)
+     * @return The address that will receive the collected fees
      */
     function _getFeeAndFeeReceiver(uint256 _currencyAmount) internal view returns (uint256, address) {
-        IFeeSettingsV2 feeSettings = token.feeSettings();
+        IFeeSettingsV2 feeSettingsV2 = token.feeSettings();
+        if (feeSettingsV2.supportsInterface(type(IFeeSettingsV3).interfaceId)) {
+            IFeeSettingsV3 feeSettingsV3 = IFeeSettingsV3(address(feeSettingsV2));
+            return (
+                feeSettingsV3.fee(FeeTypes.SECONDARY_MARKET_FEE, _currencyAmount, address(token)),
+                feeSettingsV3.feeCollector(FeeTypes.SECONDARY_MARKET_FEE, address(token))
+            );
+        }
+        // V2 fallback: use privateOfferFee until the fee settings contract is upgraded
         return (
-            feeSettings.privateOfferFee(_currencyAmount, address(token)),
-            feeSettings.privateOfferFeeCollector(address(token))
+            feeSettingsV2.privateOfferFee(_currencyAmount, address(token)),
+            feeSettingsV2.privateOfferFeeCollector(address(token))
         );
     }
 

--- a/contracts/TokenSwapBase.sol
+++ b/contracts/TokenSwapBase.sol
@@ -104,7 +104,7 @@ abstract contract TokenSwapBase is
 
     /**
      * @notice Retrieves the fee amount and the fee receiver for a token swap transaction.
-     * @dev Uses IFeeSettingsV3.fee(FeeTypes.SECONDARY_MARKET_FEE, ...) when the fee settings
+     * @dev Uses IFeeSettingsV3.fee(FeeTypes.SECONDARY_MARKET, ...) when the fee settings
      *      contract supports V3; falls back to privateOfferFee for V2-only deployments.
      * @param _currencyAmount The total currency amount involved in the swap transaction, in bits (smallest subunit of currency)
      * @return The fee amount to be collected, in bits (smallest subunit of currency)
@@ -115,8 +115,8 @@ abstract contract TokenSwapBase is
         if (feeSettingsV2.supportsInterface(type(IFeeSettingsV3).interfaceId)) {
             IFeeSettingsV3 feeSettingsV3 = IFeeSettingsV3(address(feeSettingsV2));
             return (
-                feeSettingsV3.fee(FeeTypes.SECONDARY_MARKET_FEE, _currencyAmount, address(token)),
-                feeSettingsV3.feeCollector(FeeTypes.SECONDARY_MARKET_FEE, address(token))
+                feeSettingsV3.fee(FeeTypes.SECONDARY_MARKET, _currencyAmount, address(token)),
+                feeSettingsV3.feeCollector(FeeTypes.SECONDARY_MARKET, address(token))
             );
         }
         // V2 fallback: use privateOfferFee until the fee settings contract is upgraded

--- a/contracts/factories/FeeSettingsCloneFactory.sol
+++ b/contracts/factories/FeeSettingsCloneFactory.sol
@@ -18,43 +18,23 @@ contract FeeSettingsCloneFactory is CloneFactory {
      * @param _rawSalt this value influences the address of the clone, but not the initialization
      * @param _trustedForwarder the trusted forwarder (ERC2771) can not be changed, but is checked for security
      * @param _owner address that will own the new clone
-     * @param _fees struct that contains the fee schedule for the clone
-     * @param _tokenFeeCollector address that will receive the fees for token creation
-     * @param _crowdinvestingFeeCollector address that will receive the fees for crowdinvesting
-     * @param _privateOfferFeeCollector address that will receive the fees for private offers
+     * @param _feeTypes array of fee type configurations to register on deployment
      * @return address of the new clone
      */
     function createFeeSettingsClone(
         bytes32 _rawSalt,
         address _trustedForwarder,
         address _owner,
-        Fees memory _fees,
-        address _tokenFeeCollector,
-        address _crowdinvestingFeeCollector,
-        address _privateOfferFeeCollector
+        FeeSettings.FeeTypeInit[] memory _feeTypes
     ) external returns (address) {
-        bytes32 salt = _generateSalt(
-            _rawSalt,
-            _trustedForwarder,
-            _owner,
-            _fees,
-            _tokenFeeCollector,
-            _crowdinvestingFeeCollector,
-            _privateOfferFeeCollector
-        );
+        bytes32 salt = _generateSalt(_rawSalt, _trustedForwarder, _owner, _feeTypes);
         address clone = Clones.cloneDeterministic(implementation, salt);
         FeeSettings cloneFeeSettings = FeeSettings(clone);
         require(
             cloneFeeSettings.isTrustedForwarder(_trustedForwarder),
             "FeeSettingsCloneFactory: Unexpected trustedForwarder"
         );
-        cloneFeeSettings.initialize(
-            _owner,
-            _fees,
-            _tokenFeeCollector,
-            _crowdinvestingFeeCollector,
-            _privateOfferFeeCollector
-        );
+        cloneFeeSettings.initialize(_owner, _feeTypes);
         emit NewClone(clone);
         return clone;
     }
@@ -64,64 +44,28 @@ contract FeeSettingsCloneFactory is CloneFactory {
      * @param _rawSalt this value influences the address of the clone, but not the initialization
      * @param _trustedForwarder the trusted forwarder (ERC2771) can not be changed, but is checked for security
      * @param _owner address that will own the new clone
-     * @param _fees struct that contains the fee schedule for the clone
-     * @param _tokenFeeCollector address that will receive the fees for token creation
-     * @param _crowdinvestingFeeCollector address that will receive the fees for crowdinvesting
-     * @param _privateOfferFeeCollector address that will receive the fees for private offers
+     * @param _feeTypes array of fee type configurations to register on deployment
      * @return address of the new clone
      */
     function predictCloneAddress(
         bytes32 _rawSalt,
         address _trustedForwarder,
         address _owner,
-        Fees memory _fees,
-        address _tokenFeeCollector,
-        address _crowdinvestingFeeCollector,
-        address _privateOfferFeeCollector
+        FeeSettings.FeeTypeInit[] memory _feeTypes
     ) external view returns (address) {
-        bytes32 salt = _generateSalt(
-            _rawSalt,
-            _trustedForwarder,
-            _owner,
-            _fees,
-            _tokenFeeCollector,
-            _crowdinvestingFeeCollector,
-            _privateOfferFeeCollector
-        );
+        bytes32 salt = _generateSalt(_rawSalt, _trustedForwarder, _owner, _feeTypes);
         return Clones.predictDeterministicAddress(implementation, salt);
     }
 
     /**
      * Generate a single salt from all input parameters
-     * @param _rawSalt this value influences the address of the clone, but not the initialization
-     * @param _trustedForwarder the trusted forwarder (ERC2771) can not be changed, but is checked for security
-     * @param _owner address that will own the new clone
-     * @param _fees struct that contains the fee schedule for the clone
-     * @param _tokenFeeCollector address that will receive the fees for token creation
-     * @param _crowdinvestingFeeCollector address that will receive the fees for crowdinvesting
-     * @param _privateOfferFeeCollector address that will receive the fees for private offers
-     * @return salt
      */
     function _generateSalt(
         bytes32 _rawSalt,
         address _trustedForwarder,
         address _owner,
-        Fees memory _fees,
-        address _tokenFeeCollector,
-        address _crowdinvestingFeeCollector,
-        address _privateOfferFeeCollector
+        FeeSettings.FeeTypeInit[] memory _feeTypes
     ) internal pure returns (bytes32) {
-        return
-            keccak256(
-                abi.encode(
-                    _rawSalt,
-                    _trustedForwarder,
-                    _owner,
-                    _fees,
-                    _tokenFeeCollector,
-                    _crowdinvestingFeeCollector,
-                    _privateOfferFeeCollector
-                )
-            );
+        return keccak256(abi.encode(_rawSalt, _trustedForwarder, _owner, _feeTypes));
     }
 }

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -69,12 +69,12 @@ struct Fees {
  *      in every consuming contract.
  */
 library FeeTypes {
-    bytes32 internal constant TOKEN_FEE = keccak256("TOKEN_FEE");
-    bytes32 internal constant CROWDINVESTING_FEE = keccak256("CROWDINVESTING_FEE");
-    bytes32 internal constant PRIVATE_OFFER_FEE = keccak256("PRIVATE_OFFER_FEE");
-    bytes32 internal constant SECONDARY_MARKET_FEE = keccak256("SECONDARY_MARKET_FEE");
-    bytes32 internal constant DISTRIBUTION_FEE = keccak256("DISTRIBUTION_FEE");
-    bytes32 internal constant EXIT_FEE = keccak256("EXIT_FEE");
+    bytes32 internal constant TOKEN = keccak256("TOKEN");
+    bytes32 internal constant CROWDINVESTING = keccak256("CROWDINVESTING");
+    bytes32 internal constant PRIVATE_OFFER = keccak256("PRIVATE_OFFER");
+    bytes32 internal constant SECONDARY_MARKET = keccak256("SECONDARY_MARKET");
+    bytes32 internal constant DISTRIBUTION = keccak256("DISTRIBUTION");
+    bytes32 internal constant EXIT = keccak256("EXIT");
 }
 
 /**

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -73,6 +73,8 @@ library FeeTypes {
     bytes32 internal constant CROWDINVESTING_FEE = keccak256("CROWDINVESTING_FEE");
     bytes32 internal constant PRIVATE_OFFER_FEE = keccak256("PRIVATE_OFFER_FEE");
     bytes32 internal constant SECONDARY_MARKET_FEE = keccak256("SECONDARY_MARKET_FEE");
+    bytes32 internal constant DISTRIBUTION_FEE = keccak256("DISTRIBUTION_FEE");
+    bytes32 internal constant EXIT_FEE = keccak256("EXIT_FEE");
 }
 
 /**

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -49,21 +49,6 @@ interface IFeeSettingsV2 {
 }
 
 /**
- * @notice The Fees struct contains all the parameters to change fee quantities and fee collector addresses,
- * as well as the time when the new settings can be activated.
- * @dev time has different meanings:
- *  1. it is ignored when the struct is used during initialization.
- *  2. it is the time when the new settings can be activated when the struct is used during a fee change.
- *  3. it is the time up to which the settings are valid when the struct is used for fee discounts for specific customers
- */
-struct Fees {
-    uint32 tokenFeeNumerator;
-    uint32 crowdinvestingFeeNumerator;
-    uint32 privateOfferFeeNumerator;
-    uint64 validityDate;
-}
-
-/**
  * @notice Central registry of well-known fee type identifiers.
  *      Import this library alongside IFeeSettingsV3 to avoid re-declaring the same keccak constants
  *      in every consuming contract.

--- a/contracts/interfaces/IFeeSettings.sol
+++ b/contracts/interfaces/IFeeSettings.sol
@@ -62,3 +62,42 @@ struct Fees {
     uint32 privateOfferFeeNumerator;
     uint64 validityDate;
 }
+
+/**
+ * @notice Central registry of well-known fee type identifiers.
+ *      Import this library alongside IFeeSettingsV3 to avoid re-declaring the same keccak constants
+ *      in every consuming contract.
+ */
+library FeeTypes {
+    bytes32 internal constant TOKEN_FEE = keccak256("TOKEN_FEE");
+    bytes32 internal constant CROWDINVESTING_FEE = keccak256("CROWDINVESTING_FEE");
+    bytes32 internal constant PRIVATE_OFFER_FEE = keccak256("PRIVATE_OFFER_FEE");
+    bytes32 internal constant SECONDARY_MARKET_FEE = keccak256("SECONDARY_MARKET_FEE");
+}
+
+/**
+ * @title IFeeSettingsV3
+ * @author malteish
+ * @notice Generic, extendable fee interface.
+ */
+interface IFeeSettingsV3 {
+    /**
+     * @notice Calculates the fee for a given amount and fee type.
+     * @param feeType  bytes32 key identifying the fee type (use FeeTypes library constants)
+     * @param amount   The base amount to calculate the fee on
+     * @param token    The token address — used to look up any custom discount for that token
+     * @return         The fee amount
+     */
+    function fee(bytes32 feeType, uint256 amount, address token) external view returns (uint256);
+
+    /**
+     * @notice Returns the fee collector for a given fee type and token.
+     *      Falls back to the default collector for that fee type if no custom one is set.
+     * @param feeType  bytes32 key identifying the fee type
+     * @param token    The token address
+     * @return         The fee collector address
+     */
+    function feeCollector(bytes32 feeType, address token) external view returns (address);
+
+    function supportsInterface(bytes4) external view returns (bool);
+}

--- a/docs/bestpractices.md
+++ b/docs/bestpractices.md
@@ -9,7 +9,7 @@
 
 ### Naming
 
-- Constants: `ALL_CAPS_WITH_UNDERSCORES` (e.g., `MAX_TOKEN_FEE_NUMERATOR`, `MINTALLOWER_ROLE`)
+- Constants: `ALL_CAPS_WITH_UNDERSCORES` (e.g., `MAX_TOKEN_NUMERATOR`, `MINTALLOWER_ROLE`)
 - Events: PascalCase (e.g., `RequirementsChanged`)
 - Public state variables: camelCase (e.g., `allowList`, `mintingAllowance`)
 - Private/internal state variables: `_prefixedCamelCase`

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -221,8 +221,8 @@ The following statements about the smart contracts should always be true
 - As long as an allowance remains, the limit order can be executed repeatedly.
 - The maximum amount of tokens to buy or sell is determined by the allowance granted.
 - Fees are deducted from the currency transferred during the swap.
-- Fee amount is determined by the token's fee settings' CrowdinvestingFee.
-- Fee receiver is determined by the token's fee settings' CrowdinvestingFeeCollector.
+- Fee amount is determined by the token's fee settings' SecondaryMarketFee (FeeSettingsV3) or PrivateOfferFee (FeeSettingsV2 fallback).
+- Fee receiver is determined by the token's fee settings' SecondaryMarketFeeCollector (FeeSettingsV3) or PrivateOfferFeeCollector (FeeSettingsV2 fallback).
 - No fees are deducted from the tokens transferred during the swap.
 - The buyer calling the buy function will pay no more than maxCurrencyAmount, protecting them from frontrunning or other unexpected influences.
 - The seller calling the sell function will receive no less than minCurrencyAmount, protecting them from frontrunning or other unexpected influences.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -221,8 +221,8 @@ The following statements about the smart contracts should always be true
 - As long as an allowance remains, the limit order can be executed repeatedly.
 - The maximum amount of tokens to buy or sell is determined by the allowance granted.
 - Fees are deducted from the currency transferred during the swap.
-- Fee amount is determined by the token's fee settings' SecondaryMarketFee (FeeSettingsV3) or PrivateOfferFee (FeeSettingsV2 fallback).
-- Fee receiver is determined by the token's fee settings' SecondaryMarketFeeCollector (FeeSettingsV3) or PrivateOfferFeeCollector (FeeSettingsV2 fallback).
+- Fee amount is determined by the token's fee settings' CrowdinvestingFee.
+- Fee receiver is determined by the token's fee settings' CrowdinvestingFeeCollector.
 - No fees are deducted from the tokens transferred during the swap.
 - The buyer calling the buy function will pay no more than maxCurrencyAmount, protecting them from frontrunning or other unexpected influences.
 - The seller calling the sell function will receive no less than minCurrencyAmount, protecting them from frontrunning or other unexpected influences.

--- a/script/DeployTokenFromScratch.s.sol
+++ b/script/DeployTokenFromScratch.s.sol
@@ -8,6 +8,7 @@ import "../contracts/factories/FeeSettingsCloneFactory.sol";
 import "../contracts/factories/AllowListCloneFactory.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
+import "../contracts/interfaces/IFeeSettings.sol";
 
 contract DeployPlatform is Script {
     function setUp() public {}
@@ -45,16 +46,17 @@ contract DeployPlatform is Script {
         console.log("FeeSettingsCloneFactory deployed at: ", address(feeSettingsCloneFactory));
 
         console.log("Deploying FeeSettings contract...");
-        Fees memory fees = Fees(100, 100, 100, 0);
+        FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 100, platformColdWallet);
+        feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 100, platformColdWallet);
+        feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 100, platformColdWallet);
+        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, platformColdWallet);
         FeeSettings feeSettings = FeeSettings(
             feeSettingsCloneFactory.createFeeSettingsClone(
                 bytes32(0),
                 trustedForwarder,
                 platformAdminWallet,
-                fees,
-                platformColdWallet,
-                platformColdWallet,
-                platformColdWallet
+                feeTypes
             )
         );
         console.log("FeeSettings deployed at: ", address(feeSettings));

--- a/script/DeployTokenFromScratch.s.sol
+++ b/script/DeployTokenFromScratch.s.sol
@@ -47,17 +47,12 @@ contract DeployPlatform is Script {
 
         console.log("Deploying FeeSettings contract...");
         FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
-        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 100, platformColdWallet);
-        feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 100, platformColdWallet);
-        feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 100, platformColdWallet);
-        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, platformColdWallet);
+        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, 100, platformColdWallet);
+        feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, 100, platformColdWallet);
+        feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, 100, platformColdWallet);
+        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, 0, platformColdWallet);
         FeeSettings feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                bytes32(0),
-                trustedForwarder,
-                platformAdminWallet,
-                feeTypes
-            )
+            feeSettingsCloneFactory.createFeeSettingsClone(bytes32(0), trustedForwarder, platformAdminWallet, feeTypes)
         );
         console.log("FeeSettings deployed at: ", address(feeSettings));
         feeSettings.transferOwnership(platformColdWallet);

--- a/test/CoinvestedPosition.t.sol
+++ b/test/CoinvestedPosition.t.sol
@@ -54,8 +54,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
     function setUp() public {
         // Infrastructure
         allowList = createAllowList(trustedForwarder, admin);
-        Fees memory zeroFees = Fees(0, 0, 0, 0);
-        feeSettings = createFeeSettings(trustedForwarder, admin, zeroFees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
 
         // EURc (6 dec) and EURe (18 dec)
         eurc = new FakePaymentToken(0, 6);
@@ -572,15 +571,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
 
     function testBuyNonZeroFeeDeductedBeforeCarry() public {
         // Deploy with non-zero fee
-        Fees memory fees = Fees(0, 0, 100, 0); // 1% private offer fee (bps = 100)
-        IFeeSettingsV2 feeSettings100 = createFeeSettings(
-            trustedForwarder,
-            admin,
-            fees,
-            feeCollector,
-            feeCollector,
-            feeCollector
-        );
+        IFeeSettingsV2 feeSettings100 = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 100, feeCollector, feeCollector, feeCollector));
         // Deploy new token with this fee settings
         Token tokenWithFee = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings100, admin, allowList, 0, "FeeToken", "FTK")
@@ -636,15 +627,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         // basePrice=100e6, tokenPrice=104e6, 1 token → paid=104e6
         // Without fee, carry would be 4e6.
         // With 5% fee (max allowed): fee=5.2e6, remaining=98.8e6 < basePayout=100e6 → carry=0
-        Fees memory fees = Fees(0, 0, 500, 0); // 5% private offer fee (max allowed)
-        IFeeSettingsV2 feeSettings10 = createFeeSettings(
-            trustedForwarder,
-            admin,
-            fees,
-            feeCollector,
-            feeCollector,
-            feeCollector
-        );
+        IFeeSettingsV2 feeSettings10 = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 500, feeCollector, feeCollector, feeCollector));
         Token tokenHighFee = Token(
             tokenFactory.createTokenProxy(
                 0,

--- a/test/CoinvestedPosition.t.sol
+++ b/test/CoinvestedPosition.t.sol
@@ -571,7 +571,11 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
 
     function testBuyNonZeroFeeDeductedBeforeCarry() public {
         // Deploy with non-zero fee
-        IFeeSettingsV2 feeSettings100 = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 100, feeCollector, feeCollector, feeCollector));
+        IFeeSettingsV2 feeSettings100 = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 100, feeCollector, feeCollector, feeCollector)
+        );
         // Deploy new token with this fee settings
         Token tokenWithFee = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings100, admin, allowList, 0, "FeeToken", "FTK")
@@ -627,7 +631,11 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         // basePrice=100e6, tokenPrice=104e6, 1 token → paid=104e6
         // Without fee, carry would be 4e6.
         // With 5% fee (max allowed): fee=5.2e6, remaining=98.8e6 < basePayout=100e6 → carry=0
-        IFeeSettingsV2 feeSettings10 = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 500, feeCollector, feeCollector, feeCollector));
+        IFeeSettingsV2 feeSettings10 = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 500, feeCollector, feeCollector, feeCollector)
+        );
         Token tokenHighFee = Token(
             tokenFactory.createTokenProxy(
                 0,

--- a/test/CoinvestedPositionCloneFactory.t.sol
+++ b/test/CoinvestedPositionCloneFactory.t.sol
@@ -33,8 +33,7 @@ contract CoinvestedPositionCloneFactoryTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        Fees memory fees = Fees(0, 0, 0, 0);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, fees, admin, admin, admin);
+        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "CPToken", "CPT")
         );

--- a/test/CoinvestedPositionCloneFactory.t.sol
+++ b/test/CoinvestedPositionCloneFactory.t.sol
@@ -33,7 +33,11 @@ contract CoinvestedPositionCloneFactoryTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
+        IFeeSettingsV2 feeSettings = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 0, admin, admin, admin)
+        );
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "CPToken", "CPT")
         );

--- a/test/CoinvestedPositionDistribution.t.sol
+++ b/test/CoinvestedPositionDistribution.t.sol
@@ -101,8 +101,7 @@ contract CoinvestedPositionDistributionTest is Test {
 
         // Infrastructure
         allowList = createAllowList(trustedForwarder, admin);
-        Fees memory zeroFees = Fees(0, 0, 0, 0);
-        feeSettings = createFeeSettings(trustedForwarder, admin, zeroFees, feeCollector, feeCollector, feeCollector);
+        feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, feeCollector, feeCollector, feeCollector));
 
         // Currencies
         eurc = new FakePaymentToken(0, 6);

--- a/test/CoinvestedPositionDistribution.t.sol
+++ b/test/CoinvestedPositionDistribution.t.sol
@@ -101,7 +101,11 @@ contract CoinvestedPositionDistributionTest is Test {
 
         // Infrastructure
         allowList = createAllowList(trustedForwarder, admin);
-        feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, feeCollector, feeCollector, feeCollector));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 0, feeCollector, feeCollector, feeCollector)
+        );
 
         // Currencies
         eurc = new FakePaymentToken(0, 6);

--- a/test/CoinvestedPositionERC2771.t.sol
+++ b/test/CoinvestedPositionERC2771.t.sol
@@ -21,8 +21,7 @@ contract CoinvestedPositionERC2771Test is CoinvestedPositionTestBase {
         buyer = vm.addr(buyerPrivateKey);
 
         allowList = createAllowList(trustedForwarder, admin);
-        Fees memory zeroFees = Fees(0, 0, 0, 0);
-        feeSettings = createFeeSettings(trustedForwarder, admin, zeroFees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
 
         eurc = new FakePaymentToken(0, 6);
         vm.prank(admin);

--- a/test/CoinvestedPositionExit.t.sol
+++ b/test/CoinvestedPositionExit.t.sol
@@ -80,7 +80,11 @@ contract CoinvestedPositionExitTest is Test {
 
         // Infrastructure
         allowList = createAllowList(trustedForwarder, admin);
-        feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, feeCollector, feeCollector, feeCollector));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 0, feeCollector, feeCollector, feeCollector)
+        );
 
         // Currencies
         eurc = new FakePaymentToken(0, 6);
@@ -577,7 +581,11 @@ contract CoinvestedPositionExitTest is Test {
     /// @dev Deploys a Token with 0.1% fee setting + a CoinvestedPosition for it,
     ///      mints CP_TOKEN_AMOUNT tokens to that coinvestedPosition, returns (token, cp).
     function _deployFeeTokenAndCp() internal returns (Token, CoinvestedPosition) {
-        IFeeSettingsV2 fsWithFee = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 10, 0, feeCollector, feeCollector, feeCollector));
+        IFeeSettingsV2 fsWithFee = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 10, 0, feeCollector, feeCollector, feeCollector)
+        );
         Token tokenWithFee = Token(
             tokenFactory.createTokenProxy(
                 bytes32("fee_token"),

--- a/test/CoinvestedPositionExit.t.sol
+++ b/test/CoinvestedPositionExit.t.sol
@@ -80,8 +80,7 @@ contract CoinvestedPositionExitTest is Test {
 
         // Infrastructure
         allowList = createAllowList(trustedForwarder, admin);
-        Fees memory zeroFees = Fees(0, 0, 0, 0);
-        feeSettings = createFeeSettings(trustedForwarder, admin, zeroFees, feeCollector, feeCollector, feeCollector);
+        feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, feeCollector, feeCollector, feeCollector));
 
         // Currencies
         eurc = new FakePaymentToken(0, 6);
@@ -578,15 +577,7 @@ contract CoinvestedPositionExitTest is Test {
     /// @dev Deploys a Token with 0.1% fee setting + a CoinvestedPosition for it,
     ///      mints CP_TOKEN_AMOUNT tokens to that coinvestedPosition, returns (token, cp).
     function _deployFeeTokenAndCp() internal returns (Token, CoinvestedPosition) {
-        Fees memory nonZeroFees = Fees(0, 10, 0, 0); // 0.1% crowdinvesting fee (10/10000)
-        IFeeSettingsV2 fsWithFee = createFeeSettings(
-            trustedForwarder,
-            admin,
-            nonZeroFees,
-            feeCollector,
-            feeCollector,
-            feeCollector
-        );
+        IFeeSettingsV2 fsWithFee = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 10, 0, feeCollector, feeCollector, feeCollector));
         Token tokenWithFee = Token(
             tokenFactory.createTokenProxy(
                 bytes32("fee_token"),

--- a/test/CrowdinvestingCloneFactory.t.sol
+++ b/test/CrowdinvestingCloneFactory.t.sol
@@ -6,6 +6,7 @@ import "../lib/forge-std/src/console.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/factories/FeeSettingsCloneFactory.sol";
+import "../contracts/interfaces/IFeeSettings.sol";
 import "./resources/ERC2771Helper.sol";
 import "./resources/CloneCreators.sol";
 
@@ -52,22 +53,25 @@ contract CrowdinvestingCloneFactoryTest is Test {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = createAllowList(trustedForwarder, feeSettingsAndAllowListOwner);
 
-        Fees memory fees = Fees(100, 100, 100, 0);
         FeeSettings feeSettingsLogicContract = new FeeSettings(trustedForwarder);
         FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(
             address(feeSettingsLogicContract)
         );
-        feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                0,
-                trustedForwarder,
-                feeSettingsAndAllowListOwner,
-                fees,
-                feeSettingsAndAllowListOwner,
-                feeSettingsAndAllowListOwner,
-                feeSettingsAndAllowListOwner
-            )
-        );
+        {
+            FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+            feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 100, feeSettingsAndAllowListOwner);
+            feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 100, feeSettingsAndAllowListOwner);
+            feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 100, feeSettingsAndAllowListOwner);
+            feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, feeSettingsAndAllowListOwner);
+            feeSettings = FeeSettings(
+                feeSettingsCloneFactory.createFeeSettingsClone(
+                    0,
+                    trustedForwarder,
+                    feeSettingsAndAllowListOwner,
+                    feeTypes
+                )
+            );
+        }
         vm.stopPrank();
 
         vm.prank(feeSettingsAndAllowListOwner);

--- a/test/CrowdinvestingCloneFactory.t.sol
+++ b/test/CrowdinvestingCloneFactory.t.sol
@@ -59,10 +59,10 @@ contract CrowdinvestingCloneFactoryTest is Test {
         );
         {
             FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
-            feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 100, feeSettingsAndAllowListOwner);
-            feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 100, feeSettingsAndAllowListOwner);
-            feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 100, feeSettingsAndAllowListOwner);
-            feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, feeSettingsAndAllowListOwner);
+            feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, 100, feeSettingsAndAllowListOwner);
+            feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, 100, feeSettingsAndAllowListOwner);
+            feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, 100, feeSettingsAndAllowListOwner);
+            feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, 0, feeSettingsAndAllowListOwner);
             feeSettings = FeeSettings(
                 feeSettingsCloneFactory.createFeeSettingsClone(
                     0,

--- a/test/CrowdinvestingDynamicPricing.t.sol
+++ b/test/CrowdinvestingDynamicPricing.t.sol
@@ -101,10 +101,10 @@ contract CrowdinvestingDynamicPricingTest is Test {
         FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(address(feeLogic));
         {
             FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
-            feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 100, platformAdmin);
-            feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 100, platformAdmin);
-            feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 100, platformAdmin);
-            feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, platformAdmin);
+            feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, 100, platformAdmin);
+            feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, 100, platformAdmin);
+            feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, 100, platformAdmin);
+            feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, 0, platformAdmin);
             feeSettings = IFeeSettingsV2(
                 feeSettingsCloneFactory.createFeeSettingsClone(0, trustedForwarder, platformAdmin, feeTypes)
             );

--- a/test/CrowdinvestingDynamicPricing.t.sol
+++ b/test/CrowdinvestingDynamicPricing.t.sol
@@ -7,6 +7,7 @@ import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/factories/FeeSettingsCloneFactory.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "../contracts/factories/PriceLinearCloneFactory.sol";
+import "../contracts/interfaces/IFeeSettings.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/MaliciousPaymentToken.sol";
 import "./resources/CloneCreators.sol";
@@ -96,20 +97,18 @@ contract CrowdinvestingDynamicPricingTest is Test {
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
         vm.startPrank(platformAdmin);
-        Fees memory fees = Fees(100, 100, 100, 100);
         FeeSettings feeLogic = new FeeSettings(trustedForwarder);
         FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(address(feeLogic));
-        feeSettings = IFeeSettingsV2(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                0,
-                trustedForwarder,
-                platformAdmin,
-                fees,
-                platformAdmin,
-                platformAdmin,
-                platformAdmin
-            )
-        );
+        {
+            FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+            feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 100, platformAdmin);
+            feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 100, platformAdmin);
+            feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 100, platformAdmin);
+            feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, platformAdmin);
+            feeSettings = IFeeSettingsV2(
+                feeSettingsCloneFactory.createFeeSettingsClone(0, trustedForwarder, platformAdmin, feeTypes)
+            );
+        }
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/CrowdinvestingERC2771.t.sol
+++ b/test/CrowdinvestingERC2771.t.sol
@@ -68,7 +68,11 @@ contract CrowdinvestingTest is Test {
         vm.prank(owner);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(tokenFeeNumerator, paymentTokenFeeNumerator, paymentTokenFeeNumerator, admin, admin, admin));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(tokenFeeNumerator, paymentTokenFeeNumerator, paymentTokenFeeNumerator, admin, admin, admin)
+        );
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenFactory = new TokenProxyFactory(address(implementation));

--- a/test/CrowdinvestingERC2771.t.sol
+++ b/test/CrowdinvestingERC2771.t.sol
@@ -68,8 +68,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(owner);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        Fees memory fees = Fees(tokenFeeNumerator, paymentTokenFeeNumerator, paymentTokenFeeNumerator, 0);
-        feeSettings = createFeeSettings(trustedForwarder, address(this), fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(tokenFeeNumerator, paymentTokenFeeNumerator, paymentTokenFeeNumerator, admin, admin, admin));
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenFactory = new TokenProxyFactory(address(implementation));

--- a/test/CrowdinvestingERC677.t.sol
+++ b/test/CrowdinvestingERC677.t.sol
@@ -62,7 +62,11 @@ contract CrowdinvestingTest is Test {
         vm.prank(owner);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver)
+        );
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/CrowdinvestingERC677.t.sol
+++ b/test/CrowdinvestingERC677.t.sol
@@ -62,15 +62,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(owner);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        Fees memory fees = Fees(100, 100, 100, 100);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            fees,
-            wrongFeeReceiver,
-            admin,
-            wrongFeeReceiver
-        );
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver));
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/CrowdinvestingIntegration.t.sol
+++ b/test/CrowdinvestingIntegration.t.sol
@@ -115,17 +115,20 @@ contract CrowdinvestingTest is Test {
     */
     function feeCalculation(uint32 tokenFeeNumerator, uint32 crowdinvestingFeeNumerator) public {
         // apply fees for test
-        Fees memory fees = Fees(
-            tokenFeeNumerator,
-            crowdinvestingFeeNumerator,
-            crowdinvestingFeeNumerator,
-            uint64(block.timestamp + 13 weeks)
-        );
+        uint64 activationDate = uint64(block.timestamp + 13 weeks);
         vm.prank(platformAdmin);
-        feeSettings.planFeeChange(fees);
-        vm.warp(fees.validityDate + 1 seconds);
+        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, tokenFeeNumerator, activationDate);
         vm.prank(platformAdmin);
-        feeSettings.executeFeeChange();
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, crowdinvestingFeeNumerator, activationDate);
+        vm.prank(platformAdmin);
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, crowdinvestingFeeNumerator, activationDate);
+        vm.warp(activationDate + 1 seconds);
+        vm.prank(platformAdmin);
+        feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+        vm.prank(platformAdmin);
+        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+        vm.prank(platformAdmin);
+        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
 
         uint8 _paymentTokenDecimals = 6;
         // uint8 _maxDecimals = 25;

--- a/test/CrowdinvestingIntegration.t.sol
+++ b/test/CrowdinvestingIntegration.t.sol
@@ -117,18 +117,18 @@ contract CrowdinvestingTest is Test {
         // apply fees for test
         uint64 activationDate = uint64(block.timestamp + 13 weeks);
         vm.prank(platformAdmin);
-        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, tokenFeeNumerator, activationDate);
+        feeSettings.planFeeChange(FeeTypes.TOKEN, tokenFeeNumerator, activationDate);
         vm.prank(platformAdmin);
-        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, crowdinvestingFeeNumerator, activationDate);
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, crowdinvestingFeeNumerator, activationDate);
         vm.prank(platformAdmin);
-        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, crowdinvestingFeeNumerator, activationDate);
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, crowdinvestingFeeNumerator, activationDate);
         vm.warp(activationDate + 1 seconds);
         vm.prank(platformAdmin);
-        feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+        feeSettings.executeFeeChange(FeeTypes.TOKEN);
         vm.prank(platformAdmin);
-        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
         vm.prank(platformAdmin);
-        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
+        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER);
 
         uint8 _paymentTokenDecimals = 6;
         // uint8 _maxDecimals = 25;
@@ -248,8 +248,8 @@ contract CrowdinvestingTest is Test {
     }
 
     function testVariousFees(uint32 tokenFeeNumerator, uint32 privateOfferFeeNumerator) public {
-        vm.assume(tokenFeeNumerator <= feeSettings.MAX_TOKEN_FEE_NUMERATOR());
-        vm.assume(privateOfferFeeNumerator <= feeSettings.MAX_PRIVATE_OFFER_FEE_NUMERATOR());
+        vm.assume(tokenFeeNumerator <= feeSettings.MAX_TOKEN_NUMERATOR());
+        vm.assume(privateOfferFeeNumerator <= feeSettings.MAX_PRIVATE_OFFER_NUMERATOR());
         feeCalculation(tokenFeeNumerator, privateOfferFeeNumerator);
     }
 

--- a/test/CrowdinvestingIntegration.t.sol
+++ b/test/CrowdinvestingIntegration.t.sol
@@ -52,15 +52,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(platformAdmin);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        Fees memory fees = Fees(100, 100, 100, 100);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            platformAdmin,
-            fees,
-            platformAdmin,
-            platformAdmin,
-            platformAdmin
-        );
+        feeSettings = createFeeSettings(trustedForwarder, platformAdmin, buildFeeTypes(100, 100, 100, platformAdmin, platformAdmin, platformAdmin));
         vm.prank(platformAdmin);
         token = Token(
             tokenFactory.createTokenProxy(

--- a/test/CrowdinvestingIntegration.t.sol
+++ b/test/CrowdinvestingIntegration.t.sol
@@ -248,8 +248,10 @@ contract CrowdinvestingTest is Test {
     }
 
     function testVariousFees(uint32 tokenFeeNumerator, uint32 privateOfferFeeNumerator) public {
-        vm.assume(tokenFeeNumerator <= feeSettings.MAX_TOKEN_NUMERATOR());
-        vm.assume(privateOfferFeeNumerator <= feeSettings.MAX_PRIVATE_OFFER_NUMERATOR());
+        (uint32 maxTokenNumerator,) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
+        (uint32 maxPrivateOfferNumerator,) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER);
+        vm.assume(tokenFeeNumerator <= maxTokenNumerator);
+        vm.assume(privateOfferFeeNumerator <= maxPrivateOfferNumerator);
         feeCalculation(tokenFeeNumerator, privateOfferFeeNumerator);
     }
 

--- a/test/CrowdinvestingIntegration.t.sol
+++ b/test/CrowdinvestingIntegration.t.sol
@@ -52,7 +52,11 @@ contract CrowdinvestingTest is Test {
         vm.prank(platformAdmin);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        feeSettings = createFeeSettings(trustedForwarder, platformAdmin, buildFeeTypes(100, 100, 100, platformAdmin, platformAdmin, platformAdmin));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            platformAdmin,
+            buildFeeTypes(100, 100, 100, platformAdmin, platformAdmin, platformAdmin)
+        );
         vm.prank(platformAdmin);
         token = Token(
             tokenFactory.createTokenProxy(
@@ -240,8 +244,8 @@ contract CrowdinvestingTest is Test {
     }
 
     function testVariousFees(uint32 tokenFeeNumerator, uint32 privateOfferFeeNumerator) public {
-        (uint32 maxTokenNumerator,) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
-        (uint32 maxPrivateOfferNumerator,) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER);
+        (uint32 maxTokenNumerator, ) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
+        (uint32 maxPrivateOfferNumerator, ) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER);
         vm.assume(tokenFeeNumerator <= maxTokenNumerator);
         vm.assume(privateOfferFeeNumerator <= maxPrivateOfferNumerator);
         feeCalculation(tokenFeeNumerator, privateOfferFeeNumerator);

--- a/test/CrowdinvestingMint.t.sol
+++ b/test/CrowdinvestingMint.t.sol
@@ -67,7 +67,11 @@ contract CrowdinvestingTest is Test {
         vm.prank(owner);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver)
+        );
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/CrowdinvestingMint.t.sol
+++ b/test/CrowdinvestingMint.t.sol
@@ -67,15 +67,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(owner);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        Fees memory fees = Fees(100, 100, 100, 100);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            fees,
-            wrongFeeReceiver,
-            admin,
-            wrongFeeReceiver
-        );
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver));
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/CrowdinvestingMint.t.sol
+++ b/test/CrowdinvestingMint.t.sol
@@ -1307,11 +1307,11 @@ contract CrowdinvestingTest is Test {
 
         // set fees to 0, otherwise extra tokens/currency are minted which causes an overflow
         FeeSettings _feeSettings = FeeSettings(address(token.feeSettings()));
-        _feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 0, 1);
-        _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, 0, 1);
+        _feeSettings.planFeeChange(FeeTypes.TOKEN, 0, 1);
+        _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, 0, 1);
         vm.warp(1);
-        _feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
-        _feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+        _feeSettings.executeFeeChange(FeeTypes.TOKEN);
+        _feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
 
         // grant allowances
         vm.prank(mintAllower);

--- a/test/CrowdinvestingMint.t.sol
+++ b/test/CrowdinvestingMint.t.sol
@@ -1305,10 +1305,13 @@ contract CrowdinvestingTest is Test {
         vm.prank(owner);
         crowdinvesting = Crowdinvesting(factory.createCrowdinvestingClone(0, trustedForwarder, arguments));
 
-        // set fees to 0, otherwise extra currency is minted which causes an overflow
-        Fees memory fees = Fees(0, 0, 0, 0);
-        FeeSettings(address(token.feeSettings())).planFeeChange(fees);
-        FeeSettings(address(token.feeSettings())).executeFeeChange();
+        // set fees to 0, otherwise extra tokens/currency are minted which causes an overflow
+        FeeSettings _feeSettings = FeeSettings(address(token.feeSettings()));
+        _feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 0, 1);
+        _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, 0, 1);
+        vm.warp(1);
+        _feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+        _feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
 
         // grant allowances
         vm.prank(mintAllower);

--- a/test/CrowdinvestingPrice.t.sol
+++ b/test/CrowdinvestingPrice.t.sol
@@ -66,7 +66,11 @@ contract CrowdinvestingTest is Test {
         vm.prank(owner);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver)
+        );
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/CrowdinvestingPrice.t.sol
+++ b/test/CrowdinvestingPrice.t.sol
@@ -66,15 +66,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(owner);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        Fees memory fees = Fees(100, 100, 100, 100);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            fees,
-            wrongFeeReceiver,
-            admin,
-            wrongFeeReceiver
-        );
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver));
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/CrowdinvestingTransfer.t.sol
+++ b/test/CrowdinvestingTransfer.t.sol
@@ -69,15 +69,7 @@ contract CrowdinvestingTransferTest is Test {
         list.set(tokenHolder, 0x0);
         vm.stopPrank();
 
-        Fees memory fees = Fees(100, 100, 100, 100);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            fees,
-            wrongFeeReceiver,
-            admin,
-            wrongFeeReceiver
-        );
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver));
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/CrowdinvestingTransfer.t.sol
+++ b/test/CrowdinvestingTransfer.t.sol
@@ -69,7 +69,11 @@ contract CrowdinvestingTransferTest is Test {
         list.set(tokenHolder, 0x0);
         vm.stopPrank();
 
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver)
+        );
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/Distribution.t.sol
+++ b/test/Distribution.t.sol
@@ -63,8 +63,7 @@ contract DistributionTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        Fees memory fees = Fees(0, 0, 0, 0);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, fees, admin, admin, admin);
+        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "DistToken", "DST")
         );
@@ -174,8 +173,7 @@ contract DistributionTest is Test {
 
     function testInitializeZeroTotalSupplyReverts() public {
         // Take a snapshot before any tokens are minted on a fresh token
-        Fees memory fees = Fees(0, 0, 0, 0);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, fees, admin, admin, admin);
+        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
         Token emptyToken = Token(
             tokenFactory.createTokenProxy(
                 bytes32("empty"),
@@ -235,8 +233,7 @@ contract DistributionTest is Test {
         uint256 balC = uint256(balA) + balB > 0 ? uint256(balA) + balB : 1;
 
         // Deploy a fresh token with three holders
-        Fees memory fees = Fees(0, 0, 0, 0);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, fees, admin, admin, admin);
+        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
         Token fuzzToken = Token(
             tokenFactory.createTokenProxy(
                 bytes32("fuzz"),
@@ -681,15 +678,7 @@ contract DistributionTest is Test {
     /// @dev Deploy a Distribution backed by a token with 1% private offer fee.
     ///      Returns the deployed clone and the fee amount deducted from TOTAL_CURRENCY.
     function _deployDistWithNonZeroFee() internal returns (Distribution d, uint256 fee) {
-        Fees memory nonZeroFees = Fees(0, 0, 100, 0); // 1% private offer fee (100/10000)
-        IFeeSettingsV2 feeSettingsWithFee = createFeeSettings(
-            trustedForwarder,
-            admin,
-            nonZeroFees,
-            admin,
-            admin,
-            feeCollector
-        );
+        IFeeSettingsV2 feeSettingsWithFee = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 100, admin, admin, feeCollector));
         Token feeToken = Token(
             tokenFactory.createTokenProxy(
                 bytes32("feeTok"),

--- a/test/Distribution.t.sol
+++ b/test/Distribution.t.sol
@@ -63,7 +63,11 @@ contract DistributionTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
+        IFeeSettingsV2 feeSettings = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 0, admin, admin, admin)
+        );
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "DistToken", "DST")
         );
@@ -173,7 +177,11 @@ contract DistributionTest is Test {
 
     function testInitializeZeroTotalSupplyReverts() public {
         // Take a snapshot before any tokens are minted on a fresh token
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
+        IFeeSettingsV2 feeSettings = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 0, admin, admin, admin)
+        );
         Token emptyToken = Token(
             tokenFactory.createTokenProxy(
                 bytes32("empty"),
@@ -233,7 +241,11 @@ contract DistributionTest is Test {
         uint256 balC = uint256(balA) + balB > 0 ? uint256(balA) + balB : 1;
 
         // Deploy a fresh token with three holders
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
+        IFeeSettingsV2 feeSettings = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 0, admin, admin, admin)
+        );
         Token fuzzToken = Token(
             tokenFactory.createTokenProxy(
                 bytes32("fuzz"),
@@ -678,7 +690,11 @@ contract DistributionTest is Test {
     /// @dev Deploy a Distribution backed by a token with 1% private offer fee.
     ///      Returns the deployed clone and the fee amount deducted from TOTAL_CURRENCY.
     function _deployDistWithNonZeroFee() internal returns (Distribution d, uint256 fee) {
-        IFeeSettingsV2 feeSettingsWithFee = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 100, admin, admin, feeCollector));
+        IFeeSettingsV2 feeSettingsWithFee = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 100, admin, admin, feeCollector)
+        );
         Token feeToken = Token(
             tokenFactory.createTokenProxy(
                 bytes32("feeTok"),

--- a/test/DistributionCloneFactory.t.sol
+++ b/test/DistributionCloneFactory.t.sol
@@ -37,7 +37,11 @@ contract DistributionCloneFactoryTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
+        IFeeSettingsV2 feeSettings = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 0, admin, admin, admin)
+        );
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "DistToken", "DST")
         );

--- a/test/DistributionCloneFactory.t.sol
+++ b/test/DistributionCloneFactory.t.sol
@@ -37,8 +37,7 @@ contract DistributionCloneFactoryTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        Fees memory fees = Fees(0, 0, 0, 0);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, fees, admin, admin, admin);
+        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "DistToken", "DST")
         );

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -59,7 +59,18 @@ contract TokenERC2771Test is Test {
 
         // deploy fee settings
         vm.prank(platformAdmin);
-        feeSettings = createFeeSettings(trustedForwarder, platformAdmin, buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, feeCollector, feeCollector, feeCollector));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            platformAdmin,
+            buildFeeTypes(
+                tokenFeeNumerator,
+                crowdinvestingFeeNumerator,
+                privateOfferFeeNumerator,
+                feeCollector,
+                feeCollector,
+                feeCollector
+            )
+        );
 
         Token implementation = new Token(address(forwarder));
         factory = new TokenProxyFactory(address(implementation));

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -58,16 +58,8 @@ contract TokenERC2771Test is Test {
         allowList = createAllowList(trustedForwarder, platformAdmin);
 
         // deploy fee settings
-        Fees memory fees = Fees(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
         vm.prank(platformAdmin);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            platformAdmin,
-            fees,
-            feeCollector,
-            feeCollector,
-            feeCollector
-        );
+        feeSettings = createFeeSettings(trustedForwarder, platformAdmin, buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, feeCollector, feeCollector, feeCollector));
 
         Token implementation = new Token(address(forwarder));
         factory = new TokenProxyFactory(address(implementation));

--- a/test/Exit.t.sol
+++ b/test/Exit.t.sol
@@ -59,7 +59,11 @@ contract ExitTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
+        IFeeSettingsV2 feeSettings = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 0, admin, admin, admin)
+        );
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "ExitToken", "EXT")
         );
@@ -621,7 +625,11 @@ contract ExitTest is Test {
         internal
         returns (Exit feeExit, IFeeSettingsV2 feeSettingsWithFee, Token feeToken)
     {
-        feeSettingsWithFee = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 100, admin, admin, feeCollector));
+        feeSettingsWithFee = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 100, admin, admin, feeCollector)
+        );
         feeToken = Token(
             tokenFactory.createTokenProxy(
                 bytes32("feeTok"),

--- a/test/Exit.t.sol
+++ b/test/Exit.t.sol
@@ -59,8 +59,7 @@ contract ExitTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        Fees memory fees = Fees(0, 0, 0, 0);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, fees, admin, admin, admin);
+        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "ExitToken", "EXT")
         );
@@ -622,8 +621,7 @@ contract ExitTest is Test {
         internal
         returns (Exit feeExit, IFeeSettingsV2 feeSettingsWithFee, Token feeToken)
     {
-        Fees memory nonZeroFees = Fees(0, 0, 100, 0); // 1% private offer fee (100/10000)
-        feeSettingsWithFee = createFeeSettings(trustedForwarder, admin, nonZeroFees, admin, admin, feeCollector);
+        feeSettingsWithFee = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 100, admin, admin, feeCollector));
         feeToken = Token(
             tokenFactory.createTokenProxy(
                 bytes32("feeTok"),

--- a/test/ExitCloneFactory.t.sol
+++ b/test/ExitCloneFactory.t.sol
@@ -36,7 +36,11 @@ contract ExitCloneFactoryTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
+        IFeeSettingsV2 feeSettings = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 0, admin, admin, admin)
+        );
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "ExitToken", "EXT")
         );

--- a/test/ExitCloneFactory.t.sol
+++ b/test/ExitCloneFactory.t.sol
@@ -179,16 +179,16 @@ contract ExitCloneFactoryTest is Test {
 
     // ========== F3-E. _currencyProvider Is Not in the Salt ==========
 
-    function testCurrencyProviderDoesNotAffectAddress(address currencyProvider) public {
-        vm.assume(currencyProvider != address(0));
+    function testCurrencyProviderDoesNotAffectAddress(address _currencyProvider) public {
+        vm.assume(_currencyProvider != address(0));
         ExitInitializerArguments memory args = _baseArgs();
         address predicted = factory.predictCloneAddress(EXAMPLE_SALT, trustedForwarder, args);
 
         // Provider 1 deploys
-        currency.mint(currencyProvider, args.totalCurrencyAmount);
-        vm.prank(currencyProvider);
+        currency.mint(_currencyProvider, args.totalCurrencyAmount);
+        vm.prank(_currencyProvider);
         currency.approve(predicted, args.totalCurrencyAmount);
-        address actual = factory.createExitClone(EXAMPLE_SALT, trustedForwarder, currencyProvider, args);
+        address actual = factory.createExitClone(EXAMPLE_SALT, trustedForwarder, _currencyProvider, args);
         assertEq(predicted, actual);
     }
 

--- a/test/ExitCloneFactory.t.sol
+++ b/test/ExitCloneFactory.t.sol
@@ -36,8 +36,7 @@ contract ExitCloneFactoryTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        Fees memory fees = Fees(0, 0, 0, 0);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, fees, admin, admin, admin);
+        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "ExitToken", "EXT")
         );

--- a/test/ExitSafe.t.sol
+++ b/test/ExitSafe.t.sol
@@ -61,7 +61,11 @@ contract ExitSafeTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
+        IFeeSettingsV2 feeSettings = createFeeSettings(
+            trustedForwarder,
+            admin,
+            buildFeeTypes(0, 0, 0, admin, admin, admin)
+        );
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "ExitToken", "EXT")
         );

--- a/test/ExitSafe.t.sol
+++ b/test/ExitSafe.t.sol
@@ -61,8 +61,7 @@ contract ExitSafeTest is Test {
 
         address tokenLogic = address(new Token(trustedForwarder));
         tokenFactory = new TokenProxyFactory(tokenLogic);
-        Fees memory fees = Fees(0, 0, 0, 0);
-        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, fees, admin, admin, admin);
+        IFeeSettingsV2 feeSettings = createFeeSettings(trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin));
         token = Token(
             tokenFactory.createTokenProxy(0, trustedForwarder, feeSettings, admin, allowList, 0, "ExitToken", "EXT")
         );

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -1159,4 +1159,93 @@ contract FeeSettingsTest is Test {
         vm.prank(admin);
         feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER, address(0));
     }
+
+    function testAllFeeTypesRegisteredWithUniqueSettings() public {
+        bytes32[] memory allFeeTypes = new bytes32[](6);
+        allFeeTypes[0] = FeeTypes.TOKEN;
+        allFeeTypes[1] = FeeTypes.CROWDINVESTING;
+        allFeeTypes[2] = FeeTypes.PRIVATE_OFFER;
+        allFeeTypes[3] = FeeTypes.SECONDARY_MARKET;
+        allFeeTypes[4] = FeeTypes.DISTRIBUTION;
+        allFeeTypes[5] = FeeTypes.EXIT;
+
+        FeeSettings.FeeTypeInit[] memory feeTypeInits = new FeeSettings.FeeTypeInit[](allFeeTypes.length);
+        for (uint256 i = 0; i < allFeeTypes.length; i++) {
+            uint32 maxNumerator     = uint32((i + 1) * 100);
+            uint32 defaultNumerator = uint32((i + 1) * 50);
+            address collector       = address(uint160(i + 1));
+            feeTypeInits[i] = FeeSettings.FeeTypeInit(allFeeTypes[i], maxNumerator, defaultNumerator, collector);
+        }
+
+        FeeSettings logic = new FeeSettings(trustedForwarder);
+        FeeSettingsCloneFactory factory = new FeeSettingsCloneFactory(address(logic));
+        FeeSettings freshFeeSettings = FeeSettings(
+            factory.createFeeSettingsClone("all-types-salt", trustedForwarder, admin, feeTypeInits)
+        );
+
+        for (uint256 i = 0; i < allFeeTypes.length; i++) {
+            uint32 expectedMax     = uint32((i + 1) * 100);
+            uint32 expectedDefault = uint32((i + 1) * 50);
+            address expectedCollector = address(uint160(i + 1));
+
+            (uint32 actualMax, uint32 actualDefault) = freshFeeSettings.feeTypeConfigs(allFeeTypes[i]);
+            assertEq(actualMax,     expectedMax,     "maxNumerator wrong");
+            assertEq(actualDefault, expectedDefault, "defaultNumerator wrong");
+            assertEq(
+                freshFeeSettings.feeCollector(allFeeTypes[i], address(0)),
+                expectedCollector,
+                "collector wrong"
+            );
+        }
+    }
+
+    function testFuzz_RegisterFeeTypeRevertsIfMaxNumeratorTooLarge(bytes32 feeType, uint32 maxNumerator) public {
+        vm.assume(feeType != bytes32(0));
+        vm.assume(maxNumerator >= feeSettings.FEE_DENOMINATOR());
+
+        vm.expectRevert("maxNumerator too large");
+        vm.prank(admin);
+        feeSettings.registerFeeType(feeType, maxNumerator, 0);
+    }
+
+    function testFuzz_FeeCalculationAndCollectorReturnedCorrectly(
+        bytes32 feeType,
+        uint32 maxNumerator,
+        uint32 defaultNumerator,
+        address collector,
+        uint256 amount
+    ) public {
+        // constraints from _registerFeeType
+        vm.assume(feeType != bytes32(0));
+        vm.assume(maxNumerator > 0 && maxNumerator < feeSettings.FEE_DENOMINATOR());
+        vm.assume(defaultNumerator <= maxNumerator);
+        vm.assume(collector != address(0));
+        // avoid overflow: amount * maxNumerator must not exceed uint256 max
+        vm.assume(amount <= type(uint256).max / feeSettings.FEE_DENOMINATOR());
+
+        // deploy a fresh FeeSettings with no pre-registered fee types
+        FeeSettings logic = new FeeSettings(trustedForwarder);
+        FeeSettingsCloneFactory factory = new FeeSettingsCloneFactory(address(logic));
+        FeeSettings.FeeTypeInit[] memory emptyFeeTypes = new FeeSettings.FeeTypeInit[](0);
+        FeeSettings freshFeeSettings = FeeSettings(
+            factory.createFeeSettingsClone("fuzz-salt", trustedForwarder, admin, emptyFeeTypes)
+        );
+
+        vm.startPrank(admin);
+        freshFeeSettings.registerFeeType(feeType, maxNumerator, defaultNumerator);
+        freshFeeSettings.setDefaultFeeCollector(feeType, collector);
+        vm.stopPrank();
+
+        uint256 expectedFee = (amount * defaultNumerator) / freshFeeSettings.FEE_DENOMINATOR();
+        assertEq(
+            freshFeeSettings.fee(feeType, amount, exampleTokenAddress),
+            expectedFee,
+            "Fee calculation wrong"
+        );
+        assertEq(
+            freshFeeSettings.feeCollector(feeType, exampleTokenAddress),
+            collector,
+            "Collector wrong"
+        );
+    }
 }

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -5,6 +5,7 @@ import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";
 import "../contracts/Token.sol";
 import "../contracts/factories/FeeSettingsCloneFactory.sol";
+import "../contracts/interfaces/IFeeSettings.sol";
 
 contract FeeSettingsTest is Test {
     uint32 constant MAX_TOKEN_FEE = 500;
@@ -42,6 +43,37 @@ contract FeeSettingsTest is Test {
 
     address public constant exampleTokenAddress = address(74);
 
+    function _buildFeeTypes(address collector) internal pure returns (FeeSettings.FeeTypeInit[] memory) {
+        FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 1, collector);
+        feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 2, collector);
+        feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 3, collector);
+        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, collector);
+        return feeTypes;
+    }
+
+    function _buildFeeTypesFromFees(
+        Fees memory _fees,
+        address collector
+    ) internal pure returns (FeeSettings.FeeTypeInit[] memory) {
+        FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, _fees.tokenFeeNumerator, collector);
+        feeTypes[1] = FeeSettings.FeeTypeInit(
+            FeeTypes.CROWDINVESTING_FEE,
+            1000,
+            _fees.crowdinvestingFeeNumerator,
+            collector
+        );
+        feeTypes[2] = FeeSettings.FeeTypeInit(
+            FeeTypes.PRIVATE_OFFER_FEE,
+            500,
+            _fees.privateOfferFeeNumerator,
+            collector
+        );
+        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, collector);
+        return feeTypes;
+    }
+
     function setUp() public {
         FeeSettings logic = new FeeSettings(trustedForwarder);
         feeSettingsCloneFactory = new FeeSettingsCloneFactory(address(logic));
@@ -49,14 +81,14 @@ contract FeeSettingsTest is Test {
         fees = Fees(1, 2, 3, 0);
         vm.prank(admin);
         feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, fees, admin, admin, admin)
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _buildFeeTypes(admin))
         );
     }
 
     function testLogicContractCannotBeInitialized() public {
         FeeSettings logic = new FeeSettings(trustedForwarder);
         vm.expectRevert("Initializable: contract is already initialized");
-        logic.initialize(admin, fees, admin, admin, admin);
+        logic.initialize(admin, _buildFeeTypes(admin));
 
         assertEq(logic.owner(), address(0), "Owner should be 0");
     }
@@ -64,27 +96,35 @@ contract FeeSettingsTest is Test {
     function testEnforceFeeRangeInInitializer(uint32 numerator, uint32 denominator) public {
         vm.assume(denominator > 0);
         vm.assume(!tokenOrPrivateOfferFeeInValidRange(numerator));
-        Fees memory _fees;
 
         console.log("Testing token fee");
-        _fees = Fees(numerator, 1, 1, 0);
-        vm.expectRevert("Token fee must be <= 5%");
-        feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin);
+        {
+            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, numerator, admin);
+            vm.expectRevert("default exceeds max");
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType);
+        }
 
         console.log("Testing Crowdinvesting fee");
-        _fees = Fees(1, numerator, 1, 0);
-        if (!crowdinvestingFeeInValidRange(numerator)) {
-            vm.expectRevert("Crowdinvesting fee must be <= 10%");
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin);
-        } else {
-            // this should not revert, as the fee is in valid range for crowdinvesting
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin);
+        {
+            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, numerator, admin);
+            if (!crowdinvestingFeeInValidRange(numerator)) {
+                vm.expectRevert("default exceeds max");
+                feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType);
+            } else {
+                // this should not revert, as the fee is in valid range for crowdinvesting
+                feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType);
+            }
         }
 
         console.log("Testing PrivateOffer fee");
-        _fees = Fees(1, 1, numerator, 0);
-        vm.expectRevert("PrivateOffer fee must be <= 5%");
-        feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin);
+        {
+            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, numerator, admin);
+            vm.expectRevert("default exceeds max");
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType);
+        }
     }
 
     function testEnforceTokenFeeRangeInFeeChanger(uint32 numerator, uint32 denominator) public {
@@ -120,7 +160,12 @@ contract FeeSettingsTest is Test {
         vm.assume(newNumerator > startNumerator);
         Fees memory _fees = Fees(startNumerator, startNumerator, startNumerator, 0);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                admin,
+                _buildFeeTypesFromFees(_fees, admin)
+            )
         );
 
         vm.prank(admin);
@@ -241,7 +286,12 @@ contract FeeSettingsTest is Test {
         Fees memory _fees = Fees(0, 0, 0, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                admin,
+                _buildFeeTypesFromFees(_fees, admin)
+            )
         );
 
         (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
@@ -265,7 +315,12 @@ contract FeeSettingsTest is Test {
         // create new fee settings with max fee
         Fees memory maxFee = Fees(MAX_TOKEN_FEE, MAX_CROWDINVESTING_FEE, MAX_PRIVATE_OFFER_FEE, 0);
         feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, maxFee, admin, admin, admin)
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                admin,
+                _buildFeeTypesFromFees(maxFee, admin)
+            )
         );
 
         (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
@@ -313,7 +368,12 @@ contract FeeSettingsTest is Test {
         FeeSettings _feeSettings;
         Fees memory _fees = Fees(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
         _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt2", trustedForwarder, admin, _fees, admin, admin, admin)
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt2",
+                trustedForwarder,
+                admin,
+                _buildFeeTypesFromFees(_fees, admin)
+            )
         );
 
         (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
@@ -328,49 +388,42 @@ contract FeeSettingsTest is Test {
     function testFeeCollector0FailsInInitializer() public {
         FeeSettings _feeSettings;
 
-        vm.expectRevert("Fee collector cannot be 0x0");
-        _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt",
-                trustedForwarder,
-                admin,
-                fees,
-                address(0),
-                admin,
-                admin
-            )
-        );
+        {
+            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, fees.tokenFeeNumerator, address(0));
+            vm.expectRevert("Fee collector cannot be 0x0");
+            _feeSettings = FeeSettings(
+                feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType)
+            );
+        }
 
-        vm.expectRevert("Fee collector cannot be 0x0");
-        _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt",
-                trustedForwarder,
-                admin,
-                fees,
-                admin,
-                address(0),
-                admin
-            )
-        );
-
-        vm.expectRevert("Fee collector cannot be 0x0");
-        _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt",
-                trustedForwarder,
-                admin,
-                fees,
-                admin,
-                admin,
+        {
+            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
+            feeType[0] = FeeSettings.FeeTypeInit(
+                FeeTypes.CROWDINVESTING_FEE,
+                1000,
+                fees.crowdinvestingFeeNumerator,
                 address(0)
-            )
-        );
+            );
+            vm.expectRevert("Fee collector cannot be 0x0");
+            _feeSettings = FeeSettings(
+                feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType)
+            );
+        }
+
+        {
+            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, fees.privateOfferFeeNumerator, address(0));
+            vm.expectRevert("Fee collector cannot be 0x0");
+            _feeSettings = FeeSettings(
+                feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType)
+            );
+        }
     }
 
     function testOwner0FailsInInitializer() public {
         vm.expectRevert("owner can not be zero address");
-        feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, address(0), fees, admin, admin, admin);
+        feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, address(0), _buildFeeTypes(admin));
     }
 
     function testFeeCollector0FailsInSetter() public {
@@ -426,7 +479,12 @@ contract FeeSettingsTest is Test {
 
         Fees memory _fees = Fees(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt5", trustedForwarder, admin, _fees, admin, admin, admin)
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt5",
+                trustedForwarder,
+                admin,
+                _buildFeeTypesFromFees(_fees, admin)
+            )
         );
 
         assertEq(
@@ -461,7 +519,12 @@ contract FeeSettingsTest is Test {
 
         Fees memory _fees = Fees(0, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt4", trustedForwarder, admin, _fees, admin, admin, admin)
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt4",
+                trustedForwarder,
+                admin,
+                _buildFeeTypesFromFees(_fees, admin)
+            )
         );
 
         assertEq(_feeSettings.tokenFee(amount, address(0)), 0, "Token fee mismatch");
@@ -480,7 +543,12 @@ contract FeeSettingsTest is Test {
 
         _fees = Fees(tokenFeeNumerator, 0, privateOfferFeeNumerator, 0);
         _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt3", trustedForwarder, admin, _fees, admin, admin, admin)
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt3",
+                trustedForwarder,
+                admin,
+                _buildFeeTypesFromFees(_fees, admin)
+            )
         );
         assertEq(
             _feeSettings.tokenFee(amount, address(0)),
@@ -498,7 +566,12 @@ contract FeeSettingsTest is Test {
 
         _fees = Fees(tokenFeeNumerator, crowdinvestingFeeNumerator, 0, 0);
         _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt2", trustedForwarder, admin, _fees, admin, admin, admin)
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt2",
+                trustedForwarder,
+                admin,
+                _buildFeeTypesFromFees(_fees, admin)
+            )
         );
         assertEq(
             _feeSettings.tokenFee(amount, address(0)),
@@ -563,10 +636,7 @@ contract FeeSettingsTest is Test {
                 "salt",
                 trustedForwarder,
                 address(this),
-                _fees,
-                address(this),
-                address(this),
-                address(this)
+                _buildFeeTypesFromFees(_fees, address(this))
             )
         );
         // check there is no entry for this token address
@@ -637,10 +707,7 @@ contract FeeSettingsTest is Test {
                 "salt",
                 trustedForwarder,
                 address(this),
-                _fees,
-                admin,
-                admin,
-                admin
+                _buildFeeTypesFromFees(_fees, admin)
             )
         );
         // add custom fee entry for this token address
@@ -663,10 +730,7 @@ contract FeeSettingsTest is Test {
                 "salt",
                 trustedForwarder,
                 address(this),
-                _fees,
-                admin,
-                admin,
-                admin
+                _buildFeeTypesFromFees(_fees, admin)
             )
         );
 
@@ -707,10 +771,7 @@ contract FeeSettingsTest is Test {
                 "salt",
                 trustedForwarder,
                 address(this),
-                _fees,
-                admin,
-                admin,
-                admin
+                _buildFeeTypesFromFees(_fees, admin)
             )
         );
         // add custom fee entry for this token address

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -840,7 +840,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -856,7 +856,7 @@ contract FeeSettingsTest is Test {
         feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.TOKEN, exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -885,7 +885,7 @@ contract FeeSettingsTest is Test {
         feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress);
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -903,7 +903,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -914,7 +914,7 @@ contract FeeSettingsTest is Test {
         feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -942,7 +942,7 @@ contract FeeSettingsTest is Test {
         feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress);
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -955,7 +955,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -966,7 +966,7 @@ contract FeeSettingsTest is Test {
         feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -994,7 +994,7 @@ contract FeeSettingsTest is Test {
         feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress);
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -1013,17 +1013,17 @@ contract FeeSettingsTest is Test {
         feeSettings.addManager(_manager);
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -1035,17 +1035,17 @@ contract FeeSettingsTest is Test {
         vm.stopPrank();
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.TOKEN, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
         assertEq(
-            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
         assertEq(
-            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
@@ -1057,17 +1057,17 @@ contract FeeSettingsTest is Test {
         vm.stopPrank();
 
         assertEq(
-            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.collectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -1265,7 +1265,7 @@ contract FeeSettingsTest is Test {
 
         vm.expectRevert("maxNumerator too large");
         vm.prank(admin);
-        feeSettings.registerFeeType(feeType, maxNumerator, 0);
+        feeSettings.registerFeeType(feeType, maxNumerator, 0, admin);
     }
 
     function testFuzz_FeeCalculationAndCollectorReturnedCorrectly(
@@ -1292,8 +1292,7 @@ contract FeeSettingsTest is Test {
         );
 
         vm.startPrank(admin);
-        freshFeeSettings.registerFeeType(feeType, maxNumerator, defaultNumerator);
-        freshFeeSettings.setDefaultFeeCollector(feeType, collector);
+        freshFeeSettings.registerFeeType(feeType, maxNumerator, defaultNumerator, collector);
         vm.stopPrank();
 
         uint256 expectedFee = (amount * defaultNumerator) / freshFeeSettings.FEE_DENOMINATOR();

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -840,7 +840,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -856,7 +856,7 @@ contract FeeSettingsTest is Test {
         feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -885,7 +885,7 @@ contract FeeSettingsTest is Test {
         feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -903,7 +903,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -914,7 +914,7 @@ contract FeeSettingsTest is Test {
         feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -942,7 +942,7 @@ contract FeeSettingsTest is Test {
         feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -955,7 +955,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -966,7 +966,7 @@ contract FeeSettingsTest is Test {
         feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -994,7 +994,7 @@ contract FeeSettingsTest is Test {
         feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -1013,17 +1013,17 @@ contract FeeSettingsTest is Test {
         feeSettings.addManager(_manager);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -1035,17 +1035,17 @@ contract FeeSettingsTest is Test {
         vm.stopPrank();
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
@@ -1057,17 +1057,17 @@ contract FeeSettingsTest is Test {
         vm.stopPrank();
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
+            feeSettings.customCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -8,9 +8,9 @@ import "../contracts/factories/FeeSettingsCloneFactory.sol";
 import "../contracts/interfaces/IFeeSettings.sol";
 
 contract FeeSettingsTest is Test {
-    uint32 constant MAX_TOKEN_FEE = 500;
-    uint32 constant MAX_CROWDINVESTING_FEE = 1000;
-    uint32 constant MAX_PRIVATE_OFFER_FEE = 500;
+    uint32 constant MAX_TOKEN = 500;
+    uint32 constant MAX_CROWDINVESTING = 1000;
+    uint32 constant MAX_PRIVATE_OFFER = 500;
 
     event SetFee(uint32 tokenFeeNumerator, uint32 crowdinvestingFeeNumerator, uint32 privateOfferFeeNumerator);
     event FeeCollectorsChanged(
@@ -45,12 +45,12 @@ contract FeeSettingsTest is Test {
 
     function _buildFeeTypes(address collector) internal pure returns (FeeSettings.FeeTypeInit[] memory) {
         FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
-        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 1, collector);
-        feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 2, collector);
-        feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 3, collector);
-        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, collector);
-        feeTypes[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION_FEE, 500, 0, collector);
-        feeTypes[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT_FEE, 500, 0, collector);
+        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, 1, collector);
+        feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, 2, collector);
+        feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, 3, collector);
+        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, 0, collector);
+        feeTypes[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION, 500, 0, collector);
+        feeTypes[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT, 500, 0, collector);
         return feeTypes;
     }
 
@@ -59,22 +59,17 @@ contract FeeSettingsTest is Test {
         address collector
     ) internal pure returns (FeeSettings.FeeTypeInit[] memory) {
         FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
-        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, _fees.tokenFeeNumerator, collector);
+        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, _fees.tokenFeeNumerator, collector);
         feeTypes[1] = FeeSettings.FeeTypeInit(
-            FeeTypes.CROWDINVESTING_FEE,
+            FeeTypes.CROWDINVESTING,
             1000,
             _fees.crowdinvestingFeeNumerator,
             collector
         );
-        feeTypes[2] = FeeSettings.FeeTypeInit(
-            FeeTypes.PRIVATE_OFFER_FEE,
-            500,
-            _fees.privateOfferFeeNumerator,
-            collector
-        );
-        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, collector);
-        feeTypes[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION_FEE, 500, 0, collector);
-        feeTypes[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT_FEE, 500, 0, collector);
+        feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, _fees.privateOfferFeeNumerator, collector);
+        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, 0, collector);
+        feeTypes[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION, 500, 0, collector);
+        feeTypes[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT, 500, 0, collector);
         return feeTypes;
     }
 
@@ -103,16 +98,16 @@ contract FeeSettingsTest is Test {
 
         console.log("Testing token fee");
         {
-            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
-            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, numerator, admin);
+            FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, numerator, admin);
             vm.expectRevert("default exceeds max");
             feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType);
         }
 
         console.log("Testing Crowdinvesting fee");
         {
-            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
-            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, numerator, admin);
+            FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, numerator, admin);
             if (!crowdinvestingFeeInValidRange(numerator)) {
                 vm.expectRevert("default exceeds max");
                 feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType);
@@ -124,8 +119,8 @@ contract FeeSettingsTest is Test {
 
         console.log("Testing PrivateOffer fee");
         {
-            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
-            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, numerator, admin);
+            FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, numerator, admin);
             vm.expectRevert("default exceeds max");
             feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType);
         }
@@ -137,7 +132,7 @@ contract FeeSettingsTest is Test {
 
         vm.expectRevert("exceeds max numerator");
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, numerator, uint64(block.timestamp + 7884001));
+        feeSettings.planFeeChange(FeeTypes.TOKEN, numerator, uint64(block.timestamp + 7884001));
     }
 
     function testEnforceCrowdinvestingFeeRangeInFeeChanger(uint32 numerator, uint32 denominator) public {
@@ -146,7 +141,7 @@ contract FeeSettingsTest is Test {
 
         vm.expectRevert("exceeds max numerator");
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, numerator, uint64(block.timestamp + 7884001));
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, numerator, uint64(block.timestamp + 7884001));
     }
 
     function testEnforcePrivateOfferFeeRangeInFeeChanger(uint32 numerator, uint32 denominator) public {
@@ -155,12 +150,12 @@ contract FeeSettingsTest is Test {
 
         vm.expectRevert("exceeds max numerator");
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, numerator, uint64(block.timestamp + 7884001));
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, numerator, uint64(block.timestamp + 7884001));
     }
 
     function testEnforceFeeChangeDelayOnIncrease(uint delay, uint32 startNumerator, uint32 newNumerator) public {
         vm.assume(delay <= 12 weeks);
-        vm.assume(newNumerator <= MAX_PRIVATE_OFFER_FEE);
+        vm.assume(newNumerator <= MAX_PRIVATE_OFFER);
         vm.assume(newNumerator > startNumerator);
         Fees memory _fees = Fees(startNumerator, startNumerator, startNumerator, 0);
         FeeSettings _feeSettings = FeeSettings(
@@ -174,15 +169,15 @@ contract FeeSettingsTest is Test {
 
         vm.prank(admin);
         vm.expectRevert("fee increase needs 12 week delay");
-        _feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, newNumerator, uint64(block.timestamp + delay));
+        _feeSettings.planFeeChange(FeeTypes.TOKEN, newNumerator, uint64(block.timestamp + delay));
 
         vm.prank(admin);
         vm.expectRevert("fee increase needs 12 week delay");
-        _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, newNumerator, uint64(block.timestamp + delay));
+        _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, newNumerator, uint64(block.timestamp + delay));
 
         vm.prank(admin);
         vm.expectRevert("fee increase needs 12 week delay");
-        _feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, newNumerator, uint64(block.timestamp + delay));
+        _feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, newNumerator, uint64(block.timestamp + delay));
     }
 
     function testExecuteFeeChangeTooEarly(
@@ -196,16 +191,16 @@ contract FeeSettingsTest is Test {
 
         uint64 activationDate = uint64(block.timestamp + delayAnnounced);
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, tokenFeeNumerator, activationDate);
+        feeSettings.planFeeChange(FeeTypes.TOKEN, tokenFeeNumerator, activationDate);
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, investmentFeeNumerator, activationDate);
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, investmentFeeNumerator, activationDate);
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, investmentFeeNumerator, activationDate);
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, investmentFeeNumerator, activationDate);
 
         vm.prank(admin);
         vm.expectRevert("activation date not reached");
         vm.warp(activationDate - 1);
-        feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+        feeSettings.executeFeeChange(FeeTypes.TOKEN);
     }
 
     function testExecuteFeeChangeProperly(
@@ -215,32 +210,32 @@ contract FeeSettingsTest is Test {
         uint32 privateOfferFeeNumerator
     ) public {
         vm.assume(delayAnnounced > 12 weeks && delayAnnounced < 100000000000);
-        tokenFeeNumerator = tokenFeeNumerator % MAX_TOKEN_FEE;
-        crowdinvestingFeeNumerator = crowdinvestingFeeNumerator % MAX_CROWDINVESTING_FEE;
-        privateOfferFeeNumerator = privateOfferFeeNumerator % MAX_PRIVATE_OFFER_FEE;
-        vm.assume(tokenFeeNumerator <= MAX_TOKEN_FEE);
-        vm.assume(crowdinvestingFeeNumerator <= MAX_CROWDINVESTING_FEE);
-        vm.assume(privateOfferFeeNumerator <= MAX_PRIVATE_OFFER_FEE);
+        tokenFeeNumerator = tokenFeeNumerator % MAX_TOKEN;
+        crowdinvestingFeeNumerator = crowdinvestingFeeNumerator % MAX_CROWDINVESTING;
+        privateOfferFeeNumerator = privateOfferFeeNumerator % MAX_PRIVATE_OFFER;
+        vm.assume(tokenFeeNumerator <= MAX_TOKEN);
+        vm.assume(crowdinvestingFeeNumerator <= MAX_CROWDINVESTING);
+        vm.assume(privateOfferFeeNumerator <= MAX_PRIVATE_OFFER);
 
         uint64 activationDate = uint64(block.timestamp + delayAnnounced);
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, tokenFeeNumerator, activationDate);
+        feeSettings.planFeeChange(FeeTypes.TOKEN, tokenFeeNumerator, activationDate);
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, crowdinvestingFeeNumerator, activationDate);
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, crowdinvestingFeeNumerator, activationDate);
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, privateOfferFeeNumerator, activationDate);
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, privateOfferFeeNumerator, activationDate);
 
         vm.prank(admin);
         vm.warp(activationDate + 1);
-        feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+        feeSettings.executeFeeChange(FeeTypes.TOKEN);
         vm.prank(admin);
-        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
         vm.prank(admin);
-        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
+        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER);
 
-        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
-        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
+        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
+        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING);
+        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER);
 
         assertEq(_tokenFeeNumerator, tokenFeeNumerator);
         assertEq(_crowdinvestingFeeNumerator, crowdinvestingFeeNumerator);
@@ -250,37 +245,37 @@ contract FeeSettingsTest is Test {
     function testSetFeeTo0Immediately() public {
         uint64 activationDate = uint64(block.timestamp);
 
-        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
-        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
+        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
+        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING);
+        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER);
 
         assertEq(_tokenFeeNumerator, 1);
         assertEq(_crowdinvestingFeeNumerator, 2);
         assertEq(_privateOfferFeeNumerator, 3);
 
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 0, activationDate);
+        feeSettings.planFeeChange(FeeTypes.TOKEN, 0, activationDate);
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, 0, activationDate);
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, 0, activationDate);
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, 0, activationDate);
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, 0, activationDate);
 
         vm.prank(admin);
-        feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+        feeSettings.executeFeeChange(FeeTypes.TOKEN);
         vm.prank(admin);
-        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
         vm.prank(admin);
-        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
+        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER);
 
-        (, _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
-        (, _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
+        (, _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
+        (, _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING);
+        (, _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER);
 
         assertEq(_tokenFeeNumerator, 0);
         assertEq(_crowdinvestingFeeNumerator, 0);
         assertEq(_privateOfferFeeNumerator, 0);
 
-        (uint32 proposedNumerator, uint64 proposedActivationDate) = feeSettings.proposedFeeChanges(FeeTypes.TOKEN_FEE);
+        (uint32 proposedNumerator, uint64 proposedActivationDate) = feeSettings.proposedFeeChanges(FeeTypes.TOKEN);
 
         assertEq(proposedNumerator, 0, "Token fee denominator mismatch");
         assertEq(proposedActivationDate, 0, "Time mismatch");
@@ -298,9 +293,9 @@ contract FeeSettingsTest is Test {
             )
         );
 
-        (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, uint32 _crowdinvestingFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
-        (, uint32 _privateOfferFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
+        (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
+        (, uint32 _crowdinvestingFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING);
+        (, uint32 _privateOfferFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER);
 
         assertEq(_tokenFeeNumerator, 0, "Token fee numerator mismatch");
         assertEq(_crowdinvestingFeeNumerator, 0, "Crowdinvesting fee numerator mismatch");
@@ -308,16 +303,16 @@ contract FeeSettingsTest is Test {
 
         vm.prank(admin);
         vm.expectRevert("fee increase needs 12 week delay");
-        _feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 1, 0);
+        _feeSettings.planFeeChange(FeeTypes.TOKEN, 1, 0);
     }
 
     function testReduceFeeImmediately(uint32 tokenFee, uint32 crowdinvestingFee, uint32 privateOfferFee) public {
-        vm.assume(tokenFee <= MAX_TOKEN_FEE);
-        vm.assume(crowdinvestingFee <= MAX_CROWDINVESTING_FEE);
-        vm.assume(privateOfferFee <= MAX_PRIVATE_OFFER_FEE);
+        vm.assume(tokenFee <= MAX_TOKEN);
+        vm.assume(crowdinvestingFee <= MAX_CROWDINVESTING);
+        vm.assume(privateOfferFee <= MAX_PRIVATE_OFFER);
 
         // create new fee settings with max fee
-        Fees memory maxFee = Fees(MAX_TOKEN_FEE, MAX_CROWDINVESTING_FEE, MAX_PRIVATE_OFFER_FEE, 0);
+        Fees memory maxFee = Fees(MAX_TOKEN, MAX_CROWDINVESTING, MAX_PRIVATE_OFFER, 0);
         feeSettings = FeeSettings(
             feeSettingsCloneFactory.createFeeSettingsClone(
                 "salt",
@@ -327,32 +322,32 @@ contract FeeSettingsTest is Test {
             )
         );
 
-        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
-        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
+        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
+        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING);
+        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER);
 
-        assertEq(_tokenFeeNumerator, MAX_TOKEN_FEE);
-        assertEq(_crowdinvestingFeeNumerator, MAX_CROWDINVESTING_FEE);
-        assertEq(_privateOfferFeeNumerator, MAX_PRIVATE_OFFER_FEE);
+        assertEq(_tokenFeeNumerator, MAX_TOKEN);
+        assertEq(_crowdinvestingFeeNumerator, MAX_CROWDINVESTING);
+        assertEq(_privateOfferFeeNumerator, MAX_PRIVATE_OFFER);
 
         // change fee to something lower (immediate since it's a decrease)
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, tokenFee, 0);
+        feeSettings.planFeeChange(FeeTypes.TOKEN, tokenFee, 0);
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, crowdinvestingFee, 0);
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, crowdinvestingFee, 0);
         vm.prank(admin);
-        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, privateOfferFee, 0);
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, privateOfferFee, 0);
 
         vm.prank(admin);
-        feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+        feeSettings.executeFeeChange(FeeTypes.TOKEN);
         vm.prank(admin);
-        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
         vm.prank(admin);
-        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
+        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER);
 
-        (, _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
-        (, _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
+        (, _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
+        (, _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING);
+        (, _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER);
 
         assertEq(_tokenFeeNumerator, tokenFee);
         assertEq(_crowdinvestingFeeNumerator, crowdinvestingFee);
@@ -365,9 +360,9 @@ contract FeeSettingsTest is Test {
         uint32 privateOfferFeeNumerator
     ) public {
         vm.assume(
-            tokenFeeNumerator <= MAX_TOKEN_FEE &&
-                crowdinvestingFeeNumerator <= MAX_CROWDINVESTING_FEE &&
-                privateOfferFeeNumerator <= MAX_PRIVATE_OFFER_FEE
+            tokenFeeNumerator <= MAX_TOKEN &&
+                crowdinvestingFeeNumerator <= MAX_CROWDINVESTING &&
+                privateOfferFeeNumerator <= MAX_PRIVATE_OFFER
         );
         FeeSettings _feeSettings;
         Fees memory _fees = Fees(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
@@ -380,9 +375,9 @@ contract FeeSettingsTest is Test {
             )
         );
 
-        (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, uint32 _crowdinvestingFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
-        (, uint32 _privateOfferFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
+        (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
+        (, uint32 _crowdinvestingFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING);
+        (, uint32 _privateOfferFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER);
 
         assertEq(_tokenFeeNumerator, tokenFeeNumerator, "Token fee numerator mismatch");
         assertEq(_crowdinvestingFeeNumerator, crowdinvestingFeeNumerator, "Crowdinvesting fee numerator mismatch");
@@ -393,8 +388,8 @@ contract FeeSettingsTest is Test {
         FeeSettings _feeSettings;
 
         {
-            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
-            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, fees.tokenFeeNumerator, address(0));
+            FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, fees.tokenFeeNumerator, address(0));
             vm.expectRevert("Fee collector cannot be 0x0");
             _feeSettings = FeeSettings(
                 feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType)
@@ -402,9 +397,9 @@ contract FeeSettingsTest is Test {
         }
 
         {
-            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
+            FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
             feeType[0] = FeeSettings.FeeTypeInit(
-                FeeTypes.CROWDINVESTING_FEE,
+                FeeTypes.CROWDINVESTING,
                 1000,
                 fees.crowdinvestingFeeNumerator,
                 address(0)
@@ -416,8 +411,13 @@ contract FeeSettingsTest is Test {
         }
 
         {
-            FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](1);
-            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, fees.privateOfferFeeNumerator, address(0));
+            FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
+            feeType[0] = FeeSettings.FeeTypeInit(
+                FeeTypes.PRIVATE_OFFER,
+                500,
+                fees.privateOfferFeeNumerator,
+                address(0)
+            );
             vm.expectRevert("Fee collector cannot be 0x0");
             _feeSettings = FeeSettings(
                 feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType)
@@ -433,13 +433,13 @@ contract FeeSettingsTest is Test {
     function testFeeCollector0FailsInSetter() public {
         vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setDefaultFeeCollector(FeeTypes.TOKEN_FEE, address(0));
+        feeSettings.setDefaultFeeCollector(FeeTypes.TOKEN, address(0));
         vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setDefaultFeeCollector(FeeTypes.CROWDINVESTING_FEE, address(0));
+        feeSettings.setDefaultFeeCollector(FeeTypes.CROWDINVESTING, address(0));
         vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setDefaultFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(0));
+        feeSettings.setDefaultFeeCollector(FeeTypes.PRIVATE_OFFER, address(0));
     }
 
     function testUpdateFeeCollectors(
@@ -452,9 +452,9 @@ contract FeeSettingsTest is Test {
         vm.assume(newPrivateOfferFeeCollector != address(0));
 
         vm.startPrank(admin);
-        feeSettings.setDefaultFeeCollector(FeeTypes.TOKEN_FEE, newTokenFeeCollector);
-        feeSettings.setDefaultFeeCollector(FeeTypes.CROWDINVESTING_FEE, newCrowdinvestingFeeCollector);
-        feeSettings.setDefaultFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, newPrivateOfferFeeCollector);
+        feeSettings.setDefaultFeeCollector(FeeTypes.TOKEN, newTokenFeeCollector);
+        feeSettings.setDefaultFeeCollector(FeeTypes.CROWDINVESTING, newCrowdinvestingFeeCollector);
+        feeSettings.setDefaultFeeCollector(FeeTypes.PRIVATE_OFFER, newPrivateOfferFeeCollector);
         vm.stopPrank();
         assertEq(feeSettings.feeCollector(), newTokenFeeCollector); // IFeeSettingsV1
         assertEq(feeSettings.tokenFeeCollector(address(4)), newTokenFeeCollector);
@@ -476,10 +476,10 @@ contract FeeSettingsTest is Test {
         uint32 privateOfferFeeNumerator,
         uint256 amount
     ) public {
-        vm.assume(tokenFeeNumerator <= MAX_TOKEN_FEE);
-        vm.assume(crowdinvestingFeeNumerator <= MAX_CROWDINVESTING_FEE);
-        vm.assume(privateOfferFeeNumerator <= MAX_PRIVATE_OFFER_FEE);
-        vm.assume(amount < UINT256_MAX / MAX_CROWDINVESTING_FEE);
+        vm.assume(tokenFeeNumerator <= MAX_TOKEN);
+        vm.assume(crowdinvestingFeeNumerator <= MAX_CROWDINVESTING);
+        vm.assume(privateOfferFeeNumerator <= MAX_PRIVATE_OFFER);
+        vm.assume(amount < UINT256_MAX / MAX_CROWDINVESTING);
 
         Fees memory _fees = Fees(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
         FeeSettings _feeSettings = FeeSettings(
@@ -514,10 +514,10 @@ contract FeeSettingsTest is Test {
         uint32 privateOfferFeeNumerator,
         uint256 amount
     ) public {
-        vm.assume(tokenFeeNumerator <= MAX_TOKEN_FEE);
-        vm.assume(crowdinvestingFeeNumerator <= MAX_CROWDINVESTING_FEE);
-        vm.assume(privateOfferFeeNumerator <= MAX_PRIVATE_OFFER_FEE);
-        vm.assume(amount < UINT256_MAX / MAX_CROWDINVESTING_FEE);
+        vm.assume(tokenFeeNumerator <= MAX_TOKEN);
+        vm.assume(crowdinvestingFeeNumerator <= MAX_CROWDINVESTING);
+        vm.assume(privateOfferFeeNumerator <= MAX_PRIVATE_OFFER);
+        vm.assume(amount < UINT256_MAX / MAX_CROWDINVESTING);
 
         // only token fee is 0
 
@@ -645,9 +645,9 @@ contract FeeSettingsTest is Test {
         );
         // check there is no entry for this token address
         {
-            (uint32 tokenNum, uint64 tokenValidity) = _feeSettings.customFees(FeeTypes.TOKEN_FEE, _someTokenAddress);
-            (uint32 ciNum, uint64 ciValidity) = _feeSettings.customFees(FeeTypes.CROWDINVESTING_FEE, _someTokenAddress);
-            (uint32 poNum, uint64 poValidity) = _feeSettings.customFees(FeeTypes.PRIVATE_OFFER_FEE, _someTokenAddress);
+            (uint32 tokenNum, uint64 tokenValidity) = _feeSettings.customFees(FeeTypes.TOKEN, _someTokenAddress);
+            (uint32 ciNum, uint64 ciValidity) = _feeSettings.customFees(FeeTypes.CROWDINVESTING, _someTokenAddress);
+            (uint32 poNum, uint64 poValidity) = _feeSettings.customFees(FeeTypes.PRIVATE_OFFER, _someTokenAddress);
             assertEq(tokenNum, 0, "Token fee numerator should be 0");
             assertEq(ciNum, 0, "Crowdinvesting fee numerator should be 0");
             assertEq(poNum, 0, "Private offer fee numerator should be 0");
@@ -663,9 +663,9 @@ contract FeeSettingsTest is Test {
 
         // add custom fee entry for this token address
         uint256 realEndTime = block.timestamp + 100;
-        _feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, _someTokenAddress, 3, uint64(realEndTime));
-        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING_FEE, _someTokenAddress, 4, uint64(realEndTime));
-        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER_FEE, _someTokenAddress, 2, uint64(realEndTime));
+        _feeSettings.setCustomFee(FeeTypes.TOKEN, _someTokenAddress, 3, uint64(realEndTime));
+        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING, _someTokenAddress, 4, uint64(realEndTime));
+        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER, _someTokenAddress, 2, uint64(realEndTime));
 
         // check the token fee, private offer fee and crowdinvesting fee change as expected
         assertEq(_feeSettings.tokenFee(10000, _someTokenAddress), 3, "Token fee should be 3 now");
@@ -674,9 +674,9 @@ contract FeeSettingsTest is Test {
 
         // check the custom fee entry is as expected
         {
-            (uint32 tokenNum, uint64 tokenValidity) = _feeSettings.customFees(FeeTypes.TOKEN_FEE, _someTokenAddress);
-            (uint32 ciNum, ) = _feeSettings.customFees(FeeTypes.CROWDINVESTING_FEE, _someTokenAddress);
-            (uint32 poNum, ) = _feeSettings.customFees(FeeTypes.PRIVATE_OFFER_FEE, _someTokenAddress);
+            (uint32 tokenNum, uint64 tokenValidity) = _feeSettings.customFees(FeeTypes.TOKEN, _someTokenAddress);
+            (uint32 ciNum, ) = _feeSettings.customFees(FeeTypes.CROWDINVESTING, _someTokenAddress);
+            (uint32 poNum, ) = _feeSettings.customFees(FeeTypes.PRIVATE_OFFER, _someTokenAddress);
             assertEq(tokenNum, 3, "Token fee numerator should be 3");
             assertEq(ciNum, 4, "Crowdinvesting fee numerator should be 4");
             assertEq(poNum, 2, "Private offer fee numerator should be 2");
@@ -697,7 +697,7 @@ contract FeeSettingsTest is Test {
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, someTokenAddress, 1, uint64(block.timestamp + 100));
+        feeSettings.setCustomFee(FeeTypes.TOKEN, someTokenAddress, 1, uint64(block.timestamp + 100));
     }
 
     function testCustomFeesAreNotAppliedToOtherTokens(address _someTokenAddress, address _otherTokenAddress) public {
@@ -716,9 +716,9 @@ contract FeeSettingsTest is Test {
         );
         // add custom fee entry for this token address
         uint64 customFeeValidity = uint64(block.timestamp + 100);
-        _feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, _someTokenAddress, 3, customFeeValidity);
-        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING_FEE, _someTokenAddress, 4, customFeeValidity);
-        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER_FEE, _someTokenAddress, 2, customFeeValidity);
+        _feeSettings.setCustomFee(FeeTypes.TOKEN, _someTokenAddress, 3, customFeeValidity);
+        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING, _someTokenAddress, 4, customFeeValidity);
+        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER, _someTokenAddress, 2, customFeeValidity);
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(10000, _otherTokenAddress), 10, "Token fee should be 10");
@@ -749,9 +749,9 @@ contract FeeSettingsTest is Test {
 
         // add custom fee entry for this token address
         uint64 customValidity = uint64(block.timestamp + 100);
-        _feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, someTokenAddress, 1, customValidity);
-        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING_FEE, someTokenAddress, 1, customValidity);
-        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER_FEE, someTokenAddress, 1, customValidity);
+        _feeSettings.setCustomFee(FeeTypes.TOKEN, someTokenAddress, 1, customValidity);
+        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING, someTokenAddress, 1, customValidity);
+        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER, someTokenAddress, 1, customValidity);
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(type(uint256).max, someTokenAddress), 0, "Token fee should still be 0");
@@ -780,9 +780,9 @@ contract FeeSettingsTest is Test {
         );
         // add custom fee entry for this token address
         uint64 customFeeValidity = uint64(block.timestamp + 100);
-        _feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, someTokenAddress, 3, customFeeValidity);
-        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING_FEE, someTokenAddress, 4, customFeeValidity);
-        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER_FEE, someTokenAddress, 2, customFeeValidity);
+        _feeSettings.setCustomFee(FeeTypes.TOKEN, someTokenAddress, 3, customFeeValidity);
+        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING, someTokenAddress, 4, customFeeValidity);
+        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER, someTokenAddress, 2, customFeeValidity);
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(10000, someTokenAddress), 3, "Token fee should be 3");
@@ -790,9 +790,9 @@ contract FeeSettingsTest is Test {
         assertEq(_feeSettings.privateOfferFee(10000, someTokenAddress), 2, "Private offer fee should be 2");
 
         // remove custom fee entry for this token address
-        _feeSettings.removeCustomFee(FeeTypes.TOKEN_FEE, someTokenAddress);
-        _feeSettings.removeCustomFee(FeeTypes.CROWDINVESTING_FEE, someTokenAddress);
-        _feeSettings.removeCustomFee(FeeTypes.PRIVATE_OFFER_FEE, someTokenAddress);
+        _feeSettings.removeCustomFee(FeeTypes.TOKEN, someTokenAddress);
+        _feeSettings.removeCustomFee(FeeTypes.CROWDINVESTING, someTokenAddress);
+        _feeSettings.removeCustomFee(FeeTypes.PRIVATE_OFFER, someTokenAddress);
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(10000, someTokenAddress), 10, "Token fee should be 10");
@@ -805,7 +805,7 @@ contract FeeSettingsTest is Test {
         vm.assume(feeSettings.managers(_rando) == false);
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.removeCustomFee(FeeTypes.TOKEN_FEE, someTokenAddress);
+        feeSettings.removeCustomFee(FeeTypes.TOKEN, someTokenAddress);
     }
 
     function testOwnerCanAddManager(address _manager) public {
@@ -864,7 +864,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -877,10 +877,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.tokenFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -897,7 +897,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress, _feeCollector);
 
         assertEq(
             feeSettings.tokenFeeCollector(exampleTokenAddress),
@@ -906,10 +906,10 @@ contract FeeSettingsTest is Test {
         );
 
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -927,7 +927,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -935,10 +935,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.crowdinvestingFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -954,7 +954,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress, _feeCollector);
 
         assertEq(
             feeSettings.crowdinvestingFeeCollector(exampleTokenAddress),
@@ -963,10 +963,10 @@ contract FeeSettingsTest is Test {
         );
 
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -979,7 +979,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -987,10 +987,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.privateOfferFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -1006,7 +1006,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress, _feeCollector);
 
         assertEq(
             feeSettings.privateOfferFeeCollector(exampleTokenAddress),
@@ -1015,10 +1015,10 @@ contract FeeSettingsTest is Test {
         );
 
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -1037,61 +1037,61 @@ contract FeeSettingsTest is Test {
         feeSettings.addManager(_manager);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
 
         vm.startPrank(_manager);
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress, _customFeeCollector);
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress, _customFeeCollector);
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress, _customFeeCollector);
         vm.stopPrank();
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
 
         vm.startPrank(_manager);
-        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress);
-        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress);
-        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress);
         vm.stopPrank();
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -1105,47 +1105,47 @@ contract FeeSettingsTest is Test {
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress, _customFeeCollector);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress, _customFeeCollector);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress, _customFeeCollector);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress);
     }
 
     function testSettingCustomFeeCollectorFor0AddressReverts() public {
         vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress, address(0));
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, exampleTokenAddress, address(0));
 
         vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress, address(0));
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, exampleTokenAddress, address(0));
 
         vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress, address(0));
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, exampleTokenAddress, address(0));
     }
 
     function testSettingCustomFeesFor0AddressReverts() public {
         vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, address(0), 1, uint64(block.timestamp + 100));
+        feeSettings.setCustomFee(FeeTypes.TOKEN, address(0), 1, uint64(block.timestamp + 100));
     }
 
     function testCustomFeeCollectorsOnlyApplyToSpecifiedAddress(address specifiedAddress, address someAddress) public {
@@ -1158,7 +1158,7 @@ contract FeeSettingsTest is Test {
         vm.startPrank(admin);
 
         // check token fee collector
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, specifiedAddress, customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, specifiedAddress, customFeeCollector);
         assertEq(
             feeSettings.tokenFeeCollector(specifiedAddress),
             customFeeCollector,
@@ -1179,10 +1179,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.crowdinvestingFeeCollector(someAddress), admin, "Crowdinvesting fee collector wrong");
         assertEq(feeSettings.privateOfferFeeCollector(someAddress), admin, "Private offer fee collector wrong");
 
-        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE, specifiedAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN, specifiedAddress);
 
         // test crowdinvesting fee collector
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, specifiedAddress, customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, specifiedAddress, customFeeCollector);
         assertEq(
             feeSettings.tokenFeeCollector(specifiedAddress),
             admin,
@@ -1203,10 +1203,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.crowdinvestingFeeCollector(someAddress), admin, "Crowdinvesting fee collector wrong");
         assertEq(feeSettings.privateOfferFeeCollector(someAddress), admin, "Private offer fee collector wrong");
 
-        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, specifiedAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING, specifiedAddress);
 
         // test private offer fee collector
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, specifiedAddress, customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, specifiedAddress, customFeeCollector);
         assertEq(
             feeSettings.tokenFeeCollector(specifiedAddress),
             admin,
@@ -1231,20 +1231,20 @@ contract FeeSettingsTest is Test {
     function testRemovingCustomFeeFor0AddressReverts() public {
         vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.removeCustomFee(FeeTypes.TOKEN_FEE, address(0));
+        feeSettings.removeCustomFee(FeeTypes.TOKEN, address(0));
     }
 
     function testRemovingCustomFeeCollectorsFor0AddressReverts() public {
         vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE, address(0));
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN, address(0));
 
         vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, address(0));
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING, address(0));
 
         vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(0));
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER, address(0));
     }
 }

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -91,30 +91,27 @@ contract FeeSettingsTest is Test {
         vm.assume(denominator > 0);
         vm.assume(!tokenOrPrivateOfferFeeInValidRange(numerator));
 
-        Fees memory feeChange = Fees(numerator, 1, 1, uint64(block.timestamp + 7884001));
-        vm.expectRevert("Token fee must be <= 5%");
+        vm.expectRevert("exceeds max numerator");
         vm.prank(admin);
-        feeSettings.planFeeChange(feeChange);
+        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, numerator, uint64(block.timestamp + 7884001));
     }
 
     function testEnforceCrowdinvestingFeeRangeInFeeChanger(uint32 numerator, uint32 denominator) public {
         vm.assume(denominator > 0);
         vm.assume(!crowdinvestingFeeInValidRange(numerator));
 
-        Fees memory feeChange = Fees(1, numerator, 1, uint64(block.timestamp + 7884001));
-        vm.expectRevert("Crowdinvesting fee must be <= 10%");
+        vm.expectRevert("exceeds max numerator");
         vm.prank(admin);
-        feeSettings.planFeeChange(feeChange);
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, numerator, uint64(block.timestamp + 7884001));
     }
 
     function testEnforcePrivateOfferFeeRangeInFeeChanger(uint32 numerator, uint32 denominator) public {
         vm.assume(denominator > 0);
         vm.assume(!tokenOrPrivateOfferFeeInValidRange(numerator));
 
-        Fees memory feeChange = Fees(1, 1, numerator, uint64(block.timestamp + 7884001));
-        vm.expectRevert("PrivateOffer fee must be <= 5%");
+        vm.expectRevert("exceeds max numerator");
         vm.prank(admin);
-        feeSettings.planFeeChange(feeChange);
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, numerator, uint64(block.timestamp + 7884001));
     }
 
     function testEnforceFeeChangeDelayOnIncrease(uint delay, uint32 startNumerator, uint32 newNumerator) public {
@@ -126,20 +123,17 @@ contract FeeSettingsTest is Test {
             feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
         );
 
-        Fees memory feeChange = Fees(newNumerator, 0, 0, uint64(block.timestamp + delay));
         vm.prank(admin);
-        vm.expectRevert("Fee change must be at least 12 weeks in the future");
-        _feeSettings.planFeeChange(feeChange);
+        vm.expectRevert("fee increase needs 12 week delay");
+        _feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, newNumerator, uint64(block.timestamp + delay));
 
-        feeChange = Fees(0, newNumerator, 0, uint64(block.timestamp + delay));
         vm.prank(admin);
-        vm.expectRevert("Fee change must be at least 12 weeks in the future");
-        _feeSettings.planFeeChange(feeChange);
+        vm.expectRevert("fee increase needs 12 week delay");
+        _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, newNumerator, uint64(block.timestamp + delay));
 
-        feeChange = Fees(0, 0, newNumerator, uint64(block.timestamp + delay));
         vm.prank(admin);
-        vm.expectRevert("Fee change must be at least 12 weeks in the future");
-        _feeSettings.planFeeChange(feeChange);
+        vm.expectRevert("fee increase needs 12 week delay");
+        _feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, newNumerator, uint64(block.timestamp + delay));
     }
 
     function testExecuteFeeChangeTooEarly(
@@ -151,19 +145,18 @@ contract FeeSettingsTest is Test {
         vm.assume(tokenOrPrivateOfferFeeInValidRange(tokenFeeNumerator));
         vm.assume(tokenOrPrivateOfferFeeInValidRange(investmentFeeNumerator));
 
-        Fees memory feeChange = Fees(
-            tokenFeeNumerator,
-            investmentFeeNumerator,
-            investmentFeeNumerator,
-            uint64(block.timestamp + delayAnnounced)
-        );
+        uint64 activationDate = uint64(block.timestamp + delayAnnounced);
         vm.prank(admin);
-        feeSettings.planFeeChange(feeChange);
+        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, tokenFeeNumerator, activationDate);
+        vm.prank(admin);
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, investmentFeeNumerator, activationDate);
+        vm.prank(admin);
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, investmentFeeNumerator, activationDate);
 
         vm.prank(admin);
-        vm.expectRevert("Fee change must be executed after the change time");
-        vm.warp(uint64(block.timestamp + delayAnnounced) - 1);
-        feeSettings.executeFeeChange();
+        vm.expectRevert("activation date not reached");
+        vm.warp(activationDate - 1);
+        feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
     }
 
     function testExecuteFeeChangeProperly(
@@ -180,29 +173,25 @@ contract FeeSettingsTest is Test {
         vm.assume(crowdinvestingFeeNumerator <= MAX_CROWDINVESTING_FEE);
         vm.assume(privateOfferFeeNumerator <= MAX_PRIVATE_OFFER_FEE);
 
-        Fees memory feeChange = Fees(
-            tokenFeeNumerator,
-            crowdinvestingFeeNumerator,
-            privateOfferFeeNumerator,
-            uint64(block.timestamp + delayAnnounced)
-        );
+        uint64 activationDate = uint64(block.timestamp + delayAnnounced);
         vm.prank(admin);
-        vm.expectEmit(true, true, true, true, address(feeSettings));
-        emit ChangeProposed(feeChange);
-        feeSettings.planFeeChange(feeChange);
+        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, tokenFeeNumerator, activationDate);
+        vm.prank(admin);
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, crowdinvestingFeeNumerator, activationDate);
+        vm.prank(admin);
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, privateOfferFeeNumerator, activationDate);
 
         vm.prank(admin);
-        vm.warp(uint64(block.timestamp + delayAnnounced) + 1);
-        vm.expectEmit(true, true, true, true, address(feeSettings));
-        emit SetFee(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator);
-        feeSettings.executeFeeChange();
+        vm.warp(activationDate + 1);
+        feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+        vm.prank(admin);
+        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+        vm.prank(admin);
+        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
 
-        (
-            uint32 _tokenFeeNumerator,
-            uint32 _crowdinvestingFeeNumerator,
-            uint32 _privateOfferFeeNumerator,
-
-        ) = feeSettings.fees(address(0));
+        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
 
         assertEq(_tokenFeeNumerator, tokenFeeNumerator);
         assertEq(_crowdinvestingFeeNumerator, crowdinvestingFeeNumerator);
@@ -210,36 +199,42 @@ contract FeeSettingsTest is Test {
     }
 
     function testSetFeeTo0Immediately() public {
-        Fees memory feeChange = Fees(0, 0, 0, uint64(block.timestamp));
+        uint64 activationDate = uint64(block.timestamp);
 
-        (
-            uint32 _tokenFeeNumerator,
-            uint32 _crowdinvestingFeeNumerator,
-            uint32 _privateOfferFeeNumerator,
-
-        ) = feeSettings.fees(address(0));
+        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
 
         assertEq(_tokenFeeNumerator, 1);
         assertEq(_crowdinvestingFeeNumerator, 2);
         assertEq(_privateOfferFeeNumerator, 3);
 
         vm.prank(admin);
-        feeSettings.planFeeChange(feeChange);
+        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 0, activationDate);
+        vm.prank(admin);
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, 0, activationDate);
+        vm.prank(admin);
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, 0, activationDate);
 
         vm.prank(admin);
-        //vm.warp(uint64(block.timestamp + delayAnnounced) + 1);
-        feeSettings.executeFeeChange();
+        feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+        vm.prank(admin);
+        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+        vm.prank(admin);
+        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
 
-        (_tokenFeeNumerator, _crowdinvestingFeeNumerator, _privateOfferFeeNumerator, ) = feeSettings.fees(address(0));
+        (, _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
 
         assertEq(_tokenFeeNumerator, 0);
         assertEq(_crowdinvestingFeeNumerator, 0);
         assertEq(_privateOfferFeeNumerator, 0);
 
-        (uint32 tokenFeeNumerator, , , uint64 time) = feeSettings.proposedDefaultFees();
+        (uint32 proposedNumerator, uint64 proposedActivationDate) = feeSettings.proposedFeeChanges(FeeTypes.TOKEN_FEE);
 
-        assertEq(tokenFeeNumerator, 0, "Token fee denominator mismatch");
-        assertEq(time, 0, "Time mismatch");
+        assertEq(proposedNumerator, 0, "Token fee denominator mismatch");
+        assertEq(proposedActivationDate, 0, "Time mismatch");
     }
 
     function testSetFeeToXFrom0Immediately() public {
@@ -249,22 +244,17 @@ contract FeeSettingsTest is Test {
             feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _fees, admin, admin, admin)
         );
 
-        Fees memory feeChange = Fees(1, 1, 1, 0);
-
-        (
-            uint32 _tokenFeeNumerator,
-            uint32 _crowdinvestingFeeNumerator,
-            uint32 _privateOfferFeeNumerator,
-
-        ) = _feeSettings.fees(address(0));
+        (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _crowdinvestingFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, uint32 _privateOfferFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
 
         assertEq(_tokenFeeNumerator, 0, "Token fee numerator mismatch");
         assertEq(_crowdinvestingFeeNumerator, 0, "Crowdinvesting fee numerator mismatch");
         assertEq(_privateOfferFeeNumerator, 0, "PrivateOffer fee numerator mismatch");
 
         vm.prank(admin);
-        vm.expectRevert("Fee change must be at least 12 weeks in the future");
-        _feeSettings.planFeeChange(feeChange);
+        vm.expectRevert("fee increase needs 12 week delay");
+        _feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 1, 0);
     }
 
     function testReduceFeeImmediately(uint32 tokenFee, uint32 crowdinvestingFee, uint32 privateOfferFee) public {
@@ -278,26 +268,32 @@ contract FeeSettingsTest is Test {
             feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, maxFee, admin, admin, admin)
         );
 
-        (
-            uint32 _tokenFeeNumerator,
-            uint32 _crowdinvestingFeeNumerator,
-            uint32 _privateOfferFeeNumerator,
-
-        ) = feeSettings.fees(address(0));
+        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
 
         assertEq(_tokenFeeNumerator, MAX_TOKEN_FEE);
         assertEq(_crowdinvestingFeeNumerator, MAX_CROWDINVESTING_FEE);
         assertEq(_privateOfferFeeNumerator, MAX_PRIVATE_OFFER_FEE);
 
-        // change fee to something lower
-        Fees memory feeChange = Fees(tokenFee, crowdinvestingFee, privateOfferFee, 0);
+        // change fee to something lower (immediate since it's a decrease)
         vm.prank(admin);
-        feeSettings.planFeeChange(feeChange);
+        feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, tokenFee, 0);
+        vm.prank(admin);
+        feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, crowdinvestingFee, 0);
+        vm.prank(admin);
+        feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, privateOfferFee, 0);
 
         vm.prank(admin);
-        feeSettings.executeFeeChange();
+        feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+        vm.prank(admin);
+        feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+        vm.prank(admin);
+        feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
 
-        (_tokenFeeNumerator, _crowdinvestingFeeNumerator, _privateOfferFeeNumerator, ) = feeSettings.fees(address(0));
+        (, _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
 
         assertEq(_tokenFeeNumerator, tokenFee);
         assertEq(_crowdinvestingFeeNumerator, crowdinvestingFee);
@@ -320,12 +316,9 @@ contract FeeSettingsTest is Test {
             feeSettingsCloneFactory.createFeeSettingsClone("salt2", trustedForwarder, admin, _fees, admin, admin, admin)
         );
 
-        (
-            uint32 _tokenFeeNumerator,
-            uint32 _crowdinvestingFeeNumerator,
-            uint32 _privateOfferFeeNumerator,
-
-        ) = _feeSettings.fees(address(0));
+        (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _crowdinvestingFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, uint32 _privateOfferFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
 
         assertEq(_tokenFeeNumerator, tokenFeeNumerator, "Token fee numerator mismatch");
         assertEq(_crowdinvestingFeeNumerator, crowdinvestingFeeNumerator, "Crowdinvesting fee numerator mismatch");
@@ -381,15 +374,15 @@ contract FeeSettingsTest is Test {
     }
 
     function testFeeCollector0FailsInSetter() public {
-        vm.expectRevert("Fee collector cannot be 0x0");
+        vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setFeeCollectors(address(0), address(1), address(2));
-        vm.expectRevert("Fee collector cannot be 0x0");
+        feeSettings.setDefaultFeeCollector(FeeTypes.TOKEN_FEE, address(0));
+        vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setFeeCollectors(address(2), address(0), address(1));
-        vm.expectRevert("Fee collector cannot be 0x0");
+        feeSettings.setDefaultFeeCollector(FeeTypes.CROWDINVESTING_FEE, address(0));
+        vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setFeeCollectors(address(1), address(2), address(0));
+        feeSettings.setDefaultFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(0));
     }
 
     function testUpdateFeeCollectors(
@@ -401,10 +394,11 @@ contract FeeSettingsTest is Test {
         vm.assume(newCrowdinvestingFeeCollector != address(0));
         vm.assume(newPrivateOfferFeeCollector != address(0));
 
-        vm.expectEmit(true, true, true, true, address(feeSettings));
-        emit FeeCollectorsChanged(newTokenFeeCollector, newCrowdinvestingFeeCollector, newPrivateOfferFeeCollector);
-        vm.prank(admin);
-        feeSettings.setFeeCollectors(newTokenFeeCollector, newCrowdinvestingFeeCollector, newPrivateOfferFeeCollector);
+        vm.startPrank(admin);
+        feeSettings.setDefaultFeeCollector(FeeTypes.TOKEN_FEE, newTokenFeeCollector);
+        feeSettings.setDefaultFeeCollector(FeeTypes.CROWDINVESTING_FEE, newCrowdinvestingFeeCollector);
+        feeSettings.setDefaultFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, newPrivateOfferFeeCollector);
+        vm.stopPrank();
         assertEq(feeSettings.feeCollector(), newTokenFeeCollector); // IFeeSettingsV1
         assertEq(feeSettings.tokenFeeCollector(address(4)), newTokenFeeCollector);
         assertEq(feeSettings.crowdinvestingFeeCollector(address(4)), newCrowdinvestingFeeCollector);
@@ -576,16 +570,17 @@ contract FeeSettingsTest is Test {
             )
         );
         // check there is no entry for this token address
-        (
-            uint32 tokenFeeNumerator,
-            uint32 crowdinvestingFeeNumerator,
-            uint32 privateOfferFeeNumerator,
-            uint64 endTime
-        ) = _feeSettings.fees(_someTokenAddress);
-        assertEq(tokenFeeNumerator, 0, "Token fee numerator should be 0");
-        assertEq(crowdinvestingFeeNumerator, 0, "Crowdinvesting fee numerator should be 0");
-        assertEq(privateOfferFeeNumerator, 0, "Private offer fee numerator should be 0");
-        assertEq(endTime, 0, "End time should be 0");
+        {
+            (uint32 tokenNum, uint64 tokenValidity) = _feeSettings.customFees(FeeTypes.TOKEN_FEE, _someTokenAddress);
+            (uint32 ciNum, uint64 ciValidity) = _feeSettings.customFees(FeeTypes.CROWDINVESTING_FEE, _someTokenAddress);
+            (uint32 poNum, uint64 poValidity) = _feeSettings.customFees(FeeTypes.PRIVATE_OFFER_FEE, _someTokenAddress);
+            assertEq(tokenNum, 0, "Token fee numerator should be 0");
+            assertEq(ciNum, 0, "Crowdinvesting fee numerator should be 0");
+            assertEq(poNum, 0, "Private offer fee numerator should be 0");
+            assertEq(tokenValidity, 0, "End time should be 0");
+            assertEq(ciValidity, 0, "End time should be 0");
+            assertEq(poValidity, 0, "End time should be 0");
+        }
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(10000, _someTokenAddress), 11, "Token fee should be 11");
@@ -594,8 +589,9 @@ contract FeeSettingsTest is Test {
 
         // add custom fee entry for this token address
         uint256 realEndTime = block.timestamp + 100;
-        _fees = Fees(3, 4, 2, uint64(realEndTime));
-        _feeSettings.setCustomFee(_someTokenAddress, _fees);
+        _feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, _someTokenAddress, 3, uint64(realEndTime));
+        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING_FEE, _someTokenAddress, 4, uint64(realEndTime));
+        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER_FEE, _someTokenAddress, 2, uint64(realEndTime));
 
         // check the token fee, private offer fee and crowdinvesting fee change as expected
         assertEq(_feeSettings.tokenFee(10000, _someTokenAddress), 3, "Token fee should be 3 now");
@@ -603,13 +599,15 @@ contract FeeSettingsTest is Test {
         assertEq(_feeSettings.privateOfferFee(10000, _someTokenAddress), 2, "Private offer fee should be 2 now");
 
         // check the custom fee entry is as expected
-        (tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, endTime) = _feeSettings.fees(
-            _someTokenAddress
-        );
-        assertEq(tokenFeeNumerator, 3, "Token fee numerator should be 3");
-        assertEq(crowdinvestingFeeNumerator, 4, "Crowdinvesting fee numerator should be 4");
-        assertEq(privateOfferFeeNumerator, 2, "Private offer fee numerator should be 2");
-        assertEq(endTime, realEndTime, "End time should match");
+        {
+            (uint32 tokenNum, uint64 tokenValidity) = _feeSettings.customFees(FeeTypes.TOKEN_FEE, _someTokenAddress);
+            (uint32 ciNum,) = _feeSettings.customFees(FeeTypes.CROWDINVESTING_FEE, _someTokenAddress);
+            (uint32 poNum,) = _feeSettings.customFees(FeeTypes.PRIVATE_OFFER_FEE, _someTokenAddress);
+            assertEq(tokenNum, 3, "Token fee numerator should be 3");
+            assertEq(ciNum, 4, "Crowdinvesting fee numerator should be 4");
+            assertEq(poNum, 2, "Private offer fee numerator should be 2");
+            assertEq(tokenValidity, realEndTime, "End time should match");
+        }
 
         // check that the custom fee is not applied after the end time
         vm.warp(realEndTime + 1);
@@ -623,11 +621,9 @@ contract FeeSettingsTest is Test {
         vm.assume(_rando != address(0));
         vm.assume(_rando != admin);
 
-        Fees memory _fees = Fees(1, 1, 1, 0);
-
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.setCustomFee(someTokenAddress, _fees);
+        feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, someTokenAddress, 1, uint64(block.timestamp + 100));
     }
 
     function testCustomFeesAreNotAppliedToOtherTokens(address _someTokenAddress, address _otherTokenAddress) public {
@@ -648,8 +644,10 @@ contract FeeSettingsTest is Test {
             )
         );
         // add custom fee entry for this token address
-        _fees = Fees(3, 4, 2, uint64(block.timestamp + 100));
-        _feeSettings.setCustomFee(_someTokenAddress, _fees);
+        uint64 customFeeValidity = uint64(block.timestamp + 100);
+        _feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, _someTokenAddress, 3, customFeeValidity);
+        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING_FEE, _someTokenAddress, 4, customFeeValidity);
+        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER_FEE, _someTokenAddress, 2, customFeeValidity);
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(10000, _otherTokenAddress), 10, "Token fee should be 10");
@@ -682,8 +680,10 @@ contract FeeSettingsTest is Test {
         assertEq(_feeSettings.privateOfferFee(type(uint256).max, someTokenAddress), 0, "Private offer fee should be 0");
 
         // add custom fee entry for this token address
-        _fees = Fees(1, 1, 1, uint64(block.timestamp + 100));
-        _feeSettings.setCustomFee(someTokenAddress, _fees);
+        uint64 customValidity = uint64(block.timestamp + 100);
+        _feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, someTokenAddress, 1, customValidity);
+        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING_FEE, someTokenAddress, 1, customValidity);
+        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER_FEE, someTokenAddress, 1, customValidity);
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(type(uint256).max, someTokenAddress), 0, "Token fee should still be 0");
@@ -714,8 +714,10 @@ contract FeeSettingsTest is Test {
             )
         );
         // add custom fee entry for this token address
-        _fees = Fees(3, 4, 2, uint64(block.timestamp + 100));
-        _feeSettings.setCustomFee(someTokenAddress, _fees);
+        uint64 customFeeValidity = uint64(block.timestamp + 100);
+        _feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, someTokenAddress, 3, customFeeValidity);
+        _feeSettings.setCustomFee(FeeTypes.CROWDINVESTING_FEE, someTokenAddress, 4, customFeeValidity);
+        _feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER_FEE, someTokenAddress, 2, customFeeValidity);
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(10000, someTokenAddress), 3, "Token fee should be 3");
@@ -723,7 +725,9 @@ contract FeeSettingsTest is Test {
         assertEq(_feeSettings.privateOfferFee(10000, someTokenAddress), 2, "Private offer fee should be 2");
 
         // remove custom fee entry for this token address
-        _feeSettings.removeCustomFee(someTokenAddress);
+        _feeSettings.removeCustomFee(FeeTypes.TOKEN_FEE, someTokenAddress);
+        _feeSettings.removeCustomFee(FeeTypes.CROWDINVESTING_FEE, someTokenAddress);
+        _feeSettings.removeCustomFee(FeeTypes.PRIVATE_OFFER_FEE, someTokenAddress);
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
         assertEq(_feeSettings.tokenFee(10000, someTokenAddress), 10, "Token fee should be 10");
@@ -736,7 +740,7 @@ contract FeeSettingsTest is Test {
         vm.assume(feeSettings.managers(_rando) == false);
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.removeCustomFee(someTokenAddress);
+        feeSettings.removeCustomFee(FeeTypes.TOKEN_FEE, someTokenAddress);
     }
 
     function testOwnerCanAddManager(address _manager) public {
@@ -795,7 +799,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.tokenFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -808,9 +812,9 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.tokenFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
 
         vm.prank(admin);
-        feeSettings.setCustomTokenFeeCollector(exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress, _feeCollector);
 
-        assertEq(feeSettings.tokenFeeCollectors(exampleTokenAddress), _feeCollector, "Custom fee collector wrong");
+        assertEq(feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress), _feeCollector, "Custom fee collector wrong");
         assertEq(
             feeSettings.tokenFeeCollector(exampleTokenAddress),
             _feeCollector,
@@ -824,7 +828,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         vm.prank(admin);
-        feeSettings.setCustomTokenFeeCollector(exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress, _feeCollector);
 
         assertEq(
             feeSettings.tokenFeeCollector(exampleTokenAddress),
@@ -833,10 +837,10 @@ contract FeeSettingsTest is Test {
         );
 
         vm.prank(admin);
-        feeSettings.removeCustomTokenFeeCollector(exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress);
 
         assertEq(
-            feeSettings.tokenFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -854,7 +858,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.crowdinvestingFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -862,10 +866,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.crowdinvestingFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
 
         vm.prank(admin);
-        feeSettings.setCustomCrowdinvestingFeeCollector(exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.crowdinvestingFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -881,7 +885,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         vm.prank(admin);
-        feeSettings.setCustomCrowdinvestingFeeCollector(exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress, _feeCollector);
 
         assertEq(
             feeSettings.crowdinvestingFeeCollector(exampleTokenAddress),
@@ -890,10 +894,10 @@ contract FeeSettingsTest is Test {
         );
 
         vm.prank(admin);
-        feeSettings.removeCustomCrowdinvestingFeeCollector(exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress);
 
         assertEq(
-            feeSettings.crowdinvestingFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -906,7 +910,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.privateOfferFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -914,10 +918,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.privateOfferFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
 
         vm.prank(admin);
-        feeSettings.setCustomPrivateOfferFeeCollector(exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.privateOfferFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -933,7 +937,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         vm.prank(admin);
-        feeSettings.setCustomPrivateOfferFeeCollector(exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress, _feeCollector);
 
         assertEq(
             feeSettings.privateOfferFeeCollector(exampleTokenAddress),
@@ -942,10 +946,10 @@ contract FeeSettingsTest is Test {
         );
 
         vm.prank(admin);
-        feeSettings.removeCustomPrivateOfferFeeCollector(exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress);
 
         assertEq(
-            feeSettings.privateOfferFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -964,61 +968,61 @@ contract FeeSettingsTest is Test {
         feeSettings.addManager(_manager);
 
         assertEq(
-            feeSettings.tokenFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.crowdinvestingFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.privateOfferFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
 
         vm.startPrank(_manager);
-        feeSettings.setCustomTokenFeeCollector(exampleTokenAddress, _customFeeCollector);
-        feeSettings.setCustomCrowdinvestingFeeCollector(exampleTokenAddress, _customFeeCollector);
-        feeSettings.setCustomPrivateOfferFeeCollector(exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress, _customFeeCollector);
         vm.stopPrank();
 
         assertEq(
-            feeSettings.tokenFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
         assertEq(
-            feeSettings.crowdinvestingFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
         assertEq(
-            feeSettings.privateOfferFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
 
         vm.startPrank(_manager);
-        feeSettings.removeCustomTokenFeeCollector(exampleTokenAddress);
-        feeSettings.removeCustomCrowdinvestingFeeCollector(exampleTokenAddress);
-        feeSettings.removeCustomPrivateOfferFeeCollector(exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress);
         vm.stopPrank();
 
         assertEq(
-            feeSettings.tokenFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.crowdinvestingFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.privateOfferFeeCollectors(exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -1032,47 +1036,47 @@ contract FeeSettingsTest is Test {
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.setCustomTokenFeeCollector(exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress, _customFeeCollector);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.setCustomCrowdinvestingFeeCollector(exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress, _customFeeCollector);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.setCustomPrivateOfferFeeCollector(exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress, _customFeeCollector);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.removeCustomTokenFeeCollector(exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.removeCustomCrowdinvestingFeeCollector(exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.removeCustomPrivateOfferFeeCollector(exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress);
     }
 
     function testSettingCustomFeeCollectorFor0AddressReverts() public {
-        vm.expectRevert("Fee collector cannot be 0x0");
+        vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setCustomTokenFeeCollector(exampleTokenAddress, address(0));
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress, address(0));
 
-        vm.expectRevert("Fee collector cannot be 0x0");
+        vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setCustomCrowdinvestingFeeCollector(exampleTokenAddress, address(0));
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress, address(0));
 
-        vm.expectRevert("Fee collector cannot be 0x0");
+        vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setCustomPrivateOfferFeeCollector(exampleTokenAddress, address(0));
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress, address(0));
     }
 
     function testSettingCustomFeesFor0AddressReverts() public {
-        vm.expectRevert("Token cannot be 0x0");
+        vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setCustomFee(address(0), Fees(1, 1, 1, 0));
+        feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, address(0), 1, uint64(block.timestamp + 100));
     }
 
     function testCustomFeeCollectorsOnlyApplyToSpecifiedAddress(address specifiedAddress, address someAddress) public {
@@ -1085,7 +1089,7 @@ contract FeeSettingsTest is Test {
         vm.startPrank(admin);
 
         // check token fee collector
-        feeSettings.setCustomTokenFeeCollector(specifiedAddress, customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,specifiedAddress, customFeeCollector);
         assertEq(
             feeSettings.tokenFeeCollector(specifiedAddress),
             customFeeCollector,
@@ -1106,10 +1110,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.crowdinvestingFeeCollector(someAddress), admin, "Crowdinvesting fee collector wrong");
         assertEq(feeSettings.privateOfferFeeCollector(someAddress), admin, "Private offer fee collector wrong");
 
-        feeSettings.removeCustomTokenFeeCollector(specifiedAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE,specifiedAddress);
 
         // test crowdinvesting fee collector
-        feeSettings.setCustomCrowdinvestingFeeCollector(specifiedAddress, customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,specifiedAddress, customFeeCollector);
         assertEq(
             feeSettings.tokenFeeCollector(specifiedAddress),
             admin,
@@ -1130,10 +1134,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.crowdinvestingFeeCollector(someAddress), admin, "Crowdinvesting fee collector wrong");
         assertEq(feeSettings.privateOfferFeeCollector(someAddress), admin, "Private offer fee collector wrong");
 
-        feeSettings.removeCustomCrowdinvestingFeeCollector(specifiedAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,specifiedAddress);
 
         // test private offer fee collector
-        feeSettings.setCustomPrivateOfferFeeCollector(specifiedAddress, customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,specifiedAddress, customFeeCollector);
         assertEq(
             feeSettings.tokenFeeCollector(specifiedAddress),
             admin,
@@ -1156,22 +1160,22 @@ contract FeeSettingsTest is Test {
     }
 
     function testRemovingCustomFeeFor0AddressReverts() public {
-        vm.expectRevert("Token cannot be 0x0");
+        vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.removeCustomFee(address(0));
+        feeSettings.removeCustomFee(FeeTypes.TOKEN_FEE, address(0));
     }
 
     function testRemovingCustomFeeCollectorsFor0AddressReverts() public {
-        vm.expectRevert("Token cannot be 0x0");
+        vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.removeCustomTokenFeeCollector(address(0));
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE,address(0));
 
-        vm.expectRevert("Token cannot be 0x0");
+        vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.removeCustomCrowdinvestingFeeCollector(address(0));
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,address(0));
 
-        vm.expectRevert("Token cannot be 0x0");
+        vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.removeCustomPrivateOfferFeeCollector(address(0));
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,address(0));
     }
 }

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -601,8 +601,8 @@ contract FeeSettingsTest is Test {
         // check the custom fee entry is as expected
         {
             (uint32 tokenNum, uint64 tokenValidity) = _feeSettings.customFees(FeeTypes.TOKEN_FEE, _someTokenAddress);
-            (uint32 ciNum,) = _feeSettings.customFees(FeeTypes.CROWDINVESTING_FEE, _someTokenAddress);
-            (uint32 poNum,) = _feeSettings.customFees(FeeTypes.PRIVATE_OFFER_FEE, _someTokenAddress);
+            (uint32 ciNum, ) = _feeSettings.customFees(FeeTypes.CROWDINVESTING_FEE, _someTokenAddress);
+            (uint32 poNum, ) = _feeSettings.customFees(FeeTypes.PRIVATE_OFFER_FEE, _someTokenAddress);
             assertEq(tokenNum, 3, "Token fee numerator should be 3");
             assertEq(ciNum, 4, "Crowdinvesting fee numerator should be 4");
             assertEq(poNum, 2, "Private offer fee numerator should be 2");
@@ -799,7 +799,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -812,9 +812,13 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.tokenFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress, _feeCollector);
 
-        assertEq(feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress), _feeCollector, "Custom fee collector wrong");
+        assertEq(
+            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
+            _feeCollector,
+            "Custom fee collector wrong"
+        );
         assertEq(
             feeSettings.tokenFeeCollector(exampleTokenAddress),
             _feeCollector,
@@ -828,7 +832,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress, _feeCollector);
 
         assertEq(
             feeSettings.tokenFeeCollector(exampleTokenAddress),
@@ -837,10 +841,10 @@ contract FeeSettingsTest is Test {
         );
 
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -858,7 +862,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -866,10 +870,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.crowdinvestingFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -885,7 +889,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress, _feeCollector);
 
         assertEq(
             feeSettings.crowdinvestingFeeCollector(exampleTokenAddress),
@@ -894,10 +898,10 @@ contract FeeSettingsTest is Test {
         );
 
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -910,7 +914,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -918,10 +922,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.privateOfferFeeCollector(exampleTokenAddress), admin, "Fee collector not admin address");
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress, _feeCollector);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
             _feeCollector,
             "Custom fee collector wrong"
         );
@@ -937,7 +941,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_feeCollector != admin);
 
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress, _feeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress, _feeCollector);
 
         assertEq(
             feeSettings.privateOfferFeeCollector(exampleTokenAddress),
@@ -946,10 +950,10 @@ contract FeeSettingsTest is Test {
         );
 
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -968,61 +972,61 @@ contract FeeSettingsTest is Test {
         feeSettings.addManager(_manager);
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
 
         vm.startPrank(_manager);
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress, _customFeeCollector);
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress, _customFeeCollector);
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress, _customFeeCollector);
         vm.stopPrank();
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
             _customFeeCollector,
             "Custom fee collector wrong"
         );
 
         vm.startPrank(_manager);
-        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress);
-        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress);
-        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress);
         vm.stopPrank();
 
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.TOKEN_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
         assertEq(
-            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress),
+            feeSettings.feeCollectors(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress),
             address(0),
             "Should not be custom fee collector yet"
         );
@@ -1036,41 +1040,41 @@ contract FeeSettingsTest is Test {
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress, _customFeeCollector);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress, _customFeeCollector);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress, _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress, _customFeeCollector);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress);
 
         vm.expectRevert("Only managers can call this function");
         vm.prank(_rando);
-        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress);
     }
 
     function testSettingCustomFeeCollectorFor0AddressReverts() public {
         vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,exampleTokenAddress, address(0));
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, exampleTokenAddress, address(0));
 
         vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,exampleTokenAddress, address(0));
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, exampleTokenAddress, address(0));
 
         vm.expectRevert("collector cannot be 0x0");
         vm.prank(admin);
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,exampleTokenAddress, address(0));
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, exampleTokenAddress, address(0));
     }
 
     function testSettingCustomFeesFor0AddressReverts() public {
@@ -1089,7 +1093,7 @@ contract FeeSettingsTest is Test {
         vm.startPrank(admin);
 
         // check token fee collector
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE,specifiedAddress, customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, specifiedAddress, customFeeCollector);
         assertEq(
             feeSettings.tokenFeeCollector(specifiedAddress),
             customFeeCollector,
@@ -1110,10 +1114,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.crowdinvestingFeeCollector(someAddress), admin, "Crowdinvesting fee collector wrong");
         assertEq(feeSettings.privateOfferFeeCollector(someAddress), admin, "Private offer fee collector wrong");
 
-        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE,specifiedAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE, specifiedAddress);
 
         // test crowdinvesting fee collector
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,specifiedAddress, customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, specifiedAddress, customFeeCollector);
         assertEq(
             feeSettings.tokenFeeCollector(specifiedAddress),
             admin,
@@ -1134,10 +1138,10 @@ contract FeeSettingsTest is Test {
         assertEq(feeSettings.crowdinvestingFeeCollector(someAddress), admin, "Crowdinvesting fee collector wrong");
         assertEq(feeSettings.privateOfferFeeCollector(someAddress), admin, "Private offer fee collector wrong");
 
-        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,specifiedAddress);
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, specifiedAddress);
 
         // test private offer fee collector
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,specifiedAddress, customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, specifiedAddress, customFeeCollector);
         assertEq(
             feeSettings.tokenFeeCollector(specifiedAddress),
             admin,
@@ -1168,14 +1172,14 @@ contract FeeSettingsTest is Test {
     function testRemovingCustomFeeCollectorsFor0AddressReverts() public {
         vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE,address(0));
+        feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN_FEE, address(0));
 
         vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE,address(0));
+        feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, address(0));
 
         vm.expectRevert("token cannot be 0x0");
         vm.prank(admin);
-        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE,address(0));
+        feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(0));
     }
 }

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -137,7 +137,12 @@ contract FeeSettingsTest is Test {
         vm.assume(newNumerator <= MAX_PRIVATE_OFFER);
         vm.assume(newNumerator > startNumerator);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, buildFeeTypes(startNumerator, startNumerator, startNumerator, admin, admin, admin))
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                admin,
+                buildFeeTypes(startNumerator, startNumerator, startNumerator, admin, admin, admin)
+            )
         );
 
         vm.prank(admin);
@@ -257,7 +262,12 @@ contract FeeSettingsTest is Test {
     function testSetFeeToXFrom0Immediately() public {
         vm.prank(admin);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin))
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                admin,
+                buildFeeTypes(0, 0, 0, admin, admin, admin)
+            )
         );
 
         (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
@@ -280,7 +290,12 @@ contract FeeSettingsTest is Test {
 
         // create new fee settings with max fee
         feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, buildFeeTypes(MAX_TOKEN, MAX_CROWDINVESTING, MAX_PRIVATE_OFFER, admin, admin, admin))
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                admin,
+                buildFeeTypes(MAX_TOKEN, MAX_CROWDINVESTING, MAX_PRIVATE_OFFER, admin, admin, admin)
+            )
         );
 
         (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
@@ -326,7 +341,19 @@ contract FeeSettingsTest is Test {
                 privateOfferFeeNumerator <= MAX_PRIVATE_OFFER
         );
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt2", trustedForwarder, admin, buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, admin, admin, admin))
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt2",
+                trustedForwarder,
+                admin,
+                buildFeeTypes(
+                    tokenFeeNumerator,
+                    crowdinvestingFeeNumerator,
+                    privateOfferFeeNumerator,
+                    admin,
+                    admin,
+                    admin
+                )
+            )
         );
 
         (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
@@ -352,12 +379,7 @@ contract FeeSettingsTest is Test {
 
         {
             FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
-            feeType[0] = FeeSettings.FeeTypeInit(
-                FeeTypes.CROWDINVESTING,
-                1000,
-                2,
-                address(0)
-            );
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, 2, address(0));
             vm.expectRevert("Fee collector cannot be 0x0");
             _feeSettings = FeeSettings(
                 feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType)
@@ -366,12 +388,7 @@ contract FeeSettingsTest is Test {
 
         {
             FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
-            feeType[0] = FeeSettings.FeeTypeInit(
-                FeeTypes.PRIVATE_OFFER,
-                500,
-                3,
-                address(0)
-            );
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, 3, address(0));
             vm.expectRevert("Fee collector cannot be 0x0");
             _feeSettings = FeeSettings(
                 feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType)
@@ -436,7 +453,19 @@ contract FeeSettingsTest is Test {
         vm.assume(amount < UINT256_MAX / MAX_CROWDINVESTING);
 
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt5", trustedForwarder, admin, buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, admin, admin, admin))
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt5",
+                trustedForwarder,
+                admin,
+                buildFeeTypes(
+                    tokenFeeNumerator,
+                    crowdinvestingFeeNumerator,
+                    privateOfferFeeNumerator,
+                    admin,
+                    admin,
+                    admin
+                )
+            )
         );
 
         assertEq(
@@ -471,7 +500,12 @@ contract FeeSettingsTest is Test {
 
         {
             FeeSettings _feeSettings = FeeSettings(
-                feeSettingsCloneFactory.createFeeSettingsClone("salt4", trustedForwarder, admin, buildFeeTypes(0, crowdinvestingFeeNumerator, privateOfferFeeNumerator, admin, admin, admin))
+                feeSettingsCloneFactory.createFeeSettingsClone(
+                    "salt4",
+                    trustedForwarder,
+                    admin,
+                    buildFeeTypes(0, crowdinvestingFeeNumerator, privateOfferFeeNumerator, admin, admin, admin)
+                )
             );
 
             assertEq(_feeSettings.tokenFee(amount, address(0)), 0, "Token fee mismatch");
@@ -491,7 +525,12 @@ contract FeeSettingsTest is Test {
 
         {
             FeeSettings _feeSettings = FeeSettings(
-                feeSettingsCloneFactory.createFeeSettingsClone("salt3", trustedForwarder, admin, buildFeeTypes(tokenFeeNumerator, 0, privateOfferFeeNumerator, admin, admin, admin))
+                feeSettingsCloneFactory.createFeeSettingsClone(
+                    "salt3",
+                    trustedForwarder,
+                    admin,
+                    buildFeeTypes(tokenFeeNumerator, 0, privateOfferFeeNumerator, admin, admin, admin)
+                )
             );
             assertEq(
                 _feeSettings.tokenFee(amount, address(0)),
@@ -510,7 +549,12 @@ contract FeeSettingsTest is Test {
 
         {
             FeeSettings _feeSettings = FeeSettings(
-                feeSettingsCloneFactory.createFeeSettingsClone("salt2", trustedForwarder, admin, buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, 0, admin, admin, admin))
+                feeSettingsCloneFactory.createFeeSettingsClone(
+                    "salt2",
+                    trustedForwarder,
+                    admin,
+                    buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, 0, admin, admin, admin)
+                )
             );
             assertEq(
                 _feeSettings.tokenFee(amount, address(0)),
@@ -571,7 +615,12 @@ contract FeeSettingsTest is Test {
 
         // deploying from here makes address(this) the admin
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, address(this), buildFeeTypes(11, 22, 55, address(this), address(this), address(this)))
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                address(this),
+                buildFeeTypes(11, 22, 55, address(this), address(this), address(this))
+            )
         );
         // check there is no entry for this token address
         {
@@ -636,7 +685,12 @@ contract FeeSettingsTest is Test {
         vm.assume(_someTokenAddress != _otherTokenAddress);
 
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, address(this), buildFeeTypes(10, 20, 50, admin, admin, admin))
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                address(this),
+                buildFeeTypes(10, 20, 50, admin, admin, admin)
+            )
         );
         // add custom fee entry for this token address
         uint64 customFeeValidity = uint64(block.timestamp + 100);
@@ -653,7 +707,12 @@ contract FeeSettingsTest is Test {
     function testCustomFeesDoNotIncreaseFee() public {
         address someTokenAddress = address(74);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, address(this), buildFeeTypes(0, 0, 0, admin, admin, admin))
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                address(this),
+                buildFeeTypes(0, 0, 0, admin, admin, admin)
+            )
         );
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
@@ -688,7 +747,12 @@ contract FeeSettingsTest is Test {
     function testRemovingCustomFee() public {
         address someTokenAddress = address(74);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, address(this), buildFeeTypes(10, 20, 50, admin, admin, admin))
+            feeSettingsCloneFactory.createFeeSettingsClone(
+                "salt",
+                trustedForwarder,
+                address(this),
+                buildFeeTypes(10, 20, 50, admin, admin, admin)
+            )
         );
         // add custom fee entry for this token address
         uint64 customFeeValidity = uint64(block.timestamp + 100);
@@ -1171,9 +1235,9 @@ contract FeeSettingsTest is Test {
 
         FeeSettings.FeeTypeInit[] memory feeTypeInits = new FeeSettings.FeeTypeInit[](allFeeTypes.length);
         for (uint256 i = 0; i < allFeeTypes.length; i++) {
-            uint32 maxNumerator     = uint32((i + 1) * 100);
+            uint32 maxNumerator = uint32((i + 1) * 100);
             uint32 defaultNumerator = uint32((i + 1) * 50);
-            address collector       = address(uint160(i + 1));
+            address collector = address(uint160(i + 1));
             feeTypeInits[i] = FeeSettings.FeeTypeInit(allFeeTypes[i], maxNumerator, defaultNumerator, collector);
         }
 
@@ -1184,18 +1248,14 @@ contract FeeSettingsTest is Test {
         );
 
         for (uint256 i = 0; i < allFeeTypes.length; i++) {
-            uint32 expectedMax     = uint32((i + 1) * 100);
+            uint32 expectedMax = uint32((i + 1) * 100);
             uint32 expectedDefault = uint32((i + 1) * 50);
             address expectedCollector = address(uint160(i + 1));
 
             (uint32 actualMax, uint32 actualDefault) = freshFeeSettings.feeTypeConfigs(allFeeTypes[i]);
-            assertEq(actualMax,     expectedMax,     "maxNumerator wrong");
+            assertEq(actualMax, expectedMax, "maxNumerator wrong");
             assertEq(actualDefault, expectedDefault, "defaultNumerator wrong");
-            assertEq(
-                freshFeeSettings.feeCollector(allFeeTypes[i], address(0)),
-                expectedCollector,
-                "collector wrong"
-            );
+            assertEq(freshFeeSettings.feeCollector(allFeeTypes[i], address(0)), expectedCollector, "collector wrong");
         }
     }
 
@@ -1237,15 +1297,7 @@ contract FeeSettingsTest is Test {
         vm.stopPrank();
 
         uint256 expectedFee = (amount * defaultNumerator) / freshFeeSettings.FEE_DENOMINATOR();
-        assertEq(
-            freshFeeSettings.fee(feeType, amount, exampleTokenAddress),
-            expectedFee,
-            "Fee calculation wrong"
-        );
-        assertEq(
-            freshFeeSettings.feeCollector(feeType, exampleTokenAddress),
-            collector,
-            "Collector wrong"
-        );
+        assertEq(freshFeeSettings.fee(feeType, amount, exampleTokenAddress), expectedFee, "Fee calculation wrong");
+        assertEq(freshFeeSettings.feeCollector(feeType, exampleTokenAddress), collector, "Collector wrong");
     }
 }

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -44,11 +44,13 @@ contract FeeSettingsTest is Test {
     address public constant exampleTokenAddress = address(74);
 
     function _buildFeeTypes(address collector) internal pure returns (FeeSettings.FeeTypeInit[] memory) {
-        FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+        FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
         feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 1, collector);
         feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 2, collector);
         feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 3, collector);
         feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, collector);
+        feeTypes[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION_FEE, 500, 0, collector);
+        feeTypes[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT_FEE, 500, 0, collector);
         return feeTypes;
     }
 
@@ -56,7 +58,7 @@ contract FeeSettingsTest is Test {
         Fees memory _fees,
         address collector
     ) internal pure returns (FeeSettings.FeeTypeInit[] memory) {
-        FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+        FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
         feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, _fees.tokenFeeNumerator, collector);
         feeTypes[1] = FeeSettings.FeeTypeInit(
             FeeTypes.CROWDINVESTING_FEE,
@@ -71,6 +73,8 @@ contract FeeSettingsTest is Test {
             collector
         );
         feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, collector);
+        feeTypes[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION_FEE, 500, 0, collector);
+        feeTypes[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT_FEE, 500, 0, collector);
         return feeTypes;
     }
 

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -6,6 +6,7 @@ import "../lib/forge-std/src/console.sol";
 import "../contracts/Token.sol";
 import "../contracts/factories/FeeSettingsCloneFactory.sol";
 import "../contracts/interfaces/IFeeSettings.sol";
+import "./resources/CloneCreators.sol";
 
 contract FeeSettingsTest is Test {
     uint32 constant MAX_TOKEN = 500;
@@ -18,13 +19,11 @@ contract FeeSettingsTest is Test {
         address indexed newCrowdinvestingFeeCollector,
         address indexed newPrivateOfferFeeCollector
     );
-    event ChangeProposed(Fees proposal);
     event ManagerAdded(address indexed manager);
     event ManagerRemoved(address indexed manager);
 
     FeeSettings feeSettings;
     FeeSettingsCloneFactory feeSettingsCloneFactory;
-    Fees fees;
     Token token;
     Token currency;
 
@@ -54,30 +53,10 @@ contract FeeSettingsTest is Test {
         return feeTypes;
     }
 
-    function _buildFeeTypesFromFees(
-        Fees memory _fees,
-        address collector
-    ) internal pure returns (FeeSettings.FeeTypeInit[] memory) {
-        FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
-        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, _fees.tokenFeeNumerator, collector);
-        feeTypes[1] = FeeSettings.FeeTypeInit(
-            FeeTypes.CROWDINVESTING,
-            1000,
-            _fees.crowdinvestingFeeNumerator,
-            collector
-        );
-        feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, _fees.privateOfferFeeNumerator, collector);
-        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, 0, collector);
-        feeTypes[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION, 500, 0, collector);
-        feeTypes[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT, 500, 0, collector);
-        return feeTypes;
-    }
-
     function setUp() public {
         FeeSettings logic = new FeeSettings(trustedForwarder);
         feeSettingsCloneFactory = new FeeSettingsCloneFactory(address(logic));
 
-        fees = Fees(1, 2, 3, 0);
         vm.prank(admin);
         feeSettings = FeeSettings(
             feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, _buildFeeTypes(admin))
@@ -157,14 +136,8 @@ contract FeeSettingsTest is Test {
         vm.assume(delay <= 12 weeks);
         vm.assume(newNumerator <= MAX_PRIVATE_OFFER);
         vm.assume(newNumerator > startNumerator);
-        Fees memory _fees = Fees(startNumerator, startNumerator, startNumerator, 0);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt",
-                trustedForwarder,
-                admin,
-                _buildFeeTypesFromFees(_fees, admin)
-            )
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, buildFeeTypes(startNumerator, startNumerator, startNumerator, admin, admin, admin))
         );
 
         vm.prank(admin);
@@ -282,15 +255,9 @@ contract FeeSettingsTest is Test {
     }
 
     function testSetFeeToXFrom0Immediately() public {
-        Fees memory _fees = Fees(0, 0, 0, 0);
         vm.prank(admin);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt",
-                trustedForwarder,
-                admin,
-                _buildFeeTypesFromFees(_fees, admin)
-            )
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, buildFeeTypes(0, 0, 0, admin, admin, admin))
         );
 
         (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
@@ -312,14 +279,8 @@ contract FeeSettingsTest is Test {
         vm.assume(privateOfferFee <= MAX_PRIVATE_OFFER);
 
         // create new fee settings with max fee
-        Fees memory maxFee = Fees(MAX_TOKEN, MAX_CROWDINVESTING, MAX_PRIVATE_OFFER, 0);
         feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt",
-                trustedForwarder,
-                admin,
-                _buildFeeTypesFromFees(maxFee, admin)
-            )
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, buildFeeTypes(MAX_TOKEN, MAX_CROWDINVESTING, MAX_PRIVATE_OFFER, admin, admin, admin))
         );
 
         (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
@@ -364,15 +325,8 @@ contract FeeSettingsTest is Test {
                 crowdinvestingFeeNumerator <= MAX_CROWDINVESTING &&
                 privateOfferFeeNumerator <= MAX_PRIVATE_OFFER
         );
-        FeeSettings _feeSettings;
-        Fees memory _fees = Fees(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
-        _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt2",
-                trustedForwarder,
-                admin,
-                _buildFeeTypesFromFees(_fees, admin)
-            )
+        FeeSettings _feeSettings = FeeSettings(
+            feeSettingsCloneFactory.createFeeSettingsClone("salt2", trustedForwarder, admin, buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, admin, admin, admin))
         );
 
         (, uint32 _tokenFeeNumerator) = _feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
@@ -389,7 +343,7 @@ contract FeeSettingsTest is Test {
 
         {
             FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
-            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, fees.tokenFeeNumerator, address(0));
+            feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, 1, address(0));
             vm.expectRevert("Fee collector cannot be 0x0");
             _feeSettings = FeeSettings(
                 feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, admin, feeType)
@@ -401,7 +355,7 @@ contract FeeSettingsTest is Test {
             feeType[0] = FeeSettings.FeeTypeInit(
                 FeeTypes.CROWDINVESTING,
                 1000,
-                fees.crowdinvestingFeeNumerator,
+                2,
                 address(0)
             );
             vm.expectRevert("Fee collector cannot be 0x0");
@@ -415,7 +369,7 @@ contract FeeSettingsTest is Test {
             feeType[0] = FeeSettings.FeeTypeInit(
                 FeeTypes.PRIVATE_OFFER,
                 500,
-                fees.privateOfferFeeNumerator,
+                3,
                 address(0)
             );
             vm.expectRevert("Fee collector cannot be 0x0");
@@ -481,14 +435,8 @@ contract FeeSettingsTest is Test {
         vm.assume(privateOfferFeeNumerator <= MAX_PRIVATE_OFFER);
         vm.assume(amount < UINT256_MAX / MAX_CROWDINVESTING);
 
-        Fees memory _fees = Fees(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt5",
-                trustedForwarder,
-                admin,
-                _buildFeeTypesFromFees(_fees, admin)
-            )
+            feeSettingsCloneFactory.createFeeSettingsClone("salt5", trustedForwarder, admin, buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, admin, admin, admin))
         );
 
         assertEq(
@@ -521,73 +469,61 @@ contract FeeSettingsTest is Test {
 
         // only token fee is 0
 
-        Fees memory _fees = Fees(0, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
-        FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt4",
-                trustedForwarder,
-                admin,
-                _buildFeeTypesFromFees(_fees, admin)
-            )
-        );
+        {
+            FeeSettings _feeSettings = FeeSettings(
+                feeSettingsCloneFactory.createFeeSettingsClone("salt4", trustedForwarder, admin, buildFeeTypes(0, crowdinvestingFeeNumerator, privateOfferFeeNumerator, admin, admin, admin))
+            );
 
-        assertEq(_feeSettings.tokenFee(amount, address(0)), 0, "Token fee mismatch");
-        assertEq(
-            _feeSettings.crowdinvestingFee(amount, address(0)),
-            (amount * crowdinvestingFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
-            "Investment fee mismatch"
-        );
-        assertEq(
-            _feeSettings.privateOfferFee(amount, address(0)),
-            (amount * privateOfferFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
-            "Private offer fee mismatch"
-        );
+            assertEq(_feeSettings.tokenFee(amount, address(0)), 0, "Token fee mismatch");
+            assertEq(
+                _feeSettings.crowdinvestingFee(amount, address(0)),
+                (amount * crowdinvestingFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
+                "Investment fee mismatch"
+            );
+            assertEq(
+                _feeSettings.privateOfferFee(amount, address(0)),
+                (amount * privateOfferFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
+                "Private offer fee mismatch"
+            );
+        }
 
         // only crowdinvesting fee is 0
 
-        _fees = Fees(tokenFeeNumerator, 0, privateOfferFeeNumerator, 0);
-        _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt3",
-                trustedForwarder,
-                admin,
-                _buildFeeTypesFromFees(_fees, admin)
-            )
-        );
-        assertEq(
-            _feeSettings.tokenFee(amount, address(0)),
-            (amount * tokenFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
-            "Token fee mismatch"
-        );
-        assertEq(_feeSettings.crowdinvestingFee(amount, address(0)), 0, "Investment fee mismatch");
-        assertEq(
-            _feeSettings.privateOfferFee(amount, address(0)),
-            (amount * privateOfferFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
-            "Private offer fee mismatch"
-        );
+        {
+            FeeSettings _feeSettings = FeeSettings(
+                feeSettingsCloneFactory.createFeeSettingsClone("salt3", trustedForwarder, admin, buildFeeTypes(tokenFeeNumerator, 0, privateOfferFeeNumerator, admin, admin, admin))
+            );
+            assertEq(
+                _feeSettings.tokenFee(amount, address(0)),
+                (amount * tokenFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
+                "Token fee mismatch"
+            );
+            assertEq(_feeSettings.crowdinvestingFee(amount, address(0)), 0, "Investment fee mismatch");
+            assertEq(
+                _feeSettings.privateOfferFee(amount, address(0)),
+                (amount * privateOfferFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
+                "Private offer fee mismatch"
+            );
+        }
 
         // only private offer fee is 0
 
-        _fees = Fees(tokenFeeNumerator, crowdinvestingFeeNumerator, 0, 0);
-        _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt2",
-                trustedForwarder,
-                admin,
-                _buildFeeTypesFromFees(_fees, admin)
-            )
-        );
-        assertEq(
-            _feeSettings.tokenFee(amount, address(0)),
-            (amount * tokenFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
-            "Token fee mismatch"
-        );
-        assertEq(
-            _feeSettings.crowdinvestingFee(amount, address(0)),
-            (amount * crowdinvestingFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
-            "Investment fee mismatch"
-        );
-        assertEq(_feeSettings.privateOfferFee(amount, address(0)), 0, "Private offer fee mismatch");
+        {
+            FeeSettings _feeSettings = FeeSettings(
+                feeSettingsCloneFactory.createFeeSettingsClone("salt2", trustedForwarder, admin, buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, 0, admin, admin, admin))
+            );
+            assertEq(
+                _feeSettings.tokenFee(amount, address(0)),
+                (amount * tokenFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
+                "Token fee mismatch"
+            );
+            assertEq(
+                _feeSettings.crowdinvestingFee(amount, address(0)),
+                (amount * crowdinvestingFeeNumerator) / _feeSettings.FEE_DENOMINATOR(),
+                "Investment fee mismatch"
+            );
+            assertEq(_feeSettings.privateOfferFee(amount, address(0)), 0, "Private offer fee mismatch");
+        }
     }
 
     function testERC165IsAvailable() public view {
@@ -633,15 +569,9 @@ contract FeeSettingsTest is Test {
     function testAddingCustomFees(address _someTokenAddress) public {
         vm.assume(_someTokenAddress != address(0));
 
-        Fees memory _fees = Fees(11, 22, 55, 0);
         // deploying from here makes address(this) the admin
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt",
-                trustedForwarder,
-                address(this),
-                _buildFeeTypesFromFees(_fees, address(this))
-            )
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, address(this), buildFeeTypes(11, 22, 55, address(this), address(this), address(this)))
         );
         // check there is no entry for this token address
         {
@@ -705,14 +635,8 @@ contract FeeSettingsTest is Test {
         vm.assume(_otherTokenAddress != address(0));
         vm.assume(_someTokenAddress != _otherTokenAddress);
 
-        Fees memory _fees = Fees(10, 20, 50, 0);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt",
-                trustedForwarder,
-                address(this),
-                _buildFeeTypesFromFees(_fees, admin)
-            )
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, address(this), buildFeeTypes(10, 20, 50, admin, admin, admin))
         );
         // add custom fee entry for this token address
         uint64 customFeeValidity = uint64(block.timestamp + 100);
@@ -728,14 +652,8 @@ contract FeeSettingsTest is Test {
 
     function testCustomFeesDoNotIncreaseFee() public {
         address someTokenAddress = address(74);
-        Fees memory _fees = Fees(0, 0, 0, 0);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt",
-                trustedForwarder,
-                address(this),
-                _buildFeeTypesFromFees(_fees, admin)
-            )
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, address(this), buildFeeTypes(0, 0, 0, admin, admin, admin))
         );
 
         // check the token fee, private offer fee and crowdinvesting fee are as expected
@@ -769,14 +687,8 @@ contract FeeSettingsTest is Test {
 
     function testRemovingCustomFee() public {
         address someTokenAddress = address(74);
-        Fees memory _fees = Fees(10, 20, 50, 0);
         FeeSettings _feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt",
-                trustedForwarder,
-                address(this),
-                _buildFeeTypesFromFees(_fees, admin)
-            )
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, address(this), buildFeeTypes(10, 20, 50, admin, admin, admin))
         );
         // add custom fee entry for this token address
         uint64 customFeeValidity = uint64(block.timestamp + 100);

--- a/test/FeeSettingsCloneFactory.t.sol
+++ b/test/FeeSettingsCloneFactory.t.sol
@@ -4,15 +4,10 @@ pragma solidity 0.8.23;
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";
 import "../contracts/factories/FeeSettingsCloneFactory.sol";
+import "../contracts/interfaces/IFeeSettings.sol";
 
 contract tokenTest is Test {
     FeeSettingsCloneFactory factory;
-
-    // address public constant admin = 0x0109709eCFa91a80626FF3989D68f67f5b1dD120;
-    // address public constant requirer = 0x1109709ecFA91a80626ff3989D68f67F5B1Dd121;
-    // address public constant transfererAdmin = 0x5109709EcFA91a80626ff3989d68f67F5B1dD125;
-    // address public constant transferer = 0x6109709EcFA91A80626FF3989d68f67F5b1dd126;
-    // address public constant pauser = 0x7109709eCfa91A80626Ff3989D68f67f5b1dD127;
 
     bytes32 exampleRawSalt = "salt";
     address public constant exampleToken = 0x8109709ecfa91a80626fF3989d68f67F5B1dD128;
@@ -21,11 +16,37 @@ contract tokenTest is Test {
     address public constant exampleTokenFeeCollector = 0x3109709ECfA91A80626fF3989D68f67F5B1Dd123;
     address public constant exampleCrowdinvestingFeeCollector = 0x4109709eCFa91A80626ff3989d68F67f5b1DD124;
     address public constant examplePrivateOfferFeeCollector = 0x4109709eCFa91A80626ff3989d68F67f5b1DD124;
-    Fees exampleFees1 = Fees(1, 2, 3, 0);
-    Fees exampleFees2 = Fees(70, 80, 90, 0);
+
+    // exampleFees1: tokenFee=1, crowdinvestingFee=2, privateOfferFee=3
+    // exampleFees2: tokenFee=70, crowdinvestingFee=80, privateOfferFee=90
 
     function setUp() public {
         factory = new FeeSettingsCloneFactory(address(new FeeSettings(exampleTrustedForwarder)));
+    }
+
+    function _buildFeeTypes(
+        uint32 tokenNum,
+        uint32 ciNum,
+        uint32 poNum,
+        address tokenCollector,
+        address ciCollector,
+        address poCollector
+    ) internal pure returns (FeeSettings.FeeTypeInit[] memory) {
+        FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](4);
+        feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, tokenNum, tokenCollector);
+        feeType[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, ciNum, ciCollector);
+        feeType[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, poNum, poCollector);
+        feeType[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, poCollector);
+        return feeType;
+    }
+
+    function _buildFeeTypesAllSame(
+        uint32 tokenNum,
+        uint32 ciNum,
+        uint32 poNum,
+        address collector
+    ) internal pure returns (FeeSettings.FeeTypeInit[] memory) {
+        return _buildFeeTypes(tokenNum, ciNum, poNum, collector, collector, collector);
     }
 
     function testAddressPrediction(
@@ -40,38 +61,21 @@ contract tokenTest is Test {
         vm.assume(_crowdinvestingFeeCollector != address(0));
         vm.assume(_privateOfferFeeCollector != address(0));
 
-        bytes32 salt = keccak256(
-            abi.encode(
-                _rawSalt,
-                exampleTrustedForwarder,
-                _owner,
-                exampleFees1,
-                _tokenFeeCollector,
-                _crowdinvestingFeeCollector,
-                _privateOfferFeeCollector
-            )
+        FeeSettings.FeeTypeInit[] memory feeTypes = _buildFeeTypes(
+            1,
+            2,
+            3,
+            _tokenFeeCollector,
+            _crowdinvestingFeeCollector,
+            _privateOfferFeeCollector
         );
+
+        bytes32 salt = keccak256(abi.encode(_rawSalt, exampleTrustedForwarder, _owner, feeTypes));
 
         address expected1 = factory.predictCloneAddress(salt);
-        address expected2 = factory.predictCloneAddress(
-            _rawSalt,
-            exampleTrustedForwarder,
-            _owner,
-            exampleFees1,
-            _tokenFeeCollector,
-            _crowdinvestingFeeCollector,
-            _privateOfferFeeCollector
-        );
+        address expected2 = factory.predictCloneAddress(_rawSalt, exampleTrustedForwarder, _owner, feeTypes);
 
-        address actual = factory.createFeeSettingsClone(
-            _rawSalt,
-            exampleTrustedForwarder,
-            _owner,
-            exampleFees1,
-            _tokenFeeCollector,
-            _crowdinvestingFeeCollector,
-            _privateOfferFeeCollector
-        );
+        address actual = factory.createFeeSettingsClone(_rawSalt, exampleTrustedForwarder, _owner, feeTypes);
 
         assertEq(expected1, expected2, "address prediction with salt and params not equal");
         assertEq(expected1, actual, "address prediction failed");
@@ -80,115 +84,111 @@ contract tokenTest is Test {
     function testChangingParametersChangesAddress() public view {
         address someAddress = address(42);
 
-        address base = factory.predictCloneAddress(
-            exampleRawSalt,
-            exampleTrustedForwarder,
-            exampleOwner,
-            exampleFees1,
+        FeeSettings.FeeTypeInit[] memory baseFeeTypes = _buildFeeTypes(
+            1,
+            2,
+            3,
             exampleTokenFeeCollector,
             exampleCrowdinvestingFeeCollector,
             examplePrivateOfferFeeCollector
         );
 
-        address changed = factory.predictCloneAddress(
-            "0",
-            exampleTrustedForwarder,
-            exampleOwner,
-            exampleFees2,
+        address base = factory.predictCloneAddress(exampleRawSalt, exampleTrustedForwarder, exampleOwner, baseFeeTypes);
+
+        FeeSettings.FeeTypeInit[] memory changedFeeTypes;
+
+        changedFeeTypes = _buildFeeTypes(
+            1,
+            2,
+            3,
             exampleTokenFeeCollector,
             exampleCrowdinvestingFeeCollector,
             examplePrivateOfferFeeCollector
         );
+        address changed = factory.predictCloneAddress("0", exampleTrustedForwarder, exampleOwner, changedFeeTypes);
         assertTrue(base != changed, "addresses equal with raw salt changed");
 
-        changed = factory.predictCloneAddress(
-            exampleRawSalt,
-            exampleTrustedForwarder,
-            exampleOwner,
-            exampleFees2,
+        changedFeeTypes = _buildFeeTypes(
+            70,
+            80,
+            90,
             exampleTokenFeeCollector,
             exampleCrowdinvestingFeeCollector,
             examplePrivateOfferFeeCollector
         );
+        changed = factory.predictCloneAddress(exampleRawSalt, exampleTrustedForwarder, exampleOwner, changedFeeTypes);
         assertTrue(base != changed, "addresses equal with fees changed");
 
-        changed = factory.predictCloneAddress(
-            exampleRawSalt,
-            someAddress,
-            exampleOwner,
-            exampleFees1,
+        changedFeeTypes = _buildFeeTypes(
+            1,
+            2,
+            3,
             exampleTokenFeeCollector,
             exampleCrowdinvestingFeeCollector,
             examplePrivateOfferFeeCollector
         );
+        changed = factory.predictCloneAddress(exampleRawSalt, someAddress, exampleOwner, changedFeeTypes);
         assertTrue(base != changed, "addresses equal with trustedForwarder changed");
 
-        changed = factory.predictCloneAddress(
-            exampleRawSalt,
-            exampleTrustedForwarder,
-            someAddress,
-            exampleFees1,
+        changedFeeTypes = _buildFeeTypes(
+            1,
+            2,
+            3,
             exampleTokenFeeCollector,
             exampleCrowdinvestingFeeCollector,
             examplePrivateOfferFeeCollector
         );
+        changed = factory.predictCloneAddress(exampleRawSalt, exampleTrustedForwarder, someAddress, changedFeeTypes);
         assertTrue(base != changed, "addresses equal with owner changed");
 
-        changed = factory.predictCloneAddress(
-            exampleRawSalt,
-            exampleTrustedForwarder,
-            exampleOwner,
-            exampleFees1,
+        changedFeeTypes = _buildFeeTypes(
+            1,
+            2,
+            3,
             someAddress,
             exampleCrowdinvestingFeeCollector,
             examplePrivateOfferFeeCollector
         );
+        changed = factory.predictCloneAddress(exampleRawSalt, exampleTrustedForwarder, exampleOwner, changedFeeTypes);
         assertTrue(base != changed, "addresses equal with tokenFeeCollector changed");
 
-        changed = factory.predictCloneAddress(
-            exampleRawSalt,
-            exampleTrustedForwarder,
-            exampleOwner,
-            exampleFees1,
+        changedFeeTypes = _buildFeeTypes(
+            1,
+            2,
+            3,
             exampleTokenFeeCollector,
             someAddress,
             examplePrivateOfferFeeCollector
         );
+        changed = factory.predictCloneAddress(exampleRawSalt, exampleTrustedForwarder, exampleOwner, changedFeeTypes);
         assertTrue(base != changed, "addresses equal with crowdinvestingFeeCollector changed");
 
-        changed = factory.predictCloneAddress(
-            exampleRawSalt,
-            exampleTrustedForwarder,
-            exampleOwner,
-            exampleFees1,
+        changedFeeTypes = _buildFeeTypes(
+            1,
+            2,
+            3,
             exampleTokenFeeCollector,
             exampleCrowdinvestingFeeCollector,
             someAddress
         );
+        changed = factory.predictCloneAddress(exampleRawSalt, exampleTrustedForwarder, exampleOwner, changedFeeTypes);
         assertTrue(base != changed, "addresses equal with privateOfferFeeCollector changed");
     }
 
     function testSecondDeploymentFails() public {
-        factory.createFeeSettingsClone(
-            exampleRawSalt,
-            exampleTrustedForwarder,
-            exampleOwner,
-            exampleFees1,
+        FeeSettings.FeeTypeInit[] memory feeTypes = _buildFeeTypes(
+            1,
+            2,
+            3,
             exampleTokenFeeCollector,
             exampleCrowdinvestingFeeCollector,
             examplePrivateOfferFeeCollector
         );
 
+        factory.createFeeSettingsClone(exampleRawSalt, exampleTrustedForwarder, exampleOwner, feeTypes);
+
         vm.expectRevert("ERC1167: create2 failed");
-        factory.createFeeSettingsClone(
-            exampleRawSalt,
-            exampleTrustedForwarder,
-            exampleOwner,
-            exampleFees1,
-            exampleTokenFeeCollector,
-            exampleCrowdinvestingFeeCollector,
-            examplePrivateOfferFeeCollector
-        );
+        factory.createFeeSettingsClone(exampleRawSalt, exampleTrustedForwarder, exampleOwner, feeTypes);
     }
 
     function testInitialization(
@@ -202,16 +202,17 @@ contract tokenTest is Test {
         vm.assume(_crowdinvestingFeeCollector != address(0));
         vm.assume(_privateOfferFeeCollector != address(0));
 
+        FeeSettings.FeeTypeInit[] memory feeTypes = _buildFeeTypes(
+            1,
+            2,
+            3,
+            _tokenFeeCollector,
+            _crowdinvestingFeeCollector,
+            _privateOfferFeeCollector
+        );
+
         FeeSettings feeSettings = FeeSettings(
-            factory.createFeeSettingsClone(
-                exampleRawSalt,
-                exampleTrustedForwarder,
-                _owner,
-                exampleFees1,
-                _tokenFeeCollector,
-                _crowdinvestingFeeCollector,
-                _privateOfferFeeCollector
-            )
+            factory.createFeeSettingsClone(exampleRawSalt, exampleTrustedForwarder, _owner, feeTypes)
         );
 
         assertEq(feeSettings.owner(), _owner, "owner not set");
@@ -232,18 +233,8 @@ contract tokenTest is Test {
         (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
         (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
 
-        assertEq(_tokenFeeNumerator, exampleFees1.tokenFeeNumerator, "defaultTokenFeeNumerator not set");
-
-        assertEq(
-            _crowdinvestingFeeNumerator,
-            exampleFees1.crowdinvestingFeeNumerator,
-            "defaultCrowdinvestingFeeNumerator not set"
-        );
-
-        assertEq(
-            _privateOfferFeeNumerator,
-            exampleFees1.privateOfferFeeNumerator,
-            "defaultPrivateOfferFeeNumerator not set"
-        );
+        assertEq(_tokenFeeNumerator, 1, "defaultTokenFeeNumerator not set");
+        assertEq(_crowdinvestingFeeNumerator, 2, "defaultCrowdinvestingFeeNumerator not set");
+        assertEq(_privateOfferFeeNumerator, 3, "defaultPrivateOfferFeeNumerator not set");
     }
 }

--- a/test/FeeSettingsCloneFactory.t.sol
+++ b/test/FeeSettingsCloneFactory.t.sol
@@ -32,11 +32,13 @@ contract tokenTest is Test {
         address ciCollector,
         address poCollector
     ) internal pure returns (FeeSettings.FeeTypeInit[] memory) {
-        FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](4);
+        FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](6);
         feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, tokenNum, tokenCollector);
         feeType[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, ciNum, ciCollector);
         feeType[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, poNum, poCollector);
         feeType[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, poCollector);
+        feeType[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION_FEE, 500, 0, poCollector);
+        feeType[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT_FEE, 500, 0, poCollector);
         return feeType;
     }
 

--- a/test/FeeSettingsCloneFactory.t.sol
+++ b/test/FeeSettingsCloneFactory.t.sol
@@ -228,12 +228,9 @@ contract tokenTest is Test {
             "privateOfferFeeCollector not set"
         );
 
-        (
-            uint32 _tokenFeeNumerator,
-            uint32 _crowdinvestingFeeNumerator,
-            uint32 _privateOfferFeeNumerator,
-
-        ) = feeSettings.fees(address(0));
+        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
 
         assertEq(_tokenFeeNumerator, exampleFees1.tokenFeeNumerator, "defaultTokenFeeNumerator not set");
 

--- a/test/FeeSettingsCloneFactory.t.sol
+++ b/test/FeeSettingsCloneFactory.t.sol
@@ -32,13 +32,13 @@ contract tokenTest is Test {
         address ciCollector,
         address poCollector
     ) internal pure returns (FeeSettings.FeeTypeInit[] memory) {
-        FeeSettings.FeeTypeInit[] memory feeType= new FeeSettings.FeeTypeInit[](6);
-        feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, tokenNum, tokenCollector);
-        feeType[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, ciNum, ciCollector);
-        feeType[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, poNum, poCollector);
-        feeType[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, poCollector);
-        feeType[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION_FEE, 500, 0, poCollector);
-        feeType[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT_FEE, 500, 0, poCollector);
+        FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](6);
+        feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, tokenNum, tokenCollector);
+        feeType[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, ciNum, ciCollector);
+        feeType[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, poNum, poCollector);
+        feeType[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, 0, poCollector);
+        feeType[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION, 500, 0, poCollector);
+        feeType[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT, 500, 0, poCollector);
         return feeType;
     }
 
@@ -231,9 +231,9 @@ contract tokenTest is Test {
             "privateOfferFeeCollector not set"
         );
 
-        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
-        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
+        (, uint32 _tokenFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.TOKEN);
+        (, uint32 _crowdinvestingFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.CROWDINVESTING);
+        (, uint32 _privateOfferFeeNumerator) = feeSettings.feeTypeConfigs(FeeTypes.PRIVATE_OFFER);
 
         assertEq(_tokenFeeNumerator, 1, "defaultTokenFeeNumerator not set");
         assertEq(_crowdinvestingFeeNumerator, 2, "defaultCrowdinvestingFeeNumerator not set");

--- a/test/FeeSettingsERC2771.t.sol
+++ b/test/FeeSettingsERC2771.t.sol
@@ -37,8 +37,6 @@ contract FeeSettingERC2771Test is Test {
     uint32 public constant crowdinvestingFeeNumerator = 50;
     uint32 public constant privateOfferFeeNumerator = 70;
 
-    Fees fees = Fees(feeSettingsFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
-
     bytes32 domainSeparator;
     bytes32 requestType;
 
@@ -51,14 +49,7 @@ contract FeeSettingERC2771Test is Test {
 
     function setUpFeeSettingsWithForwarder(Forwarder forwarder) public {
         // this is part of the platform setup, but we need it here to use the correct forwarder
-        feeSettings = createFeeSettings(
-            address(forwarder),
-            platformColdWallet,
-            fees,
-            feeCollector,
-            feeCollector,
-            feeCollector
-        );
+        feeSettings = createFeeSettings(address(forwarder), platformColdWallet, buildFeeTypes(feeSettingsFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, feeCollector, feeCollector, feeCollector));
 
         // make platform hot wallet a manager
         vm.prank(platformColdWallet);

--- a/test/FeeSettingsERC2771.t.sol
+++ b/test/FeeSettingsERC2771.t.sol
@@ -105,7 +105,7 @@ contract FeeSettingERC2771Test is Test {
         // 1. build request
         bytes memory payload = abi.encodeWithSelector(
             feeSettings.setCustomFee.selector,
-            FeeTypes.TOKEN_FEE,
+            FeeTypes.TOKEN,
             _token,
             _customTokenFeeNumerator,
             uint64(block.timestamp + 100 * 365 days)
@@ -138,7 +138,7 @@ contract FeeSettingERC2771Test is Test {
         require(digest.recover(signature) == request.from, "FWD: signature mismatch");
 
         // 4. check state before execution
-        (uint32 feeNumerator, uint64 endTime) = feeSettings.customFees(FeeTypes.TOKEN_FEE, _token);
+        (uint32 feeNumerator, uint64 endTime) = feeSettings.customFees(FeeTypes.TOKEN, _token);
         console.log("feeNumerator", feeNumerator);
         console.log("endTime", endTime);
         assertTrue(feeNumerator == 0, "Custom fee not 0 before");
@@ -159,7 +159,7 @@ contract FeeSettingERC2771Test is Test {
         _forwarder.execute(request, domainSeparator, requestType, suffixData, signature);
 
         // 6. check state after execution
-        (feeNumerator, endTime) = feeSettings.customFees(FeeTypes.TOKEN_FEE, _token);
+        (feeNumerator, endTime) = feeSettings.customFees(FeeTypes.TOKEN, _token);
         console.log("feeNumerator", feeNumerator);
         console.log("endTime", endTime);
         assertTrue(feeNumerator == _customTokenFeeNumerator, "Custom fee not set");

--- a/test/FeeSettingsERC2771.t.sol
+++ b/test/FeeSettingsERC2771.t.sol
@@ -5,6 +5,7 @@ import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";
 import "../contracts/factories/FeeSettingsCloneFactory.sol";
 import "../contracts/FeeSettings.sol";
+import "../contracts/interfaces/IFeeSettings.sol";
 import "./resources/ERC2771Helper.sol";
 import "./resources/CloneCreators.sol";
 import "@opengsn/contracts/src/forwarder/Forwarder.sol"; // chose specific version to avoid import error: yarn add @opengsn/contracts@2.2.5
@@ -97,19 +98,18 @@ contract FeeSettingERC2771Test is Test {
 
         setUpFeeSettingsWithForwarder(_forwarder);
 
-        Fees memory customFees = Fees(
-            _customTokenFeeNumerator,
-            crowdinvestingFeeNumerator,
-            privateOfferFeeNumerator,
-            100 * 365 days
-        );
-
         /*
          * set custom fee
          */
 
         // 1. build request
-        bytes memory payload = abi.encodeWithSelector(feeSettings.setCustomFee.selector, _token, customFees);
+        bytes memory payload = abi.encodeWithSelector(
+            feeSettings.setCustomFee.selector,
+            FeeTypes.TOKEN_FEE,
+            _token,
+            _customTokenFeeNumerator,
+            uint64(block.timestamp + 100 * 365 days)
+        );
 
         IForwarder.ForwardRequest memory request = IForwarder.ForwardRequest({
             from: platformHotWallet,
@@ -138,7 +138,7 @@ contract FeeSettingERC2771Test is Test {
         require(digest.recover(signature) == request.from, "FWD: signature mismatch");
 
         // 4. check state before execution
-        (uint32 feeNumerator, , , uint64 endTime) = feeSettings.fees(_token);
+        (uint32 feeNumerator, uint64 endTime) = feeSettings.customFees(FeeTypes.TOKEN_FEE, _token);
         console.log("feeNumerator", feeNumerator);
         console.log("endTime", endTime);
         assertTrue(feeNumerator == 0, "Custom fee not 0 before");
@@ -159,7 +159,7 @@ contract FeeSettingERC2771Test is Test {
         _forwarder.execute(request, domainSeparator, requestType, suffixData, signature);
 
         // 6. check state after execution
-        (feeNumerator, , , endTime) = feeSettings.fees(_token);
+        (feeNumerator, endTime) = feeSettings.customFees(FeeTypes.TOKEN_FEE, _token);
         console.log("feeNumerator", feeNumerator);
         console.log("endTime", endTime);
         assertTrue(feeNumerator == _customTokenFeeNumerator, "Custom fee not set");

--- a/test/FeeSettingsERC2771.t.sol
+++ b/test/FeeSettingsERC2771.t.sol
@@ -49,7 +49,18 @@ contract FeeSettingERC2771Test is Test {
 
     function setUpFeeSettingsWithForwarder(Forwarder forwarder) public {
         // this is part of the platform setup, but we need it here to use the correct forwarder
-        feeSettings = createFeeSettings(address(forwarder), platformColdWallet, buildFeeTypes(feeSettingsFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, feeCollector, feeCollector, feeCollector));
+        feeSettings = createFeeSettings(
+            address(forwarder),
+            platformColdWallet,
+            buildFeeTypes(
+                feeSettingsFeeNumerator,
+                crowdinvestingFeeNumerator,
+                privateOfferFeeNumerator,
+                feeCollector,
+                feeCollector,
+                feeCollector
+            )
+        );
 
         // make platform hot wallet a manager
         vm.prank(platformColdWallet);

--- a/test/FeeSettingsIntegration.t.sol
+++ b/test/FeeSettingsIntegration.t.sol
@@ -99,7 +99,12 @@ contract FeeSettingsIntegrationTest is Test {
         assertEq(token.balanceOf(_customFeeCollector), 0, "token.balanceOf(customFeeCollector) != 0 before");
 
         vm.startPrank(platformAdmin);
-        feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFee(
+            FeeTypes.TOKEN_FEE,
+            address(token),
+            customFees.tokenFeeNumerator,
+            customFees.validityDate
+        );
         feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, address(token), _customFeeCollector);
         vm.stopPrank();
         vm.prank(companyAdmin);
@@ -121,8 +126,18 @@ contract FeeSettingsIntegrationTest is Test {
         vm.warp(100 * 365 days);
 
         vm.startPrank(platformAdmin);
-        feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
-        feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER_FEE, address(token), customFees.privateOfferFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFee(
+            FeeTypes.TOKEN_FEE,
+            address(token),
+            customFees.tokenFeeNumerator,
+            customFees.validityDate
+        );
+        feeSettings.setCustomFee(
+            FeeTypes.PRIVATE_OFFER_FEE,
+            address(token),
+            customFees.privateOfferFeeNumerator,
+            customFees.validityDate
+        );
         feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(token), _customFeeCollector);
         vm.stopPrank();
 
@@ -198,8 +213,18 @@ contract FeeSettingsIntegrationTest is Test {
         vm.warp(100 * 365 days);
 
         vm.startPrank(platformAdmin);
-        feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
-        feeSettings.setCustomFee(FeeTypes.CROWDINVESTING_FEE, address(token), customFees.crowdinvestingFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFee(
+            FeeTypes.TOKEN_FEE,
+            address(token),
+            customFees.tokenFeeNumerator,
+            customFees.validityDate
+        );
+        feeSettings.setCustomFee(
+            FeeTypes.CROWDINVESTING_FEE,
+            address(token),
+            customFees.crowdinvestingFeeNumerator,
+            customFees.validityDate
+        );
         feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, address(token), _customFeeCollector);
         vm.stopPrank();
 

--- a/test/FeeSettingsIntegration.t.sol
+++ b/test/FeeSettingsIntegration.t.sol
@@ -42,18 +42,14 @@ contract FeeSettingsIntegrationTest is Test {
         FeeSettings feeSettingsLogic = new FeeSettings(trustedForwarder);
         FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(address(feeSettingsLogic));
         customFees = Fees(10, 20, 30, 101 * 365 days);
-        Fees memory fees = Fees(101, 102, 103, 0);
+        FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 101, platformAdmin);
+        feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 102, platformAdmin);
+        feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 103, platformAdmin);
+        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, platformAdmin);
         vm.prank(platformAdmin);
         feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                "salt",
-                trustedForwarder,
-                platformAdmin,
-                fees,
-                platformAdmin,
-                platformAdmin,
-                platformAdmin
-            )
+            feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, platformAdmin, feeTypes)
         );
 
         vm.startPrank(paymentTokenProvider);

--- a/test/FeeSettingsIntegration.t.sol
+++ b/test/FeeSettingsIntegration.t.sol
@@ -14,7 +14,10 @@ import "./resources/CloneCreators.sol";
 
 contract FeeSettingsIntegrationTest is Test {
     FeeSettings feeSettings;
-    Fees customFees;
+    uint32 customTokenFeeNumerator;
+    uint32 customCrowdinvestingFeeNumerator;
+    uint32 customPrivateOfferFeeNumerator;
+    uint64 customFeeValidity;
     Token token;
     FakePaymentToken currency;
     PrivateOfferFactory privateOfferFactory;
@@ -41,7 +44,10 @@ contract FeeSettingsIntegrationTest is Test {
     function setUp() public {
         FeeSettings feeSettingsLogic = new FeeSettings(trustedForwarder);
         FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(address(feeSettingsLogic));
-        customFees = Fees(10, 20, 30, 101 * 365 days);
+        customTokenFeeNumerator = 10;
+        customCrowdinvestingFeeNumerator = 20;
+        customPrivateOfferFeeNumerator = 30;
+        customFeeValidity = uint64(101 * 365 days);
         FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
         feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, 101, platformAdmin);
         feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, 102, platformAdmin);
@@ -95,7 +101,7 @@ contract FeeSettingsIntegrationTest is Test {
         assertEq(token.balanceOf(_customFeeCollector), 0, "token.balanceOf(customFeeCollector) != 0 before");
 
         vm.startPrank(platformAdmin);
-        feeSettings.setCustomFee(FeeTypes.TOKEN, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFee(FeeTypes.TOKEN, address(token), customTokenFeeNumerator, customFeeValidity);
         feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, address(token), _customFeeCollector);
         vm.stopPrank();
         vm.prank(companyAdmin);
@@ -117,12 +123,12 @@ contract FeeSettingsIntegrationTest is Test {
         vm.warp(100 * 365 days);
 
         vm.startPrank(platformAdmin);
-        feeSettings.setCustomFee(FeeTypes.TOKEN, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFee(FeeTypes.TOKEN, address(token), customTokenFeeNumerator, customFeeValidity);
         feeSettings.setCustomFee(
             FeeTypes.PRIVATE_OFFER,
             address(token),
-            customFees.privateOfferFeeNumerator,
-            customFees.validityDate
+            customPrivateOfferFeeNumerator,
+            customFeeValidity
         );
         feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, address(token), _customFeeCollector);
         vm.stopPrank();
@@ -199,12 +205,12 @@ contract FeeSettingsIntegrationTest is Test {
         vm.warp(100 * 365 days);
 
         vm.startPrank(platformAdmin);
-        feeSettings.setCustomFee(FeeTypes.TOKEN, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFee(FeeTypes.TOKEN, address(token), customTokenFeeNumerator, customFeeValidity);
         feeSettings.setCustomFee(
             FeeTypes.CROWDINVESTING,
             address(token),
-            customFees.crowdinvestingFeeNumerator,
-            customFees.validityDate
+            customCrowdinvestingFeeNumerator,
+            customFeeValidity
         );
         feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, address(token), _customFeeCollector);
         vm.stopPrank();

--- a/test/FeeSettingsIntegration.t.sol
+++ b/test/FeeSettingsIntegration.t.sol
@@ -5,6 +5,7 @@ import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";
 import "../contracts/Token.sol";
 import "../contracts/factories/FeeSettingsCloneFactory.sol";
+import "../contracts/interfaces/IFeeSettings.sol";
 import "../contracts/factories/CrowdinvestingCloneFactory.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
@@ -98,8 +99,8 @@ contract FeeSettingsIntegrationTest is Test {
         assertEq(token.balanceOf(_customFeeCollector), 0, "token.balanceOf(customFeeCollector) != 0 before");
 
         vm.startPrank(platformAdmin);
-        feeSettings.setCustomFee(address(token), customFees);
-        feeSettings.setCustomTokenFeeCollector(address(token), _customFeeCollector);
+        feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, address(token), _customFeeCollector);
         vm.stopPrank();
         vm.prank(companyAdmin);
         token.mint(investor, tokenAmount);
@@ -120,8 +121,9 @@ contract FeeSettingsIntegrationTest is Test {
         vm.warp(100 * 365 days);
 
         vm.startPrank(platformAdmin);
-        feeSettings.setCustomFee(address(token), customFees);
-        feeSettings.setCustomPrivateOfferFeeCollector(address(token), _customFeeCollector);
+        feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFee(FeeTypes.PRIVATE_OFFER_FEE, address(token), customFees.privateOfferFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(token), _customFeeCollector);
         vm.stopPrank();
 
         assertEq(token.balanceOf(investor), 0, "token.balanceOf(investor) != 0 before");
@@ -196,8 +198,9 @@ contract FeeSettingsIntegrationTest is Test {
         vm.warp(100 * 365 days);
 
         vm.startPrank(platformAdmin);
-        feeSettings.setCustomFee(address(token), customFees);
-        feeSettings.setCustomCrowdinvestingFeeCollector(address(token), _customFeeCollector);
+        feeSettings.setCustomFee(FeeTypes.TOKEN_FEE, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFee(FeeTypes.CROWDINVESTING_FEE, address(token), customFees.crowdinvestingFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, address(token), _customFeeCollector);
         vm.stopPrank();
 
         assertEq(token.balanceOf(investor), 0, "token.balanceOf(investor) != 0 before");

--- a/test/FeeSettingsIntegration.t.sol
+++ b/test/FeeSettingsIntegration.t.sol
@@ -43,10 +43,10 @@ contract FeeSettingsIntegrationTest is Test {
         FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(address(feeSettingsLogic));
         customFees = Fees(10, 20, 30, 101 * 365 days);
         FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
-        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 101, platformAdmin);
-        feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 102, platformAdmin);
-        feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 103, platformAdmin);
-        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, platformAdmin);
+        feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, 101, platformAdmin);
+        feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, 102, platformAdmin);
+        feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, 103, platformAdmin);
+        feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, 0, platformAdmin);
         vm.prank(platformAdmin);
         feeSettings = FeeSettings(
             feeSettingsCloneFactory.createFeeSettingsClone("salt", trustedForwarder, platformAdmin, feeTypes)
@@ -95,13 +95,8 @@ contract FeeSettingsIntegrationTest is Test {
         assertEq(token.balanceOf(_customFeeCollector), 0, "token.balanceOf(customFeeCollector) != 0 before");
 
         vm.startPrank(platformAdmin);
-        feeSettings.setCustomFee(
-            FeeTypes.TOKEN_FEE,
-            address(token),
-            customFees.tokenFeeNumerator,
-            customFees.validityDate
-        );
-        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN_FEE, address(token), _customFeeCollector);
+        feeSettings.setCustomFee(FeeTypes.TOKEN, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
+        feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, address(token), _customFeeCollector);
         vm.stopPrank();
         vm.prank(companyAdmin);
         token.mint(investor, tokenAmount);
@@ -122,19 +117,14 @@ contract FeeSettingsIntegrationTest is Test {
         vm.warp(100 * 365 days);
 
         vm.startPrank(platformAdmin);
+        feeSettings.setCustomFee(FeeTypes.TOKEN, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
         feeSettings.setCustomFee(
-            FeeTypes.TOKEN_FEE,
-            address(token),
-            customFees.tokenFeeNumerator,
-            customFees.validityDate
-        );
-        feeSettings.setCustomFee(
-            FeeTypes.PRIVATE_OFFER_FEE,
+            FeeTypes.PRIVATE_OFFER,
             address(token),
             customFees.privateOfferFeeNumerator,
             customFees.validityDate
         );
-        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER_FEE, address(token), _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, address(token), _customFeeCollector);
         vm.stopPrank();
 
         assertEq(token.balanceOf(investor), 0, "token.balanceOf(investor) != 0 before");
@@ -209,19 +199,14 @@ contract FeeSettingsIntegrationTest is Test {
         vm.warp(100 * 365 days);
 
         vm.startPrank(platformAdmin);
+        feeSettings.setCustomFee(FeeTypes.TOKEN, address(token), customFees.tokenFeeNumerator, customFees.validityDate);
         feeSettings.setCustomFee(
-            FeeTypes.TOKEN_FEE,
-            address(token),
-            customFees.tokenFeeNumerator,
-            customFees.validityDate
-        );
-        feeSettings.setCustomFee(
-            FeeTypes.CROWDINVESTING_FEE,
+            FeeTypes.CROWDINVESTING,
             address(token),
             customFees.crowdinvestingFeeNumerator,
             customFees.validityDate
         );
-        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING_FEE, address(token), _customFeeCollector);
+        feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, address(token), _customFeeCollector);
         vm.stopPrank();
 
         assertEq(token.balanceOf(investor), 0, "token.balanceOf(investor) != 0 before");

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -62,7 +62,11 @@ contract MainnetCurrencies is Test {
 
     function setUp() public {
         list = createAllowList(trustedForwarder, owner);
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, admin, admin, admin));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(100, 100, 100, admin, admin, admin)
+        );
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -62,8 +62,7 @@ contract MainnetCurrencies is Test {
 
     function setUp() public {
         list = createAllowList(trustedForwarder, owner);
-        Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = createFeeSettings(trustedForwarder, address(this), fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, admin, admin, admin));
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -315,12 +315,12 @@ contract PrivateOfferTest is Test {
 
         // set fees to 0, otherwise extra tokens are minted which causes an overflow
         FeeSettings _feeSettings = FeeSettings(address(token.feeSettings()));
-        _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, 0, uint64(block.timestamp));
-        _feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, 0, uint64(block.timestamp));
-        _feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 0, uint64(block.timestamp));
-        _feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
-        _feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
-        _feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
+        _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, 0, uint64(block.timestamp));
+        _feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, 0, uint64(block.timestamp));
+        _feeSettings.planFeeChange(FeeTypes.TOKEN, 0, uint64(block.timestamp));
+        _feeSettings.executeFeeChange(FeeTypes.TOKEN);
+        _feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
+        _feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER);
 
         vm.prank(admin);
         token.increaseMintingAllowance(expectedAddress, _tokenBuyAmount);

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -58,7 +58,11 @@ contract PrivateOfferTest is Test {
         list.set(tokenHolder, requirements);
         list.set(address(currency), TRUSTED_CURRENCY);
 
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, wrongFeeReceiver, admin));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(100, 100, 100, wrongFeeReceiver, wrongFeeReceiver, admin)
+        );
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -58,15 +58,7 @@ contract PrivateOfferTest is Test {
         list.set(tokenHolder, requirements);
         list.set(address(currency), TRUSTED_CURRENCY);
 
-        Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            fees,
-            wrongFeeReceiver,
-            wrongFeeReceiver,
-            admin
-        );
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, wrongFeeReceiver, admin));
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -7,6 +7,7 @@ import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/PrivateOffer.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
 import "./resources/CloneCreators.sol";
+import "../contracts/interfaces/IFeeSettings.sol";
 import "./resources/FakePaymentToken.sol";
 
 contract PrivateOfferTest is Test {
@@ -313,9 +314,13 @@ contract PrivateOfferTest is Test {
         address expectedAddress = factory.predictPrivateOfferAddress(salt, arguments);
 
         // set fees to 0, otherwise extra tokens are minted which causes an overflow
-        Fees memory fees = Fees(0, 0, 0, 0);
-        FeeSettings(address(token.feeSettings())).planFeeChange(fees);
-        FeeSettings(address(token.feeSettings())).executeFeeChange();
+        FeeSettings _feeSettings = FeeSettings(address(token.feeSettings()));
+        _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, 0, uint64(block.timestamp));
+        _feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, 0, uint64(block.timestamp));
+        _feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 0, uint64(block.timestamp));
+        _feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+        _feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+        _feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
 
         vm.prank(admin);
         token.increaseMintingAllowance(expectedAddress, _tokenBuyAmount);

--- a/test/PrivateOfferFactory.t.sol
+++ b/test/PrivateOfferFactory.t.sol
@@ -49,8 +49,7 @@ contract PrivateOfferFactoryTest is Test {
         vm.prank(owner);
         list.set(address(currency), TRUSTED_CURRENCY);
 
-        Fees memory fees = Fees(0, 0, 0, 0);
-        feeSettings = createFeeSettings(trustedForwarder, address(this), fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, admin, admin, admin));
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/PrivateOfferOffchainPaymentTimeLock.t.sol
+++ b/test/PrivateOfferOffchainPaymentTimeLock.t.sol
@@ -41,8 +41,7 @@ contract PrivateOfferOffchainPaymentTimeLockTest is Test {
         list.set(tokenReceiver, requirements);
         list.set(address(currency), TRUSTED_CURRENCY);
 
-        Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = createFeeSettings(trustedForwarder, address(this), fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, admin, admin, admin));
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/PrivateOfferOffchainPaymentTimeLock.t.sol
+++ b/test/PrivateOfferOffchainPaymentTimeLock.t.sol
@@ -41,7 +41,11 @@ contract PrivateOfferOffchainPaymentTimeLockTest is Test {
         list.set(tokenReceiver, requirements);
         list.set(address(currency), TRUSTED_CURRENCY);
 
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, admin, admin, admin));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(100, 100, 100, admin, admin, admin)
+        );
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/PrivateOfferTimeLock.t.sol
+++ b/test/PrivateOfferTimeLock.t.sol
@@ -44,7 +44,11 @@ contract PrivateOfferTimeLockTest is Test {
         list.set(tokenReceiver, requirements);
         list.set(address(currency), TRUSTED_CURRENCY);
 
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, admin, admin, admin));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(100, 100, 100, admin, admin, admin)
+        );
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/PrivateOfferTimeLock.t.sol
+++ b/test/PrivateOfferTimeLock.t.sol
@@ -44,8 +44,7 @@ contract PrivateOfferTimeLockTest is Test {
         list.set(tokenReceiver, requirements);
         list.set(address(currency), TRUSTED_CURRENCY);
 
-        Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = createFeeSettings(trustedForwarder, address(this), fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, admin, admin, admin));
 
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));

--- a/test/SetUpExampleCompany.t.sol
+++ b/test/SetUpExampleCompany.t.sol
@@ -90,15 +90,7 @@ contract CompanySetUpTest is Test {
         companyAdmin = vm.addr(companyAdminPrivateKey);
 
         // set up FeeSettings
-        Fees memory fees = Fees(tokenFeeNumerator, paymentTokenFeeNumerator, paymentTokenFeeNumerator, 0);
-        feeSettings = createFeeSettings(
-            address(8), // fake forwarder
-            platformAdmin,
-            fees,
-            platformFeeCollector,
-            platformFeeCollector,
-            platformFeeCollector
-        );
+        feeSettings = createFeeSettings(address(8), platformAdmin, buildFeeTypes(tokenFeeNumerator, paymentTokenFeeNumerator, paymentTokenFeeNumerator, platformFeeCollector, platformFeeCollector, platformFeeCollector));
 
         // set up currency. In real life (irl) this would be a real currency, but for testing purposes we use a fake one.
         vm.prank(paymentTokenProvider);

--- a/test/SetUpExampleCompany.t.sol
+++ b/test/SetUpExampleCompany.t.sol
@@ -90,7 +90,18 @@ contract CompanySetUpTest is Test {
         companyAdmin = vm.addr(companyAdminPrivateKey);
 
         // set up FeeSettings
-        feeSettings = createFeeSettings(address(8), platformAdmin, buildFeeTypes(tokenFeeNumerator, paymentTokenFeeNumerator, paymentTokenFeeNumerator, platformFeeCollector, platformFeeCollector, platformFeeCollector));
+        feeSettings = createFeeSettings(
+            address(8),
+            platformAdmin,
+            buildFeeTypes(
+                tokenFeeNumerator,
+                paymentTokenFeeNumerator,
+                paymentTokenFeeNumerator,
+                platformFeeCollector,
+                platformFeeCollector,
+                platformFeeCollector
+            )
+        );
 
         // set up currency. In real life (irl) this would be a real currency, but for testing purposes we use a fake one.
         vm.prank(paymentTokenProvider);

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -31,8 +31,7 @@ contract tokenTest is Test {
     function setUp() public {
         allowList = createAllowList(trustedForwarder, admin);
         vm.prank(feeSettingsOwner);
-        Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = createFeeSettings(trustedForwarder, address(this), fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, admin, admin, admin));
         token = Token(
             tokenCloneFactory.createTokenProxy(
                 0,

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -31,7 +31,11 @@ contract tokenTest is Test {
     function setUp() public {
         allowList = createAllowList(trustedForwarder, admin);
         vm.prank(feeSettingsOwner);
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, admin, admin, admin));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(100, 100, 100, admin, admin, admin)
+        );
         token = Token(
             tokenCloneFactory.createTokenProxy(
                 0,

--- a/test/TokenERC2612.t.sol
+++ b/test/TokenERC2612.t.sol
@@ -65,15 +65,7 @@ contract TokenERC2612Test is Test {
         allowList = createAllowList(trustedForwarder, platformAdmin);
 
         // deploy fee settings
-        Fees memory fees = Fees(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            platformAdmin,
-            fees,
-            feeCollector,
-            feeCollector,
-            feeCollector
-        );
+        feeSettings = createFeeSettings(trustedForwarder, platformAdmin, buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, feeCollector, feeCollector, feeCollector));
 
         // deploy forwarder
         Forwarder forwarder = new Forwarder();

--- a/test/TokenERC2612.t.sol
+++ b/test/TokenERC2612.t.sol
@@ -65,7 +65,18 @@ contract TokenERC2612Test is Test {
         allowList = createAllowList(trustedForwarder, platformAdmin);
 
         // deploy fee settings
-        feeSettings = createFeeSettings(trustedForwarder, platformAdmin, buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, feeCollector, feeCollector, feeCollector));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            platformAdmin,
+            buildFeeTypes(
+                tokenFeeNumerator,
+                crowdinvestingFeeNumerator,
+                privateOfferFeeNumerator,
+                feeCollector,
+                feeCollector,
+                feeCollector
+            )
+        );
 
         // deploy forwarder
         Forwarder forwarder = new Forwarder();

--- a/test/TokenERC2771.t.sol
+++ b/test/TokenERC2771.t.sol
@@ -52,16 +52,8 @@ contract TokenERC2771Test is Test {
         allowList = createAllowList(trustedForwarder, platformAdmin);
 
         // deploy fee settings
-        Fees memory fees = Fees(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, 0);
         vm.prank(platformAdmin);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            fees,
-            feeCollector,
-            feeCollector,
-            feeCollector
-        );
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, feeCollector, feeCollector, feeCollector));
 
         // deploy helper functions (only for testing with foundry)
         ERC2771helper = new ERC2771Helper();

--- a/test/TokenERC2771.t.sol
+++ b/test/TokenERC2771.t.sol
@@ -53,7 +53,18 @@ contract TokenERC2771Test is Test {
 
         // deploy fee settings
         vm.prank(platformAdmin);
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(tokenFeeNumerator, crowdinvestingFeeNumerator, privateOfferFeeNumerator, feeCollector, feeCollector, feeCollector));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(
+                tokenFeeNumerator,
+                crowdinvestingFeeNumerator,
+                privateOfferFeeNumerator,
+                feeCollector,
+                feeCollector,
+                feeCollector
+            )
+        );
 
         // deploy helper functions (only for testing with foundry)
         ERC2771helper = new ERC2771Helper();

--- a/test/TokenGasConsumption.t.sol
+++ b/test/TokenGasConsumption.t.sol
@@ -27,15 +27,7 @@ contract tokenTest is Test {
 
     function setUp() public {
         allowList = createAllowList(trustedForwarder, feeSettingsAndAllowListOwner);
-        Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            feeSettingsAndAllowListOwner,
-            fees,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner
-        );
+        feeSettings = createFeeSettings(trustedForwarder, feeSettingsAndAllowListOwner, buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
 
         address tokenHolder = address(this);
 

--- a/test/TokenGasConsumption.t.sol
+++ b/test/TokenGasConsumption.t.sol
@@ -27,7 +27,18 @@ contract tokenTest is Test {
 
     function setUp() public {
         allowList = createAllowList(trustedForwarder, feeSettingsAndAllowListOwner);
-        feeSettings = createFeeSettings(trustedForwarder, feeSettingsAndAllowListOwner, buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            feeSettingsAndAllowListOwner,
+            buildFeeTypes(
+                100,
+                100,
+                100,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner
+            )
+        );
 
         address tokenHolder = address(this);
 

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -32,8 +32,7 @@ contract tokenTest is Test {
 
     function setUp() public {
         allowList = createAllowList(trustedForwarder, admin);
-        Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = createFeeSettings(trustedForwarder, feeSettingsOwner, fees, admin, admin, admin);
+        feeSettings = createFeeSettings(trustedForwarder, feeSettingsOwner, buildFeeTypes(100, 100, 100, admin, admin, admin));
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));
         token = Token(
@@ -88,16 +87,14 @@ contract tokenTest is Test {
 
     function testSuggestNewFeeSettingsWrongCaller(address wrongUpdater) public {
         vm.assume(wrongUpdater != feeSettings.owner());
-        Fees memory fees = Fees(0, 0, 0, 0);
-        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), fees, pauser, pauser, pauser);
+        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, pauser, pauser, pauser));
         vm.prank(wrongUpdater);
         vm.expectRevert("Only fee settings owner can suggest fee settings update");
         token.suggestNewFeeSettings(newFeeSettings);
     }
 
     function testSuggestNewFeeSettingsFeeCollector() public {
-        Fees memory fees = Fees(0, 0, 0, 0);
-        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), fees, pauser, pauser, pauser);
+        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, pauser, pauser, pauser));
         vm.prank(feeSettings.feeCollector());
         vm.expectRevert("Only fee settings owner can suggest fee settings update");
         token.suggestNewFeeSettings(newFeeSettings);
@@ -111,15 +108,7 @@ contract tokenTest is Test {
 
     function testSuggestNewFeeSettings(address newCollector) public {
         vm.assume(newCollector != address(0));
-        Fees memory fees = Fees(0, 0, 0, 0);
-        FeeSettings newFeeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            fees,
-            newCollector,
-            newCollector,
-            newCollector
-        );
+        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, newCollector, newCollector, newCollector));
 
         (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN);
         (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
@@ -156,15 +145,7 @@ contract tokenTest is Test {
 
     function testAcceptNewFeeSettings(address newCollector) public {
         vm.assume(newCollector != address(0));
-        Fees memory fees = Fees(0, 0, 0, 0);
-        FeeSettings newFeeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            fees,
-            newCollector,
-            newCollector,
-            newCollector
-        );
+        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, newCollector, newCollector, newCollector));
         (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN);
         (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
             FeeTypes.CROWDINVESTING
@@ -194,15 +175,7 @@ contract tokenTest is Test {
 
     function testAcceptFeeCollectorInsteadOfFeeSettings(address newFeeSettingsPretendAddress) public {
         vm.assume(newFeeSettingsPretendAddress != address(0));
-        Fees memory fees = Fees(0, 0, 0, 0);
-        FeeSettings newFeeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            fees,
-            newFeeSettingsPretendAddress,
-            newFeeSettingsPretendAddress,
-            newFeeSettingsPretendAddress
-        );
+        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, newFeeSettingsPretendAddress, newFeeSettingsPretendAddress, newFeeSettingsPretendAddress));
         vm.assume(newFeeSettingsPretendAddress != address(newFeeSettings));
 
         vm.prank(feeSettings.owner());
@@ -216,37 +189,24 @@ contract tokenTest is Test {
     }
 
     function testAcceptWrongFeeSettings() public {
-        Fees memory fees = Fees(0, 0, 0, 0);
-        FeeSettings realNewFeeSettings = createFeeSettings(
-            trustedForwarder,
-            feeSettings.owner(),
-            fees,
-            feeSettings.feeCollector(),
-            feeSettings.feeCollector(),
-            feeSettings.feeCollector()
-        );
-        FeeSettings fakeNewFeeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            fees,
-            feeSettings.feeCollector(),
-            feeSettings.feeCollector(),
-            feeSettings.feeCollector()
-        );
+        {
+            FeeSettings realNewFeeSettings = createFeeSettings(trustedForwarder, feeSettings.owner(), buildFeeTypes(0, 0, 0, feeSettings.feeCollector(), feeSettings.feeCollector(), feeSettings.feeCollector()));
+            FeeSettings fakeNewFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, feeSettings.feeCollector(), feeSettings.feeCollector(), feeSettings.feeCollector()));
 
-        assertTrue(
-            address(fakeNewFeeSettings) != address(realNewFeeSettings),
-            "fakeNewFeeSettings == realNewFeeSettings, that should never happen"
-        );
+            assertTrue(
+                address(fakeNewFeeSettings) != address(realNewFeeSettings),
+                "fakeNewFeeSettings == realNewFeeSettings, that should never happen"
+            );
 
-        vm.prank(feeSettings.owner());
-        token.suggestNewFeeSettings(realNewFeeSettings);
-        console.log("Suggested fee settings: ", address(realNewFeeSettings));
+            vm.prank(feeSettings.owner());
+            token.suggestNewFeeSettings(realNewFeeSettings);
+            console.log("Suggested fee settings: ", address(realNewFeeSettings));
 
-        // admin thinks he is accepting a, but suggestion is b
-        vm.expectRevert("Only suggested fee settings can be accepted");
-        vm.prank(admin);
-        token.acceptNewFeeSettings(fakeNewFeeSettings);
+            // admin thinks he is accepting a, but suggestion is b
+            vm.expectRevert("Only suggested fee settings can be accepted");
+            vm.prank(admin);
+            token.acceptNewFeeSettings(fakeNewFeeSettings);
+        }
     }
 
     function testFeeCollectorCanAlwaysReceiveFee() public {
@@ -341,11 +301,10 @@ contract tokenTest is Test {
     }
 
     function testFeeSettingsUpdateRevertsWhenContractFailsERC165Check() public {
-        Fees memory fees = Fees(0, 0, 0, 0);
         FeeSettings[] memory feeSettingsArray = new FeeSettings[](3);
-        feeSettingsArray[0] = new FeeSettingsFailERC165Check0(fees, feeSettings.feeCollector());
-        feeSettingsArray[1] = new FeeSettingsFailERC165Check1(fees, feeSettings.feeCollector());
-        feeSettingsArray[2] = new FeeSettingsFailIFeeSettingsV2Check(fees, feeSettings.feeCollector());
+        feeSettingsArray[0] = new FeeSettingsFailERC165Check0();
+        feeSettingsArray[1] = new FeeSettingsFailERC165Check1();
+        feeSettingsArray[2] = new FeeSettingsFailIFeeSettingsV2Check();
 
         vm.startPrank(feeSettings.owner());
         // cycle through the fake contracts and make sure each one triggers a revert

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -5,6 +5,7 @@ import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/FeeSettings.sol";
+import "../contracts/interfaces/IFeeSettings.sol";
 import "./resources/WrongFeeSettings.sol";
 import "./resources/CloneCreators.sol";
 
@@ -120,12 +121,9 @@ contract tokenTest is Test {
             newCollector
         );
 
-        (
-            uint32 _oldTokenFeeNumerator,
-            uint32 _oldCrowdinvestingFeeNumerator,
-            uint32 _oldPrivateOfferFeeNumerator,
-
-        ) = FeeSettings(address(token.feeSettings())).fees(address(0));
+        (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, uint32 _oldPrivateOfferFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
 
         vm.expectEmit(true, true, true, true, address(token));
         emit NewFeeSettingsSuggested(newFeeSettings);
@@ -133,12 +131,9 @@ contract tokenTest is Test {
         token.suggestNewFeeSettings(newFeeSettings);
 
         // make sure old fees are still in effect
-        (
-            uint32 _newTokenFeeNumerator,
-            uint32 _newCrowdinvestingFeeNumerator,
-            uint32 _newPrivateOfferFeeNumerator,
-
-        ) = FeeSettings(address(token.feeSettings())).fees(address(0));
+        (, uint32 _newTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _newCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, uint32 _newPrivateOfferFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
 
         assertTrue(_oldTokenFeeNumerator == _newTokenFeeNumerator, "token fee numerator changed!");
         assertTrue(
@@ -162,9 +157,8 @@ contract tokenTest is Test {
             newCollector,
             newCollector
         );
-        (uint32 _oldTokenFeeNumerator, uint32 _oldCrowdinvestingFeeNumerator, , ) = FeeSettings(
-            address(token.feeSettings())
-        ).fees(address(0));
+        (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
 
         vm.prank(feeSettings.owner());
         token.suggestNewFeeSettings(newFeeSettings);
@@ -175,9 +169,8 @@ contract tokenTest is Test {
         vm.prank(admin);
         token.acceptNewFeeSettings(newFeeSettings);
 
-        (uint32 _newTokenFeeNumerator, uint32 _newCrowdinvestingFeeNumerator, , ) = FeeSettings(
-            address(token.feeSettings())
-        ).fees(address(0));
+        (, uint32 _newTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _newCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
         assertTrue(FeeSettings(address(token.feeSettings())) == newFeeSettings, "fee settings not changed!");
         assertEq(FeeSettings(address(token.feeSettings())).feeCollector(), newCollector, "Wrong feeCollector");
         assertTrue(

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -32,7 +32,11 @@ contract tokenTest is Test {
 
     function setUp() public {
         allowList = createAllowList(trustedForwarder, admin);
-        feeSettings = createFeeSettings(trustedForwarder, feeSettingsOwner, buildFeeTypes(100, 100, 100, admin, admin, admin));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            feeSettingsOwner,
+            buildFeeTypes(100, 100, 100, admin, admin, admin)
+        );
         Token implementation = new Token(trustedForwarder);
         TokenProxyFactory tokenCloneFactory = new TokenProxyFactory(address(implementation));
         token = Token(
@@ -87,14 +91,22 @@ contract tokenTest is Test {
 
     function testSuggestNewFeeSettingsWrongCaller(address wrongUpdater) public {
         vm.assume(wrongUpdater != feeSettings.owner());
-        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, pauser, pauser, pauser));
+        FeeSettings newFeeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(0, 0, 0, pauser, pauser, pauser)
+        );
         vm.prank(wrongUpdater);
         vm.expectRevert("Only fee settings owner can suggest fee settings update");
         token.suggestNewFeeSettings(newFeeSettings);
     }
 
     function testSuggestNewFeeSettingsFeeCollector() public {
-        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, pauser, pauser, pauser));
+        FeeSettings newFeeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(0, 0, 0, pauser, pauser, pauser)
+        );
         vm.prank(feeSettings.feeCollector());
         vm.expectRevert("Only fee settings owner can suggest fee settings update");
         token.suggestNewFeeSettings(newFeeSettings);
@@ -108,7 +120,11 @@ contract tokenTest is Test {
 
     function testSuggestNewFeeSettings(address newCollector) public {
         vm.assume(newCollector != address(0));
-        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, newCollector, newCollector, newCollector));
+        FeeSettings newFeeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(0, 0, 0, newCollector, newCollector, newCollector)
+        );
 
         (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN);
         (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
@@ -145,7 +161,11 @@ contract tokenTest is Test {
 
     function testAcceptNewFeeSettings(address newCollector) public {
         vm.assume(newCollector != address(0));
-        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, newCollector, newCollector, newCollector));
+        FeeSettings newFeeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(0, 0, 0, newCollector, newCollector, newCollector)
+        );
         (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN);
         (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
             FeeTypes.CROWDINVESTING
@@ -175,7 +195,18 @@ contract tokenTest is Test {
 
     function testAcceptFeeCollectorInsteadOfFeeSettings(address newFeeSettingsPretendAddress) public {
         vm.assume(newFeeSettingsPretendAddress != address(0));
-        FeeSettings newFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, newFeeSettingsPretendAddress, newFeeSettingsPretendAddress, newFeeSettingsPretendAddress));
+        FeeSettings newFeeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(
+                0,
+                0,
+                0,
+                newFeeSettingsPretendAddress,
+                newFeeSettingsPretendAddress,
+                newFeeSettingsPretendAddress
+            )
+        );
         vm.assume(newFeeSettingsPretendAddress != address(newFeeSettings));
 
         vm.prank(feeSettings.owner());
@@ -190,8 +221,30 @@ contract tokenTest is Test {
 
     function testAcceptWrongFeeSettings() public {
         {
-            FeeSettings realNewFeeSettings = createFeeSettings(trustedForwarder, feeSettings.owner(), buildFeeTypes(0, 0, 0, feeSettings.feeCollector(), feeSettings.feeCollector(), feeSettings.feeCollector()));
-            FeeSettings fakeNewFeeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(0, 0, 0, feeSettings.feeCollector(), feeSettings.feeCollector(), feeSettings.feeCollector()));
+            FeeSettings realNewFeeSettings = createFeeSettings(
+                trustedForwarder,
+                feeSettings.owner(),
+                buildFeeTypes(
+                    0,
+                    0,
+                    0,
+                    feeSettings.feeCollector(),
+                    feeSettings.feeCollector(),
+                    feeSettings.feeCollector()
+                )
+            );
+            FeeSettings fakeNewFeeSettings = createFeeSettings(
+                trustedForwarder,
+                address(this),
+                buildFeeTypes(
+                    0,
+                    0,
+                    0,
+                    feeSettings.feeCollector(),
+                    feeSettings.feeCollector(),
+                    feeSettings.feeCollector()
+                )
+            );
 
             assertTrue(
                 address(fakeNewFeeSettings) != address(realNewFeeSettings),

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -121,12 +121,12 @@ contract tokenTest is Test {
             newCollector
         );
 
-        (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN);
         (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
-            FeeTypes.CROWDINVESTING_FEE
+            FeeTypes.CROWDINVESTING
         );
         (, uint32 _oldPrivateOfferFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
-            FeeTypes.PRIVATE_OFFER_FEE
+            FeeTypes.PRIVATE_OFFER
         );
 
         vm.expectEmit(true, true, true, true, address(token));
@@ -135,12 +135,12 @@ contract tokenTest is Test {
         token.suggestNewFeeSettings(newFeeSettings);
 
         // make sure old fees are still in effect
-        (, uint32 _newTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _newTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN);
         (, uint32 _newCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
-            FeeTypes.CROWDINVESTING_FEE
+            FeeTypes.CROWDINVESTING
         );
         (, uint32 _newPrivateOfferFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
-            FeeTypes.PRIVATE_OFFER_FEE
+            FeeTypes.PRIVATE_OFFER
         );
 
         assertTrue(_oldTokenFeeNumerator == _newTokenFeeNumerator, "token fee numerator changed!");
@@ -165,9 +165,9 @@ contract tokenTest is Test {
             newCollector,
             newCollector
         );
-        (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN);
         (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
-            FeeTypes.CROWDINVESTING_FEE
+            FeeTypes.CROWDINVESTING
         );
 
         vm.prank(feeSettings.owner());
@@ -179,9 +179,9 @@ contract tokenTest is Test {
         vm.prank(admin);
         token.acceptNewFeeSettings(newFeeSettings);
 
-        (, uint32 _newTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
+        (, uint32 _newTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN);
         (, uint32 _newCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
-            FeeTypes.CROWDINVESTING_FEE
+            FeeTypes.CROWDINVESTING
         );
         assertTrue(FeeSettings(address(token.feeSettings())) == newFeeSettings, "fee settings not changed!");
         assertEq(FeeSettings(address(token.feeSettings())).feeCollector(), newCollector, "Wrong feeCollector");

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -122,8 +122,12 @@ contract tokenTest is Test {
         );
 
         (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
-        (, uint32 _oldPrivateOfferFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
+        (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
+            FeeTypes.CROWDINVESTING_FEE
+        );
+        (, uint32 _oldPrivateOfferFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
+            FeeTypes.PRIVATE_OFFER_FEE
+        );
 
         vm.expectEmit(true, true, true, true, address(token));
         emit NewFeeSettingsSuggested(newFeeSettings);
@@ -132,8 +136,12 @@ contract tokenTest is Test {
 
         // make sure old fees are still in effect
         (, uint32 _newTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, uint32 _newCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
-        (, uint32 _newPrivateOfferFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.PRIVATE_OFFER_FEE);
+        (, uint32 _newCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
+            FeeTypes.CROWDINVESTING_FEE
+        );
+        (, uint32 _newPrivateOfferFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
+            FeeTypes.PRIVATE_OFFER_FEE
+        );
 
         assertTrue(_oldTokenFeeNumerator == _newTokenFeeNumerator, "token fee numerator changed!");
         assertTrue(
@@ -158,7 +166,9 @@ contract tokenTest is Test {
             newCollector
         );
         (, uint32 _oldTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, uint32 _oldCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
+            FeeTypes.CROWDINVESTING_FEE
+        );
 
         vm.prank(feeSettings.owner());
         token.suggestNewFeeSettings(newFeeSettings);
@@ -170,7 +180,9 @@ contract tokenTest is Test {
         token.acceptNewFeeSettings(newFeeSettings);
 
         (, uint32 _newTokenFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.TOKEN_FEE);
-        (, uint32 _newCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(FeeTypes.CROWDINVESTING_FEE);
+        (, uint32 _newCrowdinvestingFeeNumerator) = FeeSettings(address(token.feeSettings())).feeTypeConfigs(
+            FeeTypes.CROWDINVESTING_FEE
+        );
         assertTrue(FeeSettings(address(token.feeSettings())) == newFeeSettings, "fee settings not changed!");
         assertEq(FeeSettings(address(token.feeSettings())).feeCollector(), newCollector, "Wrong feeCollector");
         assertTrue(

--- a/test/TokenProxyFactory.t.sol
+++ b/test/TokenProxyFactory.t.sol
@@ -30,7 +30,18 @@ contract tokenProxyFactoryTest is Test {
 
     function setUp() public {
         allowList = createAllowList(trustedForwarder, feeSettingsAndAllowListOwner);
-        feeSettings = createFeeSettings(trustedForwarder, feeSettingsAndAllowListOwner, buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            feeSettingsAndAllowListOwner,
+            buildFeeTypes(
+                100,
+                100,
+                100,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner
+            )
+        );
         vm.stopPrank();
 
         implementation = new Token(trustedForwarder);
@@ -153,7 +164,18 @@ contract tokenProxyFactoryTest is Test {
         console.log("name: %s", name);
         console.log("symbol: %s", symbol);
 
-        FeeSettings _feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
+        FeeSettings _feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(
+                100,
+                100,
+                100,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner
+            )
+        );
 
         Token clone = Token(
             factory.createTokenProxy(
@@ -213,7 +235,18 @@ contract tokenProxyFactoryTest is Test {
         vm.assume(rando != address(0));
         vm.assume(rando != _admin);
 
-        FeeSettings _feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
+        FeeSettings _feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(
+                100,
+                100,
+                100,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner
+            )
+        );
 
         Token _token = Token(
             factory.createTokenProxy(
@@ -258,7 +291,18 @@ contract tokenProxyFactoryTest is Test {
         vm.assume(newPauser != address(0));
         vm.assume(newPauser != admin);
 
-        FeeSettings _feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
+        FeeSettings _feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(
+                100,
+                100,
+                100,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner
+            )
+        );
 
         Token _token = Token(
             factory.createTokenProxy(

--- a/test/TokenProxyFactory.t.sol
+++ b/test/TokenProxyFactory.t.sol
@@ -30,15 +30,7 @@ contract tokenProxyFactoryTest is Test {
 
     function setUp() public {
         allowList = createAllowList(trustedForwarder, feeSettingsAndAllowListOwner);
-        Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            feeSettingsAndAllowListOwner,
-            fees,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner
-        );
+        feeSettings = createFeeSettings(trustedForwarder, feeSettingsAndAllowListOwner, buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
         vm.stopPrank();
 
         implementation = new Token(trustedForwarder);
@@ -161,14 +153,7 @@ contract tokenProxyFactoryTest is Test {
         console.log("name: %s", name);
         console.log("symbol: %s", symbol);
 
-        FeeSettings _feeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            Fees(100, 100, 100, 0),
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner
-        );
+        FeeSettings _feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
 
         Token clone = Token(
             factory.createTokenProxy(
@@ -228,14 +213,7 @@ contract tokenProxyFactoryTest is Test {
         vm.assume(rando != address(0));
         vm.assume(rando != _admin);
 
-        FeeSettings _feeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            Fees(100, 100, 100, 0),
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner
-        );
+        FeeSettings _feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
 
         Token _token = Token(
             factory.createTokenProxy(
@@ -280,14 +258,7 @@ contract tokenProxyFactoryTest is Test {
         vm.assume(newPauser != address(0));
         vm.assume(newPauser != admin);
 
-        FeeSettings _feeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            Fees(100, 100, 100, 0),
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner
-        );
+        FeeSettings _feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
 
         Token _token = Token(
             factory.createTokenProxy(

--- a/test/TokenProxyUpgrade.t.sol
+++ b/test/TokenProxyUpgrade.t.sol
@@ -42,7 +42,18 @@ contract tokenProxyUpgradeTest is Test {
 
     function setUp() public {
         allowList = createAllowList(trustedForwarder, feeSettingsAndAllowListOwner);
-        feeSettings = createFeeSettings(trustedForwarder, feeSettingsAndAllowListOwner, buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            feeSettingsAndAllowListOwner,
+            buildFeeTypes(
+                100,
+                100,
+                100,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner
+            )
+        );
         vm.stopPrank();
 
         implementation = new Token(trustedForwarder);

--- a/test/TokenProxyUpgrade.t.sol
+++ b/test/TokenProxyUpgrade.t.sol
@@ -42,15 +42,7 @@ contract tokenProxyUpgradeTest is Test {
 
     function setUp() public {
         allowList = createAllowList(trustedForwarder, feeSettingsAndAllowListOwner);
-        Fees memory fees = Fees(100, 100, 100, 0);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            feeSettingsAndAllowListOwner,
-            fees,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner
-        );
+        feeSettings = createFeeSettings(trustedForwarder, feeSettingsAndAllowListOwner, buildFeeTypes(100, 100, 100, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
         vm.stopPrank();
 
         implementation = new Token(trustedForwarder);

--- a/test/TokenSnapshots.t.sol
+++ b/test/TokenSnapshots.t.sol
@@ -28,7 +28,18 @@ contract tokenTest is Test {
 
     function setUp() public {
         allowList = createAllowList(trustedForwarder, feeSettingsAndAllowListOwner);
-        feeSettings = createFeeSettings(trustedForwarder, feeSettingsAndAllowListOwner, buildFeeTypes(0, 0, 0, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            feeSettingsAndAllowListOwner,
+            buildFeeTypes(
+                0,
+                0,
+                0,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner,
+                feeSettingsAndAllowListOwner
+            )
+        );
 
         address tokenHolder = address(this);
 

--- a/test/TokenSnapshots.t.sol
+++ b/test/TokenSnapshots.t.sol
@@ -28,15 +28,7 @@ contract tokenTest is Test {
 
     function setUp() public {
         allowList = createAllowList(trustedForwarder, feeSettingsAndAllowListOwner);
-        Fees memory fees = Fees(0, 0, 0, 0);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            feeSettingsAndAllowListOwner,
-            fees,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner,
-            feeSettingsAndAllowListOwner
-        );
+        feeSettings = createFeeSettings(trustedForwarder, feeSettingsAndAllowListOwner, buildFeeTypes(0, 0, 0, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner, feeSettingsAndAllowListOwner));
 
         address tokenHolder = address(this);
 

--- a/test/TokenSwap.t.sol
+++ b/test/TokenSwap.t.sol
@@ -62,15 +62,7 @@ contract TokenSwapTest is Test {
         vm.prank(owner);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        Fees memory fees = Fees(100, 100, 100, 100);
-        feeSettings = createFeeSettings(
-            trustedForwarder,
-            address(this),
-            fees,
-            wrongFeeReceiver,
-            admin,
-            wrongFeeReceiver
-        );
+        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver));
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/TokenSwap.t.sol
+++ b/test/TokenSwap.t.sol
@@ -6,6 +6,7 @@ import "../lib/forge-std/src/console.sol";
 
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/FeeSettings.sol";
+import "../contracts/interfaces/IFeeSettings.sol";
 import "../contracts/factories/TokenSwapCloneFactory.sol";
 import "./resources/FakePaymentToken.sol";
 import "./resources/MaliciousPaymentToken.sol";
@@ -795,9 +796,17 @@ contract TokenSwapTest is Test {
         tokenSwap.setTokenPrice(_price);
 
         // set fees to 0
-        Fees memory fees = Fees(0, 0, 0, 0);
-        FeeSettings(address(token.feeSettings())).planFeeChange(fees);
-        FeeSettings(address(token.feeSettings())).executeFeeChange();
+        {
+            FeeSettings feeSettings = FeeSettings(address(token.feeSettings()));
+            feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET_FEE, 0, uint64(block.timestamp));
+            feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+            feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+            feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
+            feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET_FEE);
+        }
 
         // approve
         vm.prank(buyer);
@@ -846,9 +855,17 @@ contract TokenSwapTest is Test {
         tokenSwap.setTokenPrice(_price);
 
         // set fees to 0
-        Fees memory fees = Fees(0, 0, 0, 0);
-        FeeSettings(address(token.feeSettings())).planFeeChange(fees);
-        FeeSettings(address(token.feeSettings())).executeFeeChange();
+        {
+            FeeSettings feeSettings = FeeSettings(address(token.feeSettings()));
+            feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET_FEE, 0, uint64(block.timestamp));
+            feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
+            feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
+            feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
+            feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET_FEE);
+        }
 
         // approve holder to spend payment token
         vm.prank(holder);
@@ -1015,14 +1032,13 @@ contract TokenSwapTest is Test {
         uint256 earningAfterFee = 98 * 10 ** paymentTokenDecimals; // 98 payment tokens
         uint32 feePercentage = 200; // 2%
 
-        // Update fee settings to 2% private offer fee
+        // Update fee settings to 2% secondary market fee
         uint64 feeActivationTime = 13 weeks;
         FeeSettings _feeSettings = FeeSettings(address(token.feeSettings()));
-        Fees memory newFees = Fees(0, 0, feePercentage, feeActivationTime);
-        _feeSettings.planFeeChange(newFees);
+        _feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET_FEE, feePercentage, feeActivationTime);
         vm.warp(feeActivationTime + 1);
-        _feeSettings.executeFeeChange();
-        assertTrue(_feeSettings.privateOfferFee(100 * 10 ** 10, address(token)) == 2 * 10 ** 10);
+        _feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET_FEE);
+        assertTrue(_feeSettings.fee(FeeTypes.SECONDARY_MARKET_FEE, 100 * 10 ** 10, address(token)) == 2 * 10 ** 10);
 
         // Update token price
         vm.prank(owner);
@@ -1084,14 +1100,13 @@ contract TokenSwapTest is Test {
         uint256 payoutAfterFee = 98 * 10 ** paymentTokenDecimals; // 98 payment tokens
         uint32 feePercentage = 200; // 2%
 
-        // Update fee settings to 2% private offer fee
+        // Update fee settings to 2% secondary market fee
         uint64 feeActivationTime = 13 weeks;
         FeeSettings _feeSettings = FeeSettings(address(token.feeSettings()));
-        Fees memory newFees = Fees(0, 0, feePercentage, feeActivationTime);
-        _feeSettings.planFeeChange(newFees);
+        _feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET_FEE, feePercentage, feeActivationTime);
         vm.warp(feeActivationTime + 1);
-        _feeSettings.executeFeeChange();
-        assertTrue(_feeSettings.privateOfferFee(100 * 10 ** 10, address(token)) == 2 * 10 ** 10);
+        _feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET_FEE);
+        assertTrue(_feeSettings.fee(FeeTypes.SECONDARY_MARKET_FEE, 100 * 10 ** 10, address(token)) == 2 * 10 ** 10);
 
         // Update token price
         vm.prank(owner);

--- a/test/TokenSwap.t.sol
+++ b/test/TokenSwap.t.sol
@@ -798,14 +798,14 @@ contract TokenSwapTest is Test {
         // set fees to 0
         {
             FeeSettings feeSettings = FeeSettings(address(token.feeSettings()));
-            feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET_FEE, 0, uint64(block.timestamp));
-            feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
-            feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
-            feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
-            feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET_FEE);
+            feeSettings.planFeeChange(FeeTypes.TOKEN, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET, 0, uint64(block.timestamp));
+            feeSettings.executeFeeChange(FeeTypes.TOKEN);
+            feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
+            feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER);
+            feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET);
         }
 
         // approve
@@ -857,14 +857,14 @@ contract TokenSwapTest is Test {
         // set fees to 0
         {
             FeeSettings feeSettings = FeeSettings(address(token.feeSettings()));
-            feeSettings.planFeeChange(FeeTypes.TOKEN_FEE, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.CROWDINVESTING_FEE, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER_FEE, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET_FEE, 0, uint64(block.timestamp));
-            feeSettings.executeFeeChange(FeeTypes.TOKEN_FEE);
-            feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING_FEE);
-            feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER_FEE);
-            feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET_FEE);
+            feeSettings.planFeeChange(FeeTypes.TOKEN, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, 0, uint64(block.timestamp));
+            feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET, 0, uint64(block.timestamp));
+            feeSettings.executeFeeChange(FeeTypes.TOKEN);
+            feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
+            feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER);
+            feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET);
         }
 
         // approve holder to spend payment token
@@ -1035,10 +1035,10 @@ contract TokenSwapTest is Test {
         // Update fee settings to 2% secondary market fee
         uint64 feeActivationTime = 13 weeks;
         FeeSettings _feeSettings = FeeSettings(address(token.feeSettings()));
-        _feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET_FEE, feePercentage, feeActivationTime);
+        _feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET, feePercentage, feeActivationTime);
         vm.warp(feeActivationTime + 1);
-        _feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET_FEE);
-        assertTrue(_feeSettings.fee(FeeTypes.SECONDARY_MARKET_FEE, 100 * 10 ** 10, address(token)) == 2 * 10 ** 10);
+        _feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET);
+        assertTrue(_feeSettings.fee(FeeTypes.SECONDARY_MARKET, 100 * 10 ** 10, address(token)) == 2 * 10 ** 10);
 
         // Update token price
         vm.prank(owner);
@@ -1103,10 +1103,10 @@ contract TokenSwapTest is Test {
         // Update fee settings to 2% secondary market fee
         uint64 feeActivationTime = 13 weeks;
         FeeSettings _feeSettings = FeeSettings(address(token.feeSettings()));
-        _feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET_FEE, feePercentage, feeActivationTime);
+        _feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET, feePercentage, feeActivationTime);
         vm.warp(feeActivationTime + 1);
-        _feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET_FEE);
-        assertTrue(_feeSettings.fee(FeeTypes.SECONDARY_MARKET_FEE, 100 * 10 ** 10, address(token)) == 2 * 10 ** 10);
+        _feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET);
+        assertTrue(_feeSettings.fee(FeeTypes.SECONDARY_MARKET, 100 * 10 ** 10, address(token)) == 2 * 10 ** 10);
 
         // Update token price
         vm.prank(owner);

--- a/test/TokenSwap.t.sol
+++ b/test/TokenSwap.t.sol
@@ -62,7 +62,11 @@ contract TokenSwapTest is Test {
         vm.prank(owner);
         list.set(address(paymentToken), TRUSTED_CURRENCY);
 
-        feeSettings = createFeeSettings(trustedForwarder, address(this), buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver));
+        feeSettings = createFeeSettings(
+            trustedForwarder,
+            address(this),
+            buildFeeTypes(100, 100, 100, wrongFeeReceiver, admin, wrongFeeReceiver)
+        );
 
         // create token
         address tokenLogicContract = address(new Token(trustedForwarder));

--- a/test/TokenSwapCloneFactory.t.sol
+++ b/test/TokenSwapCloneFactory.t.sol
@@ -6,6 +6,7 @@ import "../lib/forge-std/src/console.sol";
 import "../contracts/factories/TokenSwapCloneFactory.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/factories/FeeSettingsCloneFactory.sol";
+import "../contracts/interfaces/IFeeSettings.sol";
 import "./resources/ERC2771Helper.sol";
 import "./resources/CloneCreators.sol";
 
@@ -46,22 +47,25 @@ contract TokenSwapCloneFactoryTest is Test {
         vm.startPrank(feeSettingsAndAllowListOwner);
         allowList = createAllowList(trustedForwarder, feeSettingsAndAllowListOwner);
 
-        Fees memory fees = Fees(100, 100, 100, 0);
         FeeSettings feeSettingsLogicContract = new FeeSettings(trustedForwarder);
         FeeSettingsCloneFactory feeSettingsCloneFactory = new FeeSettingsCloneFactory(
             address(feeSettingsLogicContract)
         );
-        feeSettings = FeeSettings(
-            feeSettingsCloneFactory.createFeeSettingsClone(
-                0,
-                trustedForwarder,
-                feeSettingsAndAllowListOwner,
-                fees,
-                feeSettingsAndAllowListOwner,
-                feeSettingsAndAllowListOwner,
-                feeSettingsAndAllowListOwner
-            )
-        );
+        {
+            FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+            feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 100, feeSettingsAndAllowListOwner);
+            feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 100, feeSettingsAndAllowListOwner);
+            feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 100, feeSettingsAndAllowListOwner);
+            feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, feeSettingsAndAllowListOwner);
+            feeSettings = FeeSettings(
+                feeSettingsCloneFactory.createFeeSettingsClone(
+                    0,
+                    trustedForwarder,
+                    feeSettingsAndAllowListOwner,
+                    feeTypes
+                )
+            );
+        }
         vm.stopPrank();
 
         vm.prank(feeSettingsAndAllowListOwner);

--- a/test/TokenSwapCloneFactory.t.sol
+++ b/test/TokenSwapCloneFactory.t.sol
@@ -53,10 +53,10 @@ contract TokenSwapCloneFactoryTest is Test {
         );
         {
             FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
-            feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, 100, feeSettingsAndAllowListOwner);
-            feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING_FEE, 1000, 100, feeSettingsAndAllowListOwner);
-            feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER_FEE, 500, 100, feeSettingsAndAllowListOwner);
-            feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET_FEE, 500, 0, feeSettingsAndAllowListOwner);
+            feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, 100, feeSettingsAndAllowListOwner);
+            feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, 100, feeSettingsAndAllowListOwner);
+            feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, 100, feeSettingsAndAllowListOwner);
+            feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, 0, feeSettingsAndAllowListOwner);
             feeSettings = FeeSettings(
                 feeSettingsCloneFactory.createFeeSettingsClone(
                     0,

--- a/test/VestingDemo.t.sol
+++ b/test/VestingDemo.t.sol
@@ -48,10 +48,7 @@ contract VestingDemoTest is Test {
         FeeSettings feeSettings = createFeeSettings(
             trustedForwarder,
             platformAdmin,
-            Fees(100, 500, 200, 0),
-            platformAdmin,
-            platformAdmin,
-            platformAdmin
+            buildFeeTypes(100, 500, 200, platformAdmin, platformAdmin, platformAdmin)
         );
         AllowList allowList = createAllowList(trustedForwarder, owner);
         Token localCompanyToken = Token(

--- a/test/resources/CloneCreators.sol
+++ b/test/resources/CloneCreators.sol
@@ -21,7 +21,7 @@ function createFeeSettings(
     address _crowdinvestingFeeCollector,
     address _privateOfferFeeCollector
 ) returns (FeeSettings) {
-    FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+    FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
     feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, _fees.tokenFeeNumerator, _tokenFeeCollector);
     feeTypes[1] = FeeSettings.FeeTypeInit(
         FeeTypes.CROWDINVESTING_FEE,
@@ -37,6 +37,18 @@ function createFeeSettings(
     );
     feeTypes[3] = FeeSettings.FeeTypeInit(
         FeeTypes.SECONDARY_MARKET_FEE,
+        500,
+        _fees.privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+    feeTypes[4] = FeeSettings.FeeTypeInit(
+        FeeTypes.DISTRIBUTION_FEE,
+        500,
+        _fees.privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+    feeTypes[5] = FeeSettings.FeeTypeInit(
+        FeeTypes.EXIT_FEE,
         500,
         _fees.privateOfferFeeNumerator,
         _privateOfferFeeCollector

--- a/test/resources/CloneCreators.sol
+++ b/test/resources/CloneCreators.sol
@@ -23,10 +23,30 @@ function buildFeeTypes(
 ) pure returns (FeeSettings.FeeTypeInit[] memory) {
     FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
     feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, _tokenFeeNumerator, _tokenFeeCollector);
-    feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, _crowdinvestingFeeNumerator, _crowdinvestingFeeCollector);
-    feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
-    feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
-    feeTypes[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
+    feeTypes[1] = FeeSettings.FeeTypeInit(
+        FeeTypes.CROWDINVESTING,
+        1000,
+        _crowdinvestingFeeNumerator,
+        _crowdinvestingFeeCollector
+    );
+    feeTypes[2] = FeeSettings.FeeTypeInit(
+        FeeTypes.PRIVATE_OFFER,
+        500,
+        _privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+    feeTypes[3] = FeeSettings.FeeTypeInit(
+        FeeTypes.SECONDARY_MARKET,
+        500,
+        _privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+    feeTypes[4] = FeeSettings.FeeTypeInit(
+        FeeTypes.DISTRIBUTION,
+        500,
+        _privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
     feeTypes[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
     return feeTypes;
 }

--- a/test/resources/CloneCreators.sol
+++ b/test/resources/CloneCreators.sol
@@ -21,19 +21,30 @@ function createFeeSettings(
     address _crowdinvestingFeeCollector,
     address _privateOfferFeeCollector
 ) returns (FeeSettings) {
+    FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+    feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, _fees.tokenFeeNumerator, _tokenFeeCollector);
+    feeTypes[1] = FeeSettings.FeeTypeInit(
+        FeeTypes.CROWDINVESTING_FEE,
+        1000,
+        _fees.crowdinvestingFeeNumerator,
+        _crowdinvestingFeeCollector
+    );
+    feeTypes[2] = FeeSettings.FeeTypeInit(
+        FeeTypes.PRIVATE_OFFER_FEE,
+        500,
+        _fees.privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+    feeTypes[3] = FeeSettings.FeeTypeInit(
+        FeeTypes.SECONDARY_MARKET_FEE,
+        500,
+        _fees.privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+
     FeeSettings logicContract = new FeeSettings(_trustedForwarder);
     FeeSettingsCloneFactory factory = new FeeSettingsCloneFactory(address(logicContract));
-    FeeSettings clone = FeeSettings(
-        factory.createFeeSettingsClone(
-            "someSalt",
-            _trustedForwarder,
-            _owner,
-            _fees,
-            _tokenFeeCollector,
-            _crowdinvestingFeeCollector,
-            _privateOfferFeeCollector
-        )
-    );
+    FeeSettings clone = FeeSettings(factory.createFeeSettingsClone("someSalt", _trustedForwarder, _owner, feeTypes));
 
     return clone;
 }

--- a/test/resources/CloneCreators.sol
+++ b/test/resources/CloneCreators.sol
@@ -22,33 +22,33 @@ function createFeeSettings(
     address _privateOfferFeeCollector
 ) returns (FeeSettings) {
     FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
-    feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, _fees.tokenFeeNumerator, _tokenFeeCollector);
+    feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, _fees.tokenFeeNumerator, _tokenFeeCollector);
     feeTypes[1] = FeeSettings.FeeTypeInit(
-        FeeTypes.CROWDINVESTING_FEE,
+        FeeTypes.CROWDINVESTING,
         1000,
         _fees.crowdinvestingFeeNumerator,
         _crowdinvestingFeeCollector
     );
     feeTypes[2] = FeeSettings.FeeTypeInit(
-        FeeTypes.PRIVATE_OFFER_FEE,
+        FeeTypes.PRIVATE_OFFER,
         500,
         _fees.privateOfferFeeNumerator,
         _privateOfferFeeCollector
     );
     feeTypes[3] = FeeSettings.FeeTypeInit(
-        FeeTypes.SECONDARY_MARKET_FEE,
+        FeeTypes.SECONDARY_MARKET,
         500,
         _fees.privateOfferFeeNumerator,
         _privateOfferFeeCollector
     );
     feeTypes[4] = FeeSettings.FeeTypeInit(
-        FeeTypes.DISTRIBUTION_FEE,
+        FeeTypes.DISTRIBUTION,
         500,
         _fees.privateOfferFeeNumerator,
         _privateOfferFeeCollector
     );
     feeTypes[5] = FeeSettings.FeeTypeInit(
-        FeeTypes.EXIT_FEE,
+        FeeTypes.EXIT,
         500,
         _fees.privateOfferFeeNumerator,
         _privateOfferFeeCollector

--- a/test/resources/CloneCreators.sol
+++ b/test/resources/CloneCreators.sol
@@ -13,50 +13,32 @@ function createAllowList(address _trustedForwarder, address _owner) returns (All
     return clone;
 }
 
-function createFeeSettings(
-    address _trustedForwarder,
-    address _owner,
-    Fees memory _fees,
+function buildFeeTypes(
+    uint32 _tokenFeeNumerator,
+    uint32 _crowdinvestingFeeNumerator,
+    uint32 _privateOfferFeeNumerator,
     address _tokenFeeCollector,
     address _crowdinvestingFeeCollector,
     address _privateOfferFeeCollector
-) returns (FeeSettings) {
+) pure returns (FeeSettings.FeeTypeInit[] memory) {
     FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
-    feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, _fees.tokenFeeNumerator, _tokenFeeCollector);
-    feeTypes[1] = FeeSettings.FeeTypeInit(
-        FeeTypes.CROWDINVESTING,
-        1000,
-        _fees.crowdinvestingFeeNumerator,
-        _crowdinvestingFeeCollector
-    );
-    feeTypes[2] = FeeSettings.FeeTypeInit(
-        FeeTypes.PRIVATE_OFFER,
-        500,
-        _fees.privateOfferFeeNumerator,
-        _privateOfferFeeCollector
-    );
-    feeTypes[3] = FeeSettings.FeeTypeInit(
-        FeeTypes.SECONDARY_MARKET,
-        500,
-        _fees.privateOfferFeeNumerator,
-        _privateOfferFeeCollector
-    );
-    feeTypes[4] = FeeSettings.FeeTypeInit(
-        FeeTypes.DISTRIBUTION,
-        500,
-        _fees.privateOfferFeeNumerator,
-        _privateOfferFeeCollector
-    );
-    feeTypes[5] = FeeSettings.FeeTypeInit(
-        FeeTypes.EXIT,
-        500,
-        _fees.privateOfferFeeNumerator,
-        _privateOfferFeeCollector
-    );
+    feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, _tokenFeeNumerator, _tokenFeeCollector);
+    feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, _crowdinvestingFeeNumerator, _crowdinvestingFeeCollector);
+    feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
+    feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
+    feeTypes[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
+    feeTypes[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
+    return feeTypes;
+}
 
+function createFeeSettings(
+    address _trustedForwarder,
+    address _owner,
+    FeeSettings.FeeTypeInit[] memory _feeTypes
+) returns (FeeSettings) {
     FeeSettings logicContract = new FeeSettings(_trustedForwarder);
     FeeSettingsCloneFactory factory = new FeeSettingsCloneFactory(address(logicContract));
-    FeeSettings clone = FeeSettings(factory.createFeeSettingsClone("someSalt", _trustedForwarder, _owner, feeTypes));
+    FeeSettings clone = FeeSettings(factory.createFeeSettingsClone("someSalt", _trustedForwarder, _owner, _feeTypes));
 
     return clone;
 }

--- a/test/resources/FeeSettingsCreator.sol
+++ b/test/resources/FeeSettingsCreator.sol
@@ -4,50 +4,32 @@ pragma solidity 0.8.23;
 import "../../lib/forge-std/src/Test.sol";
 import "../../contracts/factories/FeeSettingsCloneFactory.sol";
 
-function createFeeSettings(
-    address _trustedForwarder,
-    address _owner,
-    Fees memory _fees,
+function buildFeeTypes(
+    uint32 _tokenFeeNumerator,
+    uint32 _crowdinvestingFeeNumerator,
+    uint32 _privateOfferFeeNumerator,
     address _tokenFeeCollector,
     address _crowdinvestingFeeCollector,
     address _privateOfferFeeCollector
-) returns (FeeSettings) {
+) pure returns (FeeSettings.FeeTypeInit[] memory) {
     FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
-    feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, _fees.tokenFeeNumerator, _tokenFeeCollector);
-    feeTypes[1] = FeeSettings.FeeTypeInit(
-        FeeTypes.CROWDINVESTING,
-        1000,
-        _fees.crowdinvestingFeeNumerator,
-        _crowdinvestingFeeCollector
-    );
-    feeTypes[2] = FeeSettings.FeeTypeInit(
-        FeeTypes.PRIVATE_OFFER,
-        500,
-        _fees.privateOfferFeeNumerator,
-        _privateOfferFeeCollector
-    );
-    feeTypes[3] = FeeSettings.FeeTypeInit(
-        FeeTypes.SECONDARY_MARKET,
-        500,
-        _fees.privateOfferFeeNumerator,
-        _privateOfferFeeCollector
-    );
-    feeTypes[4] = FeeSettings.FeeTypeInit(
-        FeeTypes.DISTRIBUTION,
-        500,
-        _fees.privateOfferFeeNumerator,
-        _privateOfferFeeCollector
-    );
-    feeTypes[5] = FeeSettings.FeeTypeInit(
-        FeeTypes.EXIT,
-        500,
-        _fees.privateOfferFeeNumerator,
-        _privateOfferFeeCollector
-    );
+    feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, _tokenFeeNumerator, _tokenFeeCollector);
+    feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, _crowdinvestingFeeNumerator, _crowdinvestingFeeCollector);
+    feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
+    feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
+    feeTypes[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
+    feeTypes[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
+    return feeTypes;
+}
 
+function createFeeSettings(
+    address _trustedForwarder,
+    address _owner,
+    FeeSettings.FeeTypeInit[] memory _feeTypes
+) returns (FeeSettings) {
     FeeSettings logicContract = new FeeSettings(_trustedForwarder);
     FeeSettingsCloneFactory factory = new FeeSettingsCloneFactory(address(logicContract));
-    FeeSettings clone = FeeSettings(factory.createFeeSettingsClone("someSalt", _trustedForwarder, _owner, feeTypes));
+    FeeSettings clone = FeeSettings(factory.createFeeSettingsClone("someSalt", _trustedForwarder, _owner, _feeTypes));
 
     return clone;
 }

--- a/test/resources/FeeSettingsCreator.sol
+++ b/test/resources/FeeSettingsCreator.sol
@@ -12,7 +12,7 @@ function createFeeSettings(
     address _crowdinvestingFeeCollector,
     address _privateOfferFeeCollector
 ) returns (FeeSettings) {
-    FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+    FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
     feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, _fees.tokenFeeNumerator, _tokenFeeCollector);
     feeTypes[1] = FeeSettings.FeeTypeInit(
         FeeTypes.CROWDINVESTING_FEE,
@@ -28,6 +28,18 @@ function createFeeSettings(
     );
     feeTypes[3] = FeeSettings.FeeTypeInit(
         FeeTypes.SECONDARY_MARKET_FEE,
+        500,
+        _fees.privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+    feeTypes[4] = FeeSettings.FeeTypeInit(
+        FeeTypes.DISTRIBUTION_FEE,
+        500,
+        _fees.privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+    feeTypes[5] = FeeSettings.FeeTypeInit(
+        FeeTypes.EXIT_FEE,
         500,
         _fees.privateOfferFeeNumerator,
         _privateOfferFeeCollector

--- a/test/resources/FeeSettingsCreator.sol
+++ b/test/resources/FeeSettingsCreator.sol
@@ -12,19 +12,30 @@ function createFeeSettings(
     address _crowdinvestingFeeCollector,
     address _privateOfferFeeCollector
 ) returns (FeeSettings) {
+    FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](4);
+    feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, _fees.tokenFeeNumerator, _tokenFeeCollector);
+    feeTypes[1] = FeeSettings.FeeTypeInit(
+        FeeTypes.CROWDINVESTING_FEE,
+        1000,
+        _fees.crowdinvestingFeeNumerator,
+        _crowdinvestingFeeCollector
+    );
+    feeTypes[2] = FeeSettings.FeeTypeInit(
+        FeeTypes.PRIVATE_OFFER_FEE,
+        500,
+        _fees.privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+    feeTypes[3] = FeeSettings.FeeTypeInit(
+        FeeTypes.SECONDARY_MARKET_FEE,
+        500,
+        _fees.privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+
     FeeSettings logicContract = new FeeSettings(_trustedForwarder);
     FeeSettingsCloneFactory factory = new FeeSettingsCloneFactory(address(logicContract));
-    FeeSettings clone = FeeSettings(
-        factory.createFeeSettingsClone(
-            "someSalt",
-            _trustedForwarder,
-            _owner,
-            _fees,
-            _tokenFeeCollector,
-            _crowdinvestingFeeCollector,
-            _privateOfferFeeCollector
-        )
-    );
+    FeeSettings clone = FeeSettings(factory.createFeeSettingsClone("someSalt", _trustedForwarder, _owner, feeTypes));
 
     return clone;
 }

--- a/test/resources/FeeSettingsCreator.sol
+++ b/test/resources/FeeSettingsCreator.sol
@@ -14,10 +14,30 @@ function buildFeeTypes(
 ) pure returns (FeeSettings.FeeTypeInit[] memory) {
     FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
     feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, _tokenFeeNumerator, _tokenFeeCollector);
-    feeTypes[1] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, _crowdinvestingFeeNumerator, _crowdinvestingFeeCollector);
-    feeTypes[2] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
-    feeTypes[3] = FeeSettings.FeeTypeInit(FeeTypes.SECONDARY_MARKET, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
-    feeTypes[4] = FeeSettings.FeeTypeInit(FeeTypes.DISTRIBUTION, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
+    feeTypes[1] = FeeSettings.FeeTypeInit(
+        FeeTypes.CROWDINVESTING,
+        1000,
+        _crowdinvestingFeeNumerator,
+        _crowdinvestingFeeCollector
+    );
+    feeTypes[2] = FeeSettings.FeeTypeInit(
+        FeeTypes.PRIVATE_OFFER,
+        500,
+        _privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+    feeTypes[3] = FeeSettings.FeeTypeInit(
+        FeeTypes.SECONDARY_MARKET,
+        500,
+        _privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
+    feeTypes[4] = FeeSettings.FeeTypeInit(
+        FeeTypes.DISTRIBUTION,
+        500,
+        _privateOfferFeeNumerator,
+        _privateOfferFeeCollector
+    );
     feeTypes[5] = FeeSettings.FeeTypeInit(FeeTypes.EXIT, 500, _privateOfferFeeNumerator, _privateOfferFeeCollector);
     return feeTypes;
 }

--- a/test/resources/FeeSettingsCreator.sol
+++ b/test/resources/FeeSettingsCreator.sol
@@ -13,33 +13,33 @@ function createFeeSettings(
     address _privateOfferFeeCollector
 ) returns (FeeSettings) {
     FeeSettings.FeeTypeInit[] memory feeTypes = new FeeSettings.FeeTypeInit[](6);
-    feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN_FEE, 500, _fees.tokenFeeNumerator, _tokenFeeCollector);
+    feeTypes[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, _fees.tokenFeeNumerator, _tokenFeeCollector);
     feeTypes[1] = FeeSettings.FeeTypeInit(
-        FeeTypes.CROWDINVESTING_FEE,
+        FeeTypes.CROWDINVESTING,
         1000,
         _fees.crowdinvestingFeeNumerator,
         _crowdinvestingFeeCollector
     );
     feeTypes[2] = FeeSettings.FeeTypeInit(
-        FeeTypes.PRIVATE_OFFER_FEE,
+        FeeTypes.PRIVATE_OFFER,
         500,
         _fees.privateOfferFeeNumerator,
         _privateOfferFeeCollector
     );
     feeTypes[3] = FeeSettings.FeeTypeInit(
-        FeeTypes.SECONDARY_MARKET_FEE,
+        FeeTypes.SECONDARY_MARKET,
         500,
         _fees.privateOfferFeeNumerator,
         _privateOfferFeeCollector
     );
     feeTypes[4] = FeeSettings.FeeTypeInit(
-        FeeTypes.DISTRIBUTION_FEE,
+        FeeTypes.DISTRIBUTION,
         500,
         _fees.privateOfferFeeNumerator,
         _privateOfferFeeCollector
     );
     feeTypes[5] = FeeSettings.FeeTypeInit(
-        FeeTypes.EXIT_FEE,
+        FeeTypes.EXIT,
         500,
         _fees.privateOfferFeeNumerator,
         _privateOfferFeeCollector

--- a/test/resources/WrongFeeSettings.sol
+++ b/test/resources/WrongFeeSettings.sol
@@ -8,7 +8,7 @@ import "../../contracts/FeeSettings.sol";
     fake currency to test the main contract with
 */
 contract FeeSettingsFailERC165Check0 is FeeSettings {
-    constructor(Fees memory _fees, address _feeCollector) FeeSettings(address(0)) {}
+    constructor() FeeSettings(address(0)) {}
 
     function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
         if (interfaceId == 0x01ffc9a7) {
@@ -20,7 +20,7 @@ contract FeeSettingsFailERC165Check0 is FeeSettings {
 }
 
 contract FeeSettingsFailERC165Check1 is FeeSettings {
-    constructor(Fees memory _fees, address _feeCollector) FeeSettings(address(0)) {}
+    constructor() FeeSettings(address(0)) {}
 
     function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
         if (interfaceId == 0x01ffc9a7) {
@@ -33,7 +33,7 @@ contract FeeSettingsFailERC165Check1 is FeeSettings {
 }
 
 contract FeeSettingsFailIFeeSettingsV2Check is FeeSettings {
-    constructor(Fees memory _fees, address _feeCollector) FeeSettings(address(0)) {}
+    constructor() FeeSettings(address(0)) {}
 
     function supportsInterface(bytes4 interfaceId) public view override returns (bool) {
         if (interfaceId == 0x01ffc9a7) {


### PR DESCRIPTION
# FeeSettings.sol rework

## What changed

The fee system has been **generalized from three hardcoded fee types to a
dynamic registry**. Previously, `FeeSettings` had TOKEN, CROWDINVESTING, and
PRIVATE_OFFER baked in as constants with fixed per-type caps (5%, 10%, 5%).
Now, fee types are registered at deployment (or later) with arbitrary names and
caps, and the contract can accommodate new product lines without an upgrade.

**How fees work now:**
- Each fee type is identified by a `bytes32` key (e.g. `keccak256("TOKEN")`)
  and configured with a max cap and a default numerator at registration time.
- Custom per-token discounts and fee collector overrides work the same way as
  before, but are now keyed by `(feeType, token)` instead of living in
  separate mappings per type.
- Fee increases still require a 12-week delay, now enforced per fee type
  independently.
- Owner registers types and sets defaults; managers grant per-token discounts
  — same role separation as before.

## What stays compatible

All existing callers (Token, Crowdinvesting, PrivateOffer contracts) continue
to work unchanged. The V1 and V2 interface functions (`tokenFee`,
`crowdinvestingFee`, `privateOfferFee`, and the matching `feeCollector`
variants) are retained as thin wrappers over the new generic logic. ERC-165
reports support for V1, V2, and the new V3 interface.

## What breaks

Any tooling or scripts that call the old management functions by name will need
updating: `planFeeChange(Fees)`, `executeFeeChange()`, `setFeeCollectors(...)`,
`setCustomFee(address, Fees)`, and the six per-type collector setters/removers
are all replaced by generic equivalents that take a `bytes32 feeType` as the
first argument. Events have changed accordingly.
