### PR TITLE
Feat/simplified coinvested position

### DIFF
--- a/contracts/CoinvestedPosition.sol
+++ b/contracts/CoinvestedPosition.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.23;
 
 import "@openzeppelin/contracts/utils/math/Math.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 
 import "./TokenSwapBase.sol";
 import "./IDistribution.sol";
@@ -22,9 +21,9 @@ struct CoinvestedPositionInitializerArguments {
     address receiver;
     /// lead investors and their carry fractions
     LeadInvestor[] leadInvestors;
-    /// base price per token in bits in currency below
+    /// base price per token in bits of baseCurrency
     uint256 basePrice;
-    /// currency used for buy() payments. Must be a EURO ERC20 (TRUSTED_CURRENCY | EURO_CURRENCY bits set on the token's allowList).
+    /// currency used for buy() payments
     IERC20 baseCurrency;
     /// token being held
     Token token;
@@ -35,13 +34,13 @@ struct CoinvestedPositionInitializerArguments {
  * @author malteish, cjentzsch
  * @notice This contract holds tokens and sells them at a preset price, distributing proceeds
  *      between a coinvestor (receiver) and lead investors.
- *      The coinvestor (receiver) receives basePrice (a EURO reference price) per token sold.
+ *      The coinvestor (receiver) receives basePrice per token sold.
  *      Any remaining proceeds after fees and coinvestor payout are split among lead investors
  *      according to their carry percentages, with dust going to the coinvestor.
  *      If the sale price minus fees is less than the base price, all proceeds go to the coinvestor.
- *      For exits, any EURO token (TRUSTED_CURRENCY | EURO_CURRENCY bits) may be used.
- *      For dividends, any trusted token (TRUSTED_CURRENCY bit) may be used.
- *      Neither needs to match the currency stored for buy().
+ *      Any currency may be used for exits and dividends; when a currency different from the stored
+ *      currency is used, the coinvestor provides an altBasePrice expressing the base price in that
+ *      currency's units.
  * @dev Uses clone/proxy pattern. Constructor disables initializers, separate initialize().
  */
 contract CoinvestedPosition is TokenSwapBase {
@@ -49,10 +48,8 @@ contract CoinvestedPosition is TokenSwapBase {
 
     /// lead investors and their carry fractions
     LeadInvestor[] public leadInvestors;
-    /// base price per token in EURO bits (smallest subunit of any EURO currency)
+    /// base price per token in bits of the current currency (always expressed in current currency's decimals)
     uint256 public basePrice;
-    /// decimals of the currency used when basePrice was set; used to scale payouts when a different EURO token is used at exit/dividend time
-    uint8 public basePriceDecimals;
 
     /**
      * This constructor creates a logic contract that is used to clone new contracts.
@@ -70,11 +67,6 @@ contract CoinvestedPosition is TokenSwapBase {
     function initialize(CoinvestedPositionInitializerArguments memory _arguments) external initializer {
         _initializeBase(_arguments.owner, 0, _arguments.baseCurrency, _arguments.token, _arguments.receiver);
 
-        require(
-            _arguments.token.allowList().map(address(_arguments.baseCurrency)) & (TRUSTED_CURRENCY | EURO_CURRENCY) ==
-                (TRUSTED_CURRENCY | EURO_CURRENCY),
-            "currency must be a trusted EURO currency"
-        );
         require(_arguments.leadInvestors.length > 0, "There must be at least one lead investor");
         uint64 carryFractionsSum = 0;
         for (uint256 i = 0; i < _arguments.leadInvestors.length; i++) {
@@ -84,24 +76,24 @@ contract CoinvestedPosition is TokenSwapBase {
             leadInvestors.push(_arguments.leadInvestors[i]);
         }
         basePrice = _arguments.basePrice;
-        basePriceDecimals = IERC20Metadata(address(_arguments.baseCurrency)).decimals();
 
         // Pausing the contract prevents an immediate sell of the tokens. Once they should be sold, update price and unpause.
         _pause();
     }
 
     /**
-     * @notice Change the payment currency to any trusted EURO currency.
-     * @dev basePrice remains in its original canonical units (basePriceDecimals); buy() scales it
-     *      dynamically, so no re-scaling of basePrice is needed here.
-     * @param _currency new currency; must have TRUSTED_CURRENCY | EURO_CURRENCY bits set on the token's allowList
+     * @notice Change the payment currency. When changing to a different currency, provide the
+     *      equivalent base price in the new currency's units; it overwrites the stored basePrice.
+     * @param _currency new currency
+     * @param _altBasePrice base price in the new currency's units; ignored if _currency == currency
      */
-    function setCurrency(IERC20 _currency) external onlyOwner {
-        require(
-            token.allowList().map(address(_currency)) & (TRUSTED_CURRENCY | EURO_CURRENCY) ==
-                (TRUSTED_CURRENCY | EURO_CURRENCY),
-            "currency must be a trusted EURO currency"
-        );
+    function setCurrency(IERC20 _currency, uint256 _altBasePrice) external onlyOwner {
+        require(address(_currency) != address(0), "zero address");
+        require(address(_currency) != address(token), "currency cannot be the held token");
+        if (_currency != currency) {
+            require(_altBasePrice > 0, "altBasePrice must be > 0");
+            basePrice = _altBasePrice;
+        }
         currency = _currency;
     }
 
@@ -133,8 +125,7 @@ contract CoinvestedPosition is TokenSwapBase {
         uint256 remaining = currencyAmount - fee;
 
         // calculate carry: surplus above base price. If remaining <= base price, carry is 0 and receiver gets everything.
-        uint256 scaledBasePrice = _scaleToDecimals(basePrice, IERC20Metadata(address(currency)).decimals());
-        uint256 payoutCoinvestor = (scaledBasePrice * _tokenAmount) / (10 ** token.decimals());
+        uint256 payoutCoinvestor = (basePrice * _tokenAmount) / (10 ** token.decimals());
         uint256 carry = payoutCoinvestor < remaining ? remaining - payoutCoinvestor : 0;
 
         _settle(carry, currency);
@@ -146,28 +137,13 @@ contract CoinvestedPosition is TokenSwapBase {
     }
 
     /**
-     * @notice Scales `_amount` from `basePriceDecimals` to `_targetDecimals`.
-     * @param _amount amount expressed in basePriceDecimals units
-     * @param _targetDecimals decimals of the target currency
-     * @return scaled amount in target currency units
-     */
-    function _scaleToDecimals(uint256 _amount, uint8 _targetDecimals) internal view returns (uint256) {
-        if (_targetDecimals > basePriceDecimals) {
-            return _amount * 10 ** (_targetDecimals - basePriceDecimals);
-        } else if (_targetDecimals < basePriceDecimals) {
-            return _amount / 10 ** (basePriceDecimals - _targetDecimals);
-        }
-        return _amount;
-    }
-
-    /**
      * @notice Distributes `carry` among lead investors by carryFraction, then sweeps the contract's
      *      full remaining balance of `_currency` to receiver. This even includes currency accidentally
      *      sent to the contract.
      * @dev The sweep covers the base price portion and any rounding dust. Pass carry=0 when there is
      *      no surplus above base price; the loop produces no transfers and the full balance goes to receiver.
      * @param carry surplus above base price to split among lead investors
-     * @param _currency the EURO token to settle
+     * @param _currency the token to settle
      */
     function _settle(uint256 carry, IERC20 _currency) internal {
         require(address(_currency) != address(token), "currency cannot be the held token");
@@ -183,15 +159,11 @@ contract CoinvestedPosition is TokenSwapBase {
     /**
      * @notice Claim this contract's eligible dividend share from `_dist` and split it among lead investors.
      * @dev The full received amount is treated as carry and split among lead investors by carryFraction;
-     *      remainder goes to receiver. Any trusted currency may be used (TRUSTED_CURRENCY bit required).
+     *      remainder goes to receiver. Any currency may be used.
      * @param _dist the Distribution (dividend) contract to claim from
      * @param _dividendCurrency the currency paid out by the distribution
      */
     function distributeDividends(IDistribution _dist, IERC20 _dividendCurrency) external onlyOwner nonReentrant {
-        require(
-            token.allowList().map(address(_dividendCurrency)) & TRUSTED_CURRENCY == TRUSTED_CURRENCY,
-            "dividend currency must be a trusted currency"
-        );
         uint256 before = _dividendCurrency.balanceOf(address(this));
         _dist.claim(address(this));
         uint256 received = _dividendCurrency.balanceOf(address(this)) - before;
@@ -204,33 +176,38 @@ contract CoinvestedPosition is TokenSwapBase {
      * @dev Transfers all held tokens to the Exit contract in exchange for currency.
      *      If proceeds < base, receiver gets everything.
      *      Carry is split among lead investors by carryFraction; remainder goes to receiver.
-     *      Any EURO token (TRUSTED_CURRENCY | EURO_CURRENCY) may be used, independent of the currency used for buy().
+     *      Any currency may be used. When _exitCurrency differs from the stored currency, provide
+     *      _altBasePrice expressing the base price in the exit currency's units.
      * @param _exit the Exit contract to claim from
-     * @param _exitCurrency the EURO token paid out by the exit
+     * @param _exitCurrency the token paid out by the exit
      * @param _minCurrencyAmount minimum currency the call must receive; reverts if proceeds fall short.
      *      This guards against faulty or malicious exit contracts.
+     * @param _altBasePrice base price in _exitCurrency's units; ignored when _exitCurrency == currency
      */
     function distributeExit(
         IExit _exit,
         IERC20 _exitCurrency,
-        uint256 _minCurrencyAmount
+        uint256 _minCurrencyAmount,
+        uint256 _altBasePrice
     ) external onlyOwner nonReentrant {
-        require(
-            token.allowList().map(address(_exitCurrency)) & (TRUSTED_CURRENCY | EURO_CURRENCY) ==
-                (TRUSTED_CURRENCY | EURO_CURRENCY),
-            "exit currency must be a trusted EURO currency"
-        );
         uint256 tokenBalance = token.balanceOf(address(this));
         require(tokenBalance > 0, "no tokens to claim");
+
+        uint256 effectiveBasePrice;
+        if (_exitCurrency == currency) {
+            effectiveBasePrice = basePrice;
+        } else {
+            require(_altBasePrice > 0, "altBasePrice must be > 0");
+            effectiveBasePrice = _altBasePrice;
+        }
+
+        uint256 basePayout = (effectiveBasePrice * tokenBalance) / 10 ** token.decimals();
+
         IERC20(address(token)).approve(address(_exit), tokenBalance);
         uint256 before = _exitCurrency.balanceOf(address(this));
         _exit.claim(tokenBalance, address(this));
         uint256 received = _exitCurrency.balanceOf(address(this)) - before;
         require(received >= _minCurrencyAmount, "received less than _minCurrencyAmount");
-        uint256 basePayout = _scaleToDecimals(
-            (basePrice * tokenBalance) / 10 ** token.decimals(),
-            IERC20Metadata(address(_exitCurrency)).decimals()
-        );
         uint256 carry = basePayout < received ? received - basePayout : 0;
         _settle(carry, _exitCurrency);
     }

--- a/contracts/CoinvestedPosition.sol
+++ b/contracts/CoinvestedPosition.sol
@@ -188,16 +188,20 @@ contract CoinvestedPosition is TokenSwapBase {
     /**
      * @notice Claim this contract's eligible dividend share from `_dist` and split it among lead investors.
      * @dev The full received amount is treated as carry and split among lead investors by carryFraction;
-     *      remainder goes to receiver. Any currency may be used.
+     *      remainder goes to receiver. Any trusted currency may be used.
      * @param _dist the Distribution (dividend) contract to claim from
+     * @param _dividendCurrency the currency paid out by the distribution; must be trusted
      */
     function distributeDividends(IDistribution _dist, IERC20 _dividendCurrency) external onlyOwner nonReentrant {
-        IERC20 dividendCurrency = _dist.currency();
+        require(
+            token.allowList().map(address(_dividendCurrency)) == TRUSTED_CURRENCY,
+            "dividend currency must be a trusted currency"
+        );
         uint256 before = _dividendCurrency.balanceOf(address(this));
         _dist.claim(address(this));
-        uint256 received = dividendCurrency.balanceOf(address(this)) - before;
+        uint256 received = _dividendCurrency.balanceOf(address(this)) - before;
         require(received > 0, "didn't receive expected currency from distribution");
-        _settle(received, dividendCurrency);
+        _settle(received, _dividendCurrency);
     }
 
     /**
@@ -207,18 +211,18 @@ contract CoinvestedPosition is TokenSwapBase {
      *      Carry is split among lead investors by carryFraction; remainder goes to receiver.
      *      Any currency may be used. When _exitCurrency differs from the stored currency, provide
      *      _altBasePrice expressing the base price in the exit currency's units.
-     * @param _exit the Exit contract to claim from
      * @param _exitCurrency the token paid out by the exit
      * @param _minCurrencyAmount minimum currency the call must receive; reverts if proceeds fall short.
      *      This guards against faulty or malicious exit contracts.
      * @param _altBasePrice base price in _exitCurrency's units; ignored when _exitCurrency == currency
      */
     function distributeExit(
-        IExit _exit,
         IERC20 _exitCurrency,
         uint256 _minCurrencyAmount,
         uint256 _altBasePrice
     ) external onlyOwner nonReentrant {
+        IExit _exit = tokenExitRegistry.exit();
+        require(address(_exit) != address(0), "no exit set in tokenExitRegistry");
         uint256 tokenBalance = token.balanceOf(address(this));
         require(tokenBalance > 0, "no tokens to claim");
 
@@ -234,7 +238,7 @@ contract CoinvestedPosition is TokenSwapBase {
 
         IERC20(address(token)).approve(address(_exit), tokenBalance);
         uint256 before = _exitCurrency.balanceOf(address(this));
-        exit.claim(tokenBalance, address(this));
+        _exit.claim(tokenBalance, address(this));
         uint256 received = _exitCurrency.balanceOf(address(this)) - before;
         require(received >= _minCurrencyAmount, "received less than _minCurrencyAmount");
         uint256 carry = basePayout < received ? received - basePayout : 0;

--- a/contracts/CoinvestedPosition.sol
+++ b/contracts/CoinvestedPosition.sol
@@ -40,13 +40,12 @@ struct CoinvestedPositionInitializerArguments {
  * @notice This contract holds tokens and sells them at a preset price, distributing proceeds
  *      between a coinvestor (receiver) and lead investors.
  *      The coinvestor (receiver) receives basePrice per token sold.
- *      Any remaining proceeds after fees and coinvestor payout are split among lead investors
- *      according to their carry percentages, with dust going to the coinvestor.
+ *      Any remaining proceeds after fees and coinvestor payout are split between coinvestor and
+ *      lead investors according to their carry percentages.
  *      If the sale price minus fees is less than the base price, all proceeds go to the coinvestor.
  *      Any trusted currency may be used for exits and dividends; when a currency different from the stored
  *      currency is used, the coinvestor provides an altBasePrice expressing the base price in that
  *      currency's units.
- * @dev Uses clone/proxy pattern. Constructor disables initializers, separate initialize().
  */
 contract CoinvestedPosition is TokenSwapBase {
     using SafeERC20 for IERC20;
@@ -85,7 +84,7 @@ contract CoinvestedPosition is TokenSwapBase {
         for (uint256 i = 0; i < _arguments.leadInvestors.length; i++) {
             require(_arguments.leadInvestors[i].account != address(0), "lead investor can not be zero address");
             require(_arguments.leadInvestors[i].carryFraction > 0, "lead investor carry fraction can not be zero");
-            carryFractionsSum += _arguments.leadInvestors[i].carryFraction; // reverts on overflow
+            carryFractionsSum += _arguments.leadInvestors[i].carryFraction; // reverts on overflow, thus avoiding carryFractionsSum > 100%
             leadInvestors.push(_arguments.leadInvestors[i]);
         }
         require(address(_arguments.tokenExitRegistry) != address(0), "tokenExitRegistry can not be zero address");
@@ -107,22 +106,19 @@ contract CoinvestedPosition is TokenSwapBase {
     }
 
     /**
-     * @notice Change the payment currency to any trusted EURO currency.
-     * @dev basePrice remains in its original canonical units (basePriceDecimals); buy() scales it
-     *      dynamically, so no re-scaling of basePrice is needed here.
+     * @notice Change the payment currency and update basePrice to match the new currency's units.
      * @param _currency new currency; must have TRUSTED_CURRENCY bit set on the token's allowList
+     * @param _basePrice base price expressed in the new currency's units; must be > 0
      */
-    function setCurrency(IERC20 _currency, uint256 _altBasePrice) external onlyOwner {
+    function setCurrency(IERC20 _currency, uint256 _basePrice) external onlyOwner {
         require(address(_currency) != address(0), "zero address");
         require(address(_currency) != address(token), "currency cannot be the held token");
-        if (_currency != currency) {
-            require(_altBasePrice > 0, "altBasePrice must be > 0");
-            basePrice = _altBasePrice;
-        }
+        require(_basePrice > 0, "altBasePrice must be > 0");
         require(
             token.allowList().map(address(_currency)) == TRUSTED_CURRENCY,
             "currency needs to be on the allowlist with TRUSTED_CURRENCY attribute"
         );
+        basePrice = _basePrice;
         currency = _currency;
     }
 
@@ -210,16 +206,16 @@ contract CoinvestedPosition is TokenSwapBase {
      *      If proceeds < base, receiver gets everything.
      *      Carry is split among lead investors by carryFraction; remainder goes to receiver.
      *      Any currency may be used. When _exitCurrency differs from the stored currency, provide
-     *      _altBasePrice expressing the base price in the exit currency's units.
+     *      _basePrice expressing the base price in the exit currency's units.
      * @param _exitCurrency the token paid out by the exit
      * @param _minCurrencyAmount minimum currency the call must receive; reverts if proceeds fall short.
      *      This guards against faulty or malicious exit contracts.
-     * @param _altBasePrice base price in _exitCurrency's units; ignored when _exitCurrency == currency
+     * @param _basePrice base price in _exitCurrency's units; ignored when _exitCurrency == currency
      */
     function distributeExit(
         IERC20 _exitCurrency,
         uint256 _minCurrencyAmount,
-        uint256 _altBasePrice
+        uint256 _basePrice
     ) external onlyOwner nonReentrant {
         IExit _exit = tokenExitRegistry.exit();
         require(address(_exit) != address(0), "no exit set in tokenExitRegistry");
@@ -230,8 +226,8 @@ contract CoinvestedPosition is TokenSwapBase {
         if (_exitCurrency == currency) {
             effectiveBasePrice = basePrice;
         } else {
-            require(_altBasePrice > 0, "altBasePrice must be > 0");
-            effectiveBasePrice = _altBasePrice;
+            require(_basePrice > 0, "altBasePrice must be > 0");
+            effectiveBasePrice = _basePrice;
         }
 
         uint256 basePayout = (effectiveBasePrice * tokenBalance) / 10 ** token.decimals();

--- a/contracts/CoinvestedPosition.sol
+++ b/contracts/CoinvestedPosition.sol
@@ -168,7 +168,7 @@ contract CoinvestedPosition is TokenSwapBase {
      * @dev The sweep covers the base price portion and any rounding dust. Pass carry=0 when there is
      *      no surplus above base price; the loop produces no transfers and the full balance goes to receiver.
      * @param carry surplus above base price to split among lead investors
-     * @param _currency the token to settle
+     * @param _currency the ERC20 token to use as currency for the settlement
      */
     function _settle(uint256 carry, IERC20 _currency) internal {
         require(address(_currency) != address(token), "currency cannot be the held token");

--- a/test/CoinvestedPosition.t.sol
+++ b/test/CoinvestedPosition.t.sol
@@ -160,7 +160,6 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         assertEq(address(logic.receiver()), address(0), "receiver");
         assertEq(logic.tokenPrice(), 0, "tokenPrice");
         assertEq(logic.basePrice(), 0, "basePrice");
-        assertEq(logic.basePriceDecimals(), 0, "basePriceDecimals");
         assertEq(logic.getLeadInvestorsCount(), 0, "leadInvestors length");
         assertEq(logic.owner(), address(0), "owner");
         // NOTE: logic contract starts unpaused (paused=false is the storage default).
@@ -179,7 +178,6 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         assertEq(address(coinvestedPosition.currency()), address(eurc), "currency");
         assertEq(address(coinvestedPosition.token()), address(token), "token");
         assertEq(coinvestedPosition.basePrice(), 100e6, "basePrice");
-        assertEq(coinvestedPosition.basePriceDecimals(), 6, "basePriceDecimals");
         assertEq(coinvestedPosition.getLeadInvestorsCount(), 2, "leadInvestors length");
         (address acc0, uint64 frac0) = coinvestedPosition.leadInvestors(0);
         assertEq(acc0, leadA, "leadA account");
@@ -197,7 +195,6 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
             eure,
             _defaultLeadInvestors()
         );
-        assertEq(coinvestedPosition18.basePriceDecimals(), 18, "wrong basePriceDecimals");
     }
 
     function testFuzz_InitBasePriceDecimalsAndPriceStoredCorrectly(uint8 decimals, uint256 basePrice) public {
@@ -223,7 +220,6 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
             factory.createCoinvestedPositionClone(salt, trustedForwarder, args)
         );
 
-        assertEq(fuzzPosition.basePriceDecimals(), decimals, "basePriceDecimals does not match currency decimals");
         assertEq(fuzzPosition.basePrice(), basePrice, "basePrice not stored as-is");
     }
 
@@ -365,14 +361,14 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
     function testSetCurrencyOnlyOwner() public {
         vm.prank(buyer);
         vm.expectRevert("Ownable: caller is not the owner");
-        coinvestedPosition.setCurrency(IERC20(address(eure)));
+        coinvestedPosition.setCurrency(IERC20(address(eure)), 1);
     }
 
     function testFuzz_SetCurrencyOnlyOwner(address caller) public {
         vm.assume(caller != owner && caller != address(0));
         vm.prank(caller);
         vm.expectRevert("Ownable: caller is not the owner");
-        coinvestedPosition.setCurrency(IERC20(address(eure)));
+        coinvestedPosition.setCurrency(IERC20(address(eure)), 1);
     }
 
     function testSetCurrencyNonTrustedReverts() public {
@@ -380,7 +376,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         // not on allowList → 0 attributes, no TRUSTED_CURRENCY bit
         vm.prank(owner);
         vm.expectRevert("currency needs to be on the allowlist with TRUSTED_CURRENCY attribute");
-        coinvestedPosition.setCurrency(IERC20(address(nonTrusted)));
+        coinvestedPosition.setCurrency(IERC20(address(nonTrusted)), 1);
     }
 
     function testFuzz_SetCurrencyValidAccepted(uint8 decimals) public {
@@ -389,23 +385,14 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         // Not on allowList yet → revert
         vm.prank(owner);
         vm.expectRevert();
-        coinvestedPosition.setCurrency(IERC20(address(newCurrency)));
+        coinvestedPosition.setCurrency(IERC20(address(newCurrency)), 1);
 
         // Add to allowList with TRUSTED_CURRENCY bit → accepted
         vm.prank(admin);
         allowList.set(address(newCurrency), TRUSTED_CURRENCY);
         vm.prank(owner);
-        coinvestedPosition.setCurrency(IERC20(address(newCurrency)));
+        coinvestedPosition.setCurrency(IERC20(address(newCurrency)), 1);
         assertEq(address(coinvestedPosition.currency()), address(newCurrency));
-    }
-
-    function testSetCurrencyDoesNotUpdateBasePriceDecimals() public {
-        uint8 decimalsBefore = coinvestedPosition.basePriceDecimals();
-        // Ensure eure has different decimals so the assertion is meaningful
-        assertTrue(eure.decimals() != decimalsBefore, "test requires new currency to have different decimals");
-        vm.prank(owner);
-        coinvestedPosition.setCurrency(IERC20(address(eure)));
-        assertEq(coinvestedPosition.basePriceDecimals(), decimalsBefore, "basePriceDecimals changed after setCurrency");
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -795,10 +782,9 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         // basePriceDecimals=6, setCurrency→EURe (18 dec), tokenPrice=200e18
         // scaledBasePrice = 100e6 scaled to 18 dec = 100e18
         // buy 2 tokens: paid=400e18, basePayout=200e18, carry=200e18
-        assertEq(coinvestedPosition.basePriceDecimals(), 6, "basePriceDecimals changed");
 
         vm.prank(owner);
-        coinvestedPosition.setCurrency(IERC20(address(eure)));
+        coinvestedPosition.setCurrency(IERC20(address(eure)), 100e18);
 
         vm.prank(admin);
         token.mint(address(coinvestedPosition), 10e18);
@@ -837,10 +823,8 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
             eure,
             _defaultLeadInvestors()
         );
-        assertEq(coinvestedPosition18.basePriceDecimals(), 18);
-
         vm.prank(owner);
-        coinvestedPosition18.setCurrency(IERC20(address(eurc)));
+        coinvestedPosition18.setCurrency(IERC20(address(eurc)), 100e6);
 
         vm.prank(admin);
         token.mint(address(coinvestedPosition18), 10e18);
@@ -930,7 +914,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         vm.prank(owner);
         coinvestedPosition.pause();
         vm.prank(owner);
-        coinvestedPosition.setCurrency(IERC20(address(eure)));
+        coinvestedPosition.setCurrency(IERC20(address(eure)), 100e18);
         vm.prank(owner);
         coinvestedPosition.setTokenPrice(200e18);
         vm.prank(owner);
@@ -1065,7 +1049,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
     function testSettleDifferentCurrencyNotSwept() public {
         // Active currency = EURe; a pre-existing EURc balance stays on the contract
         vm.prank(owner);
-        coinvestedPosition.setCurrency(IERC20(address(eure)));
+        coinvestedPosition.setCurrency(IERC20(address(eure)), 100e18);
 
         vm.prank(admin);
         token.mint(address(coinvestedPosition), 10e18);
@@ -1238,14 +1222,13 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         );
 
         // Assert initial state is stored correctly
-        assertEq(fuzzPosition.basePriceDecimals(), baseDecimals, "basePriceDecimals");
         assertEq(fuzzPosition.basePrice(), uint256(basePrice), "basePrice");
 
         // Switch currency to eure (18 dec) and set tokenPrice = 2× scaledBasePrice
         // so carry = scaledBasePrice (50% markup over base)
         uint256 tokenPrice = 2 * scaledBasePrice;
         vm.prank(owner);
-        fuzzPosition.setCurrency(IERC20(address(eure)));
+        fuzzPosition.setCurrency(IERC20(address(eure)), scaledBasePrice);
 
         vm.prank(admin);
         token.mint(address(fuzzPosition), 1e18);
@@ -1298,7 +1281,6 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         );
 
         // Assert initial state is stored correctly
-        assertEq(fuzzPosition.basePriceDecimals(), 18, "basePriceDecimals");
         assertEq(fuzzPosition.basePrice(), uint256(basePrice), "basePrice");
 
         // Create a fresh buy currency with fuzzed decimals and register it
@@ -1310,7 +1292,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         // so carry = scaledBasePrice (50% markup over base)
         uint256 tokenPrice = 2 * scaledBasePrice;
         vm.prank(owner);
-        fuzzPosition.setCurrency(IERC20(address(buyCurrency)));
+        fuzzPosition.setCurrency(IERC20(address(buyCurrency)), scaledBasePrice);
 
         vm.prank(admin);
         token.mint(address(fuzzPosition), 1e18);
@@ -1347,7 +1329,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         vm.assume(caller != address(0) && caller != owner);
         vm.prank(caller);
         vm.expectRevert("Ownable: caller is not the owner");
-        coinvestedPosition.setCurrency(IERC20(address(eure)));
+        coinvestedPosition.setCurrency(IERC20(address(eure)), 1);
     }
 
     function testFuzz_AccessControl_SetTokenPrice(address caller) public {
@@ -1393,28 +1375,14 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
     // ─────────────────────────────────────────────────────────────────────────
 
     function testBuyRevertsWhenCurrencyIsHeldToken() public {
-        // Give token TRUSTED_CURRENCY so setCurrency accepts it
+        // Give token TRUSTED_CURRENCY so the allowList check passes
         vm.prank(admin);
         allowList.set(address(token), TRUSTED_CURRENCY);
 
-        // Switch the sell currency to the equity token itself
-        vm.prank(owner);
-        coinvestedPosition.setCurrency(IERC20(address(token)));
-
-        // Mint tokens to cp and prepare for a buy
-        uint256 tokenPrice = 2e18; // 2 token per token (arbitrary, just needs currencyAmount > 0)
-        _setupBuy(10e18, tokenPrice);
-
-        // Mint equity token to buyer (requirements == 0 so no allowList entry needed)
-        uint256 cost = Math.ceilDiv(1e18 * tokenPrice, 10 ** token.decimals());
-        vm.prank(admin);
-        token.mint(buyer, cost);
-        vm.prank(buyer);
-        IERC20(address(token)).approve(address(coinvestedPosition), cost);
-
+        // setCurrency itself must reject the held token as currency
         vm.expectRevert("currency cannot be the held token");
-        vm.prank(buyer);
-        coinvestedPosition.buy(1e18, cost, tokenReceiver);
+        vm.prank(owner);
+        coinvestedPosition.setCurrency(IERC20(address(token)), 1);
     }
 
     function testReentrancyBuyReverts() public {

--- a/test/CoinvestedPosition.t.sol
+++ b/test/CoinvestedPosition.t.sol
@@ -187,16 +187,6 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         assertEq(frac1, CARRY_5PCT, "leadB fraction");
     }
 
-    function testInitBasePriceDecimalsReflectsBaseCurrency() public {
-        // Deploy with 18-dec currency → basePriceDecimals = 18
-        CoinvestedPosition coinvestedPosition18 = _deployCoinvestedPosition(
-            bytes32("salt"),
-            100e18,
-            eure,
-            _defaultLeadInvestors()
-        );
-    }
-
     function testFuzz_InitBasePriceDecimalsAndPriceStoredCorrectly(uint8 decimals, uint256 basePrice) public {
         vm.assume(basePrice > 0);
         vm.assume(decimals <= 30);
@@ -324,10 +314,10 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
     }
 
     function testInitCarryFractionsSumOverflowReverts() public {
-        // Two investors each with uint64.max: sum overflows uint64 → arithmetic revert
+        // (max/2 + 1) + (max/2 + 1) = max + 1: sum overflows uint64 → arithmetic revert
         LeadInvestor[] memory leadInvestors = new LeadInvestor[](2);
-        leadInvestors[0] = LeadInvestor({account: leadA, carryFraction: type(uint64).max});
-        leadInvestors[1] = LeadInvestor({account: leadB, carryFraction: 1});
+        leadInvestors[0] = LeadInvestor({account: leadA, carryFraction: type(uint64).max / 2 + 1});
+        leadInvestors[1] = LeadInvestor({account: leadB, carryFraction: type(uint64).max / 2 + 1});
         CoinvestedPositionInitializerArguments memory args = CoinvestedPositionInitializerArguments({
             owner: owner,
             receiver: receiver,

--- a/test/CoinvestedPositionCloneFactory.t.sol
+++ b/test/CoinvestedPositionCloneFactory.t.sol
@@ -85,7 +85,7 @@ contract CoinvestedPositionCloneFactoryTest is Test {
 
     // ========== F1-CP. Address Prediction ==========
 
-    function testBothPredictOverloadsMatch() public {
+    function testBothPredictOverloadsMatch() public view {
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
         bytes32 precomputed = keccak256(abi.encode(EXAMPLE_SALT, trustedForwarder, args));
 
@@ -111,21 +111,21 @@ contract CoinvestedPositionCloneFactoryTest is Test {
 
     // ========== F2-CP. Each Salt Parameter Changes the Address ==========
 
-    function testRawSaltChangesAddress() public {
+    function testRawSaltChangesAddress() public view {
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
         address a1 = factory.predictCloneAddress(bytes32(uint256(1)), trustedForwarder, args);
         address a2 = factory.predictCloneAddress(bytes32(uint256(2)), trustedForwarder, args);
         assertFalse(a1 == a2);
     }
 
-    function testTrustedForwarderChangesAddress() public {
+    function testTrustedForwarderChangesAddress() public view {
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
         address a1 = factory.predictCloneAddress(EXAMPLE_SALT, trustedForwarder, args);
         address a2 = factory.predictCloneAddress(EXAMPLE_SALT, address(0x9999), args);
         assertFalse(a1 == a2);
     }
 
-    function testOwnerChangesAddress() public {
+    function testOwnerChangesAddress() public view {
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
         address a1 = factory.predictCloneAddress(EXAMPLE_SALT, trustedForwarder, args);
         args.owner = address(0x9999);
@@ -133,7 +133,7 @@ contract CoinvestedPositionCloneFactoryTest is Test {
         assertFalse(a1 == a2);
     }
 
-    function testReceiverChangesAddress() public {
+    function testReceiverChangesAddress() public view {
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
         address a1 = factory.predictCloneAddress(EXAMPLE_SALT, trustedForwarder, args);
         args.receiver = address(0x9999);
@@ -141,7 +141,7 @@ contract CoinvestedPositionCloneFactoryTest is Test {
         assertFalse(a1 == a2);
     }
 
-    function testBasePriceChangesAddress() public {
+    function testBasePriceChangesAddress() public view {
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
         address a1 = factory.predictCloneAddress(EXAMPLE_SALT, trustedForwarder, args);
         args.basePrice = EXAMPLE_BASE_PRICE + 1;
@@ -149,7 +149,7 @@ contract CoinvestedPositionCloneFactoryTest is Test {
         assertFalse(a1 == a2);
     }
 
-    function testBaseCurrencyChangesAddress() public {
+    function testBaseCurrencyChangesAddress() public view {
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
         address a1 = factory.predictCloneAddress(EXAMPLE_SALT, trustedForwarder, args);
         args.baseCurrency = IERC20(address(0x9999));
@@ -157,7 +157,7 @@ contract CoinvestedPositionCloneFactoryTest is Test {
         assertFalse(a1 == a2);
     }
 
-    function testTokenChangesAddress() public {
+    function testTokenChangesAddress() public view {
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
         address a1 = factory.predictCloneAddress(EXAMPLE_SALT, trustedForwarder, args);
         args.token = Token(address(0x9999));
@@ -165,7 +165,7 @@ contract CoinvestedPositionCloneFactoryTest is Test {
         assertFalse(a1 == a2);
     }
 
-    function testLeadInvestorsCarryFractionChangesAddress() public {
+    function testLeadInvestorsCarryFractionChangesAddress() public view {
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
         address a1 = factory.predictCloneAddress(EXAMPLE_SALT, trustedForwarder, args);
         args.leadInvestors[0].carryFraction = type(uint64).max / 10 + 1;
@@ -173,7 +173,7 @@ contract CoinvestedPositionCloneFactoryTest is Test {
         assertFalse(a1 == a2);
     }
 
-    function testLeadInvestorsLengthChangesAddress() public {
+    function testLeadInvestorsLengthChangesAddress() public view {
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
         address a1 = factory.predictCloneAddress(EXAMPLE_SALT, trustedForwarder, args);
 

--- a/test/CoinvestedPositionCloneFactory.t.sol
+++ b/test/CoinvestedPositionCloneFactory.t.sol
@@ -214,7 +214,6 @@ contract CoinvestedPositionCloneFactoryTest is Test {
         assertEq(address(cp.currency()), address(args.baseCurrency));
         assertEq(address(cp.token()), address(args.token));
         assertEq(cp.basePrice(), args.basePrice);
-        assertEq(cp.basePriceDecimals(), 6); // FakePaymentToken has 6 decimals
         assertEq(cp.getLeadInvestorsCount(), 2);
         assertTrue(cp.paused()); // starts paused
         assertEq(cp.tokenPrice(), 0);

--- a/test/CoinvestedPositionDistribution.t.sol
+++ b/test/CoinvestedPositionDistribution.t.sol
@@ -257,7 +257,7 @@ contract CoinvestedPositionDistributionTest is Test {
         uint256 beforeR = usdc.balanceOf(receiver);
 
         vm.prank(owner);
-        coinvestedPosition.distributeDividends(IDistribution(address(distribution)));
+        coinvestedPosition.distributeDividends(IDistribution(address(distribution)), usdc);
 
         uint256 aGot = usdc.balanceOf(leadA) - beforeA;
         uint256 bGot = usdc.balanceOf(leadB) - beforeB;
@@ -320,7 +320,7 @@ contract CoinvestedPositionDistributionTest is Test {
         uint256 beforeB = usdc.balanceOf(leadB);
 
         vm.prank(owner);
-        coinvestedPosition.distributeDividends(IDistribution(address(distribution)));
+        coinvestedPosition.distributeDividends(IDistribution(address(distribution)), usdc);
 
         uint256 aGot = usdc.balanceOf(leadA) - beforeA;
         uint256 bGot = usdc.balanceOf(leadB) - beforeB;
@@ -401,7 +401,7 @@ contract CoinvestedPositionDistributionTest is Test {
         uint256 beforeR = usdc.balanceOf(receiver);
 
         vm.prank(owner);
-        coinvestedPosition3.distributeDividends(IDistribution(address(distribution)));
+        coinvestedPosition3.distributeDividends(IDistribution(address(distribution)), usdc);
 
         assertEq(usdc.balanceOf(leadA) - beforeA, expectedA, "DI-III-A: wrong leadA payout");
         assertEq(usdc.balanceOf(leadB) - beforeB, expectedB, "DI-III-A: wrong leadB payout");
@@ -484,7 +484,7 @@ contract CoinvestedPositionDistributionTest is Test {
         uint256 beforeR = eure.balanceOf(receiver);
 
         vm.prank(owner);
-        coinvestedPosition3.distributeDividends(IDistribution(address(distribution)));
+        coinvestedPosition3.distributeDividends(IDistribution(address(distribution)), eure);
 
         assertEq(eure.balanceOf(leadA) - beforeA, expectedA, "DI-III-B: wrong leadA EURe payout");
         assertEq(eure.balanceOf(leadB) - beforeB, expectedB, "DI-III-B: wrong leadB EURe payout");
@@ -518,7 +518,7 @@ contract CoinvestedPositionDistributionTest is Test {
 
         // Must not revert
         vm.prank(owner);
-        coinvestedPosition.distributeDividends(IDistribution(address(distribution)));
+        coinvestedPosition.distributeDividends(IDistribution(address(distribution)), usdc);
 
         uint256 aGot = usdc.balanceOf(leadA) - beforeA;
         uint256 bGot = usdc.balanceOf(leadB) - beforeB;
@@ -543,10 +543,11 @@ contract CoinvestedPositionDistributionTest is Test {
         // bypassing Distribution's own constructor guard.
         FakePaymentToken untrusted = new FakePaymentToken(0, 6);
         TokenTransferStub stub = new TokenTransferStub(IERC20(address(untrusted)), 0);
+        IERC20 untrustedCurrency = IERC20(address(stub.currency()));
 
         vm.expectRevert("dividend currency must be a trusted currency");
         vm.prank(owner);
-        coinvestedPosition.distributeDividends(IDistribution(address(stub)));
+        coinvestedPosition.distributeDividends(IDistribution(address(stub)), untrustedCurrency);
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -566,7 +567,7 @@ contract CoinvestedPositionDistributionTest is Test {
         uint256 beforeR = usdc.balanceOf(receiver);
 
         vm.prank(owner);
-        coinvestedPosition.distributeDividends(IDistribution(address(distribution)));
+        coinvestedPosition.distributeDividends(IDistribution(address(distribution)), usdc);
 
         uint256 aGot = usdc.balanceOf(leadA) - beforeA;
         uint256 bGot = usdc.balanceOf(leadB) - beforeB;
@@ -611,7 +612,7 @@ contract CoinvestedPositionDistributionTest is Test {
         // distributeDividends must revert because received = 0
         vm.expectRevert("didn't receive expected currency from distribution");
         vm.prank(owner);
-        coinvestedPositionZero.distributeDividends(IDistribution(address(distribution)));
+        coinvestedPositionZero.distributeDividends(IDistribution(address(distribution)), usdc);
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -657,7 +658,7 @@ contract CoinvestedPositionDistributionTest is Test {
         uint256 beforeR = usdc.balanceOf(receiver);
 
         vm.prank(owner);
-        coinvestedPosition.distributeDividends(IDistribution(address(distribution)));
+        coinvestedPosition.distributeDividends(IDistribution(address(distribution)), usdc);
 
         uint256 aGot = usdc.balanceOf(leadA) - beforeA;
         uint256 bGot = usdc.balanceOf(leadB) - beforeB;
@@ -702,7 +703,7 @@ contract CoinvestedPositionDistributionTest is Test {
             uint256 beforeR = usdc.balanceOf(receiver);
 
             vm.prank(owner);
-            coinvestedPosition.distributeDividends(IDistribution(address(usdcDistribution)));
+            coinvestedPosition.distributeDividends(IDistribution(address(usdcDistribution)), usdc);
 
             uint256 aGot = usdc.balanceOf(leadA) - beforeA;
             uint256 bGot = usdc.balanceOf(leadB) - beforeB;
@@ -740,7 +741,7 @@ contract CoinvestedPositionDistributionTest is Test {
             uint256 beforeR = eure.balanceOf(receiver);
 
             vm.prank(owner);
-            coinvestedPosition.distributeDividends(IDistribution(address(eureDistribution)));
+            coinvestedPosition.distributeDividends(IDistribution(address(eureDistribution)), eure);
 
             uint256 aGot = eure.balanceOf(leadA) - beforeA;
             uint256 bGot = eure.balanceOf(leadB) - beforeB;
@@ -780,7 +781,7 @@ contract CoinvestedPositionDistributionTest is Test {
         uint256 beforeR = usdc.balanceOf(receiver);
 
         vm.prank(owner);
-        coinvestedPosition.distributeDividends(IDistribution(address(distribution)));
+        coinvestedPosition.distributeDividends(IDistribution(address(distribution)), usdc);
 
         uint256 aGot = usdc.balanceOf(leadA) - beforeA;
         uint256 bGot = usdc.balanceOf(leadB) - beforeB;
@@ -853,7 +854,7 @@ contract CoinvestedPositionDistributionTest is Test {
         uint256 beforeR = usdc.balanceOf(receiver);
 
         vm.prank(owner);
-        coinvestedPosition.distributeDividends(IDistribution(address(distribution)));
+        coinvestedPosition.distributeDividends(IDistribution(address(distribution)), usdc);
 
         uint256 aGot = usdc.balanceOf(leadA) - beforeA;
         uint256 bGot = usdc.balanceOf(leadB) - beforeB;
@@ -919,10 +920,11 @@ contract CoinvestedPositionDistributionTest is Test {
         token.mint(address(this), stubAmount);
         TokenTransferStub stub = new TokenTransferStub(IERC20(address(token)), stubAmount);
         IERC20(address(token)).transfer(address(stub), stubAmount);
+        IERC20 tokenCurrency = IERC20(address(stub.currency()));
 
         vm.expectRevert("currency cannot be the held token");
         vm.prank(owner);
-        coinvestedPosition.distributeDividends(IDistribution(address(stub)));
+        coinvestedPosition.distributeDividends(IDistribution(address(stub)), tokenCurrency);
     }
 
     /**
@@ -1063,7 +1065,7 @@ contract CoinvestedPositionDistributionTest is Test {
         if (coinvestedPositionEligible == 0) {
             vm.expectRevert("didn't receive expected currency from distribution");
             vm.prank(owner);
-            coinvestedPositionFuzz.distributeDividends(IDistribution(address(distributionFuzz)));
+            coinvestedPositionFuzz.distributeDividends(IDistribution(address(distributionFuzz)), usdc);
             return;
         }
 
@@ -1076,7 +1078,7 @@ contract CoinvestedPositionDistributionTest is Test {
         snaps[3] = usdc.balanceOf(receiver);
 
         vm.prank(owner);
-        coinvestedPositionFuzz.distributeDividends(IDistribution(address(distributionFuzz)));
+        coinvestedPositionFuzz.distributeDividends(IDistribution(address(distributionFuzz)), usdc);
 
         uint256 totalGot = 0;
         {

--- a/test/CoinvestedPositionExit.t.sol
+++ b/test/CoinvestedPositionExit.t.sol
@@ -238,7 +238,7 @@ contract CoinvestedPositionExitTest is Test {
         // Do NOT warp — still before claimStart
         vm.expectRevert("exit not yet started");
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
     }
 
     function testDistributeExitSucceedsAfterDrainStart() public {
@@ -248,7 +248,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
     }
 
     function testDistributeExitRevertsWhenZeroTokens() public {
@@ -267,7 +267,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.warp(claimStart);
         vm.expectRevert("no tokens to claim");
         vm.prank(owner);
-        coinvestedPositionEmpty.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPositionEmpty.distributeExit(IERC20(address(eurc)), 1, 0);
     }
 
     function testDistributeExitOnlyOwner() public {
@@ -276,7 +276,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.warp(claimStart);
         vm.expectRevert("Ownable: caller is not the owner");
         // called by address(this) which is not owner
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -298,7 +298,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         uint256 received = 40_000e6;
         uint256 carry = 20_000e6; // received - basePayout(20,000e6)
@@ -336,7 +336,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         uint256 received = 20_000e6;
         uint256 aGot = eurc.balanceOf(leadA) - beforeA;
@@ -366,7 +366,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         uint256 received = 12_000e6; // 200 * 60e6 / 1e18 * 1e18 = 12,000e6
         uint256 aGot = eurc.balanceOf(leadA) - beforeA;
@@ -401,7 +401,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eure)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eure)), 1, 100e18);
 
         // received: 200e18 * 200e18 / 1e18 = 40,000e18 EURe
         // basePayout: scaleToDecimals(20,000e6, 18) = 20,000e18 EURe
@@ -448,7 +448,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPositionEure.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPositionEure.distributeExit(IERC20(address(eurc)), 1, 100e6);
 
         // received: 200e18 * 200e6 / 1e18 = 40,000e6 EURc
         // basePayout: scaleToDecimals(20,000e18, 6) = 20,000e6 EURc; carry = 20,000e6
@@ -483,7 +483,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         // Same as II-A — using formula-based expected values to confirm no double-scaling
         uint256 carryIIIC = 20_000e6;
@@ -529,7 +529,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition3.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition3.distributeExit(IERC20(address(eurc)), 1, 0);
 
         _checkIVA(beforeA, beforeB, beforeC, beforeR, eurc.balanceOf(receiver) - beforeR, address(coinvestedPosition3));
     }
@@ -581,7 +581,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPositionSingle.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPositionSingle.distributeExit(IERC20(address(eurc)), 1, 0);
 
         uint256 received = 40_000e6;
         uint256 carry = 20_000e6; // received - basePayout
@@ -686,7 +686,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistryForFeeToken.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPositionFee.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPositionFee.distributeExit(IERC20(address(eurc)), 1, 0);
 
         // Full 40,000e6 distributed; no fee deducted
         uint256 received = 40_000e6;
@@ -723,7 +723,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         // received computed via before-snapshot excludes the 500e6 pre-existing
         // => received = 40,000e6; carry = 20,000e6; A=2,000; B=1,000; receiver gets 37,000 + 500 = 37,500
@@ -760,7 +760,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         // EURe balance on cp is unchanged
         assertEq(eure.balanceOf(address(coinvestedPosition)), eureBalanceBefore, "VIB: EURe balance changed");
@@ -785,7 +785,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.warp(claimStart);
         vm.expectRevert("ERC20: transfer amount exceeds balance");
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         // cp retains its tokens
         assertEq(token.balanceOf(address(coinvestedPosition)), cpTokensBefore, "VIIA: cp lost tokens despite revert");
@@ -801,7 +801,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         // Exit currency balance = 0 after full claim
         assertEq(eurc.balanceOf(address(exitContract)), 0, "VIIB: exit EURc not fully exhausted");
@@ -823,7 +823,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         assertEq(token.balanceOf(address(coinvestedPosition)), 0, "VIII: cp still holds tokens after");
         assertEq(token.balanceOf(address(exitContract)), CP_TOKEN_AMOUNT, "VIII: exit does not hold tokens");
@@ -879,7 +879,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPositionFuzz.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPositionFuzz.distributeExit(IERC20(address(eurc)), 1, 0);
 
         uint256 aGot = eurc.balanceOf(leadA) - beforeA;
         uint256 bGot = eurc.balanceOf(leadB) - beforeB;
@@ -909,7 +909,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         uint256 received = 40_000e6; // snapshot-based, excludes preExisting
         uint256 carry = 20_000e6;
@@ -986,7 +986,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         // received = 150e18 * 200e6 / 1e18 = 30,000e6
         // basePayout = scaleToDecimals((100e6 * 150e18) / 1e18, 6) = 15,000e6
@@ -1021,7 +1021,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);
 
         assertEq(token.balanceOf(address(coinvestedPosition)), 0, "KI: cp still holds tokens after exit");
     }
@@ -1041,7 +1041,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.warp(claimStart);
         vm.prank(owner);
         vm.expectRevert("received less than _minCurrencyAmount");
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), totalCurrency + 1);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), totalCurrency + 1, 0);
     }
 
     /// XI-B: succeeds when received == _minCurrencyAmount (exact boundary)
@@ -1054,7 +1054,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), totalCurrency);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), totalCurrency, 0);
 
         assertEq(token.balanceOf(address(coinvestedPosition)), 0, "XIB: cp still holds tokens after exit");
     }
@@ -1068,7 +1068,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(admin);
         tokenExitRegistry.setExit(IExit(address(exitContract)));
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(eurc)), 0);
+        coinvestedPosition.distributeExit(IERC20(address(eurc)), 0, 0);
 
         assertEq(token.balanceOf(address(coinvestedPosition)), 0, "XIC: cp still holds tokens after exit");
     }
@@ -1090,7 +1090,7 @@ contract CoinvestedPositionExitTest is Test {
         tokenExitRegistry.setExit(IExit(address(noOpExit)));
         vm.expectRevert("currency cannot be the held token");
         vm.prank(owner);
-        coinvestedPosition.distributeExit(IERC20(address(token)), 0);
+        coinvestedPosition.distributeExit(IERC20(address(token)), 0, 1);
     }
 
     /// XI-D: fuzz — reverts iff _minCurrencyAmount > received; succeeds otherwise
@@ -1112,6 +1112,6 @@ contract CoinvestedPositionExitTest is Test {
         if (uint256(minCurrencyAmount) > received) {
             vm.expectRevert("received less than _minCurrencyAmount");
         }
-        coinvestedPositionFuzz.distributeExit(IERC20(address(eurc)), uint256(minCurrencyAmount));
+        coinvestedPositionFuzz.distributeExit(IERC20(address(eurc)), uint256(minCurrencyAmount), 0);
     }
 }

--- a/test/CoinvestedPositionExit.t.sol
+++ b/test/CoinvestedPositionExit.t.sol
@@ -271,9 +271,6 @@ contract CoinvestedPositionExitTest is Test {
     }
 
     function testDistributeExitOnlyOwner() public {
-        Exit exitContract = _deployExit(bytes32("i5"), eurc, 200e6, CP_TOKEN_AMOUNT);
-
-        vm.warp(claimStart);
         vm.expectRevert("Ownable: caller is not the owner");
         // called by address(this) which is not owner
         coinvestedPosition.distributeExit(IERC20(address(eurc)), 1, 0);

--- a/test/TokenSwap.t.sol
+++ b/test/TokenSwap.t.sol
@@ -793,15 +793,15 @@ contract TokenSwapTest is Test {
 
         // set fees to 0
         {
-            FeeSettings feeSettings = FeeSettings(address(token.feeSettings()));
-            feeSettings.planFeeChange(FeeTypes.TOKEN, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET, 0, uint64(block.timestamp));
-            feeSettings.executeFeeChange(FeeTypes.TOKEN);
-            feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
-            feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER);
-            feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET);
+            FeeSettings _feeSettings = FeeSettings(address(token.feeSettings()));
+            _feeSettings.planFeeChange(FeeTypes.TOKEN, 0, uint64(block.timestamp));
+            _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, 0, uint64(block.timestamp));
+            _feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, 0, uint64(block.timestamp));
+            _feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET, 0, uint64(block.timestamp));
+            _feeSettings.executeFeeChange(FeeTypes.TOKEN);
+            _feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
+            _feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER);
+            _feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET);
         }
 
         // approve
@@ -852,15 +852,15 @@ contract TokenSwapTest is Test {
 
         // set fees to 0
         {
-            FeeSettings feeSettings = FeeSettings(address(token.feeSettings()));
-            feeSettings.planFeeChange(FeeTypes.TOKEN, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, 0, uint64(block.timestamp));
-            feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET, 0, uint64(block.timestamp));
-            feeSettings.executeFeeChange(FeeTypes.TOKEN);
-            feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
-            feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER);
-            feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET);
+            FeeSettings _feeSettings = FeeSettings(address(token.feeSettings()));
+            _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, 0, uint64(block.timestamp));
+            _feeSettings.planFeeChange(FeeTypes.TOKEN, 0, uint64(block.timestamp));
+            _feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, 0, uint64(block.timestamp));
+            _feeSettings.planFeeChange(FeeTypes.SECONDARY_MARKET, 0, uint64(block.timestamp));
+            _feeSettings.executeFeeChange(FeeTypes.TOKEN);
+            _feeSettings.executeFeeChange(FeeTypes.CROWDINVESTING);
+            _feeSettings.executeFeeChange(FeeTypes.PRIVATE_OFFER);
+            _feeSettings.executeFeeChange(FeeTypes.SECONDARY_MARKET);
         }
 
         // approve holder to spend payment token


### PR DESCRIPTION
CoinvestedPosition restricted exit and dividend currencies to trusted EURO tokens, intended to prevent the         
  coinvestor from manipulating the carry calculation by using an unfavorable exchange rate for a different currency.
                                                                                                                     
  This restriction turns out to be ineffective. The same carry manipulation is already possible in the same-currency 
  path: the coinvestor controls tokenPrice and can set it equal to basePrice, producing zero carry regardless of
  currency. Since the contract already trusts the coinvestor on price, restricting the currency adds friction without
   closing any real attack vector.                                

  Game theory exploration                                                                                            
  
  We explored whether a smarter on-chain mechanism could resolve the underlying trust problem — specifically, whether
   lead investors could be given a veto over a proposed altBasePrice for a different currency.
                                                                                                                     
  Several approaches were considered:                                                                                
  
  - Proposal/veto: Lead investors veto a bad proposal, but the coinvestor can re-propose indefinitely with no        
  on-chain consequence. Toothless.                                
  - Counter-price veto: Lead investors must submit a counter when vetoing, creating negotiation. But both sides can  
  anchor at extremes (0 and maximum) and nothing converges.                                                          
  - Oracle: Use an on-chain EUR/USD rate. No reliable on-chain source for historic rates exists, and even current
  rates can be timed for a favorable moment.                                                                         
  - Divide-and-choose (Texas Shootout): Coinvestor names a price; lead investors can take the other side. Doesn't
  apply cleanly here because lead investors have a small carryFraction (~15%) while the base payout is the large     
  portion — they would always prefer to swap, making the mechanism degenerate.
                                                                                                                     
  Conclusion: The blockchain cannot self-enforce honest pricing when both parties have opposing incentives and no    
  objective on-chain truth source exists. The contract's value is correct automatic execution for the honest case and
   an immutable auditable record for legal recourse — not dispute resolution.                                        
                                                                  
  Design                                                                                                             
  
  Drop the currency restrictions and the complexity they imply. The coinvestor provides altBasePrice — the base price
   expressed in the exit/sell currency's own units — at the point of use:
                                                                                                                     
  - setCurrency(currency, altBasePrice): when changing the buy currency, the new altBasePrice overwrites the stored  
  basePrice. All subsequent buy() carry calculations use it automatically.
  - distributeExit(exit, exitCurrency, minAmount, altBasePrice): same-currency exits use the stored basePrice        
  directly; different-currency exits use the inline altBasePrice.                                                    
  - distributeDividends: currency restriction removed entirely — the coinvestor doesn't choose the dividend currency,
   and dividends are always 100% carry regardless of currency.                                                       
                                                                  
  Simplification                                                                                                     
                                                                  
  basePriceDecimals and _scaleToDecimals are removed. With basePrice always expressed in the current currency's      
  decimals (invariant maintained by initialize and setCurrency), decimal scaling is always a no-op and the field is
  redundant.     