### PR TITLE
Chore/modernize

### DIFF
--- a/.github/workflows/foundry.yml
+++ b/.github/workflows/foundry.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: stable
+          version: nightly
 
       - name: Run local tests
         working-directory: .

--- a/audits/2026-05_Hacken_scope.md
+++ b/audits/2026-05_Hacken_scope.md
@@ -44,7 +44,7 @@ These need a full review:
 - `AllowList`
 - `PriceLinear`
 - `IPriceDynamic`
-- `FeeSplitter`
+- `FeeDistributor`
 
 # Requested Analysis Depth
 

--- a/contracts/AllowList.sol
+++ b/contracts/AllowList.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";

--- a/contracts/AllowList.sol
+++ b/contracts/AllowList.sol
@@ -4,6 +4,8 @@ pragma solidity 0.8.34;
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";
 
+import "./common/Errors.sol";
+
 /**
  * @dev the last bit is defined as special bit for the "trusted currency" attribute.
  * This specific bit was chosen for this purpose because the allowList operators are
@@ -86,7 +88,7 @@ contract AllowList is Ownable2StepUpgradeable, ERC2771ContextUpgradeable {
      * @param _owner the owner of the contract
      */
     function initialize(address _owner) public initializer {
-        require(_owner != address(0), "owner can not be zero address");
+        require(_owner != address(0), ZeroOwnerAddress());
         _transferOwnership(_owner);
     }
 
@@ -99,7 +101,7 @@ contract AllowList is Ownable2StepUpgradeable, ERC2771ContextUpgradeable {
         address[] calldata _addresses,
         uint256[] calldata _attributes
     ) public initializer {
-        require(_owner != address(0), "owner can not be zero address");
+        require(_owner != address(0), ZeroOwnerAddress());
         _transferOwnership(_owner);
         _set(_addresses, _attributes);
     }
@@ -140,7 +142,7 @@ contract AllowList is Ownable2StepUpgradeable, ERC2771ContextUpgradeable {
      * @param _attributes array of attributes to be assigned to addresses
      */
     function _set(address[] calldata _addr, uint256[] calldata _attributes) internal {
-        require(_addr.length == _attributes.length, "lengths do not match");
+        require(_addr.length == _attributes.length, ArrayLengthMismatch());
         for (uint256 i = 0; i < _addr.length; i++) {
             _set(_addr[i], _attributes[i]);
         }

--- a/contracts/CoinvestedPosition.sol
+++ b/contracts/CoinvestedPosition.sol
@@ -215,7 +215,7 @@ contract CoinvestedPosition is TokenSwapBase {
 
         IERC20 exitCurrency = _exit.currency();
         uint256 effectiveBasePrice;
-        if (exitCurrency == currency) {
+        if (address(exitCurrency) == address(currency)) {
             effectiveBasePrice = basePrice;
         } else {
             uint256 rate = _exit.referenceToExitRate(currency);

--- a/contracts/CoinvestedPosition.sol
+++ b/contracts/CoinvestedPosition.sol
@@ -51,6 +51,14 @@ struct CoinvestedPositionInitializerArguments {
 contract CoinvestedPosition is TokenSwapBase {
     using SafeERC20 for IERC20;
 
+    error NoLeadInvestors();
+    error ZeroLeadInvestorAddress();
+    error ZeroLeadInvestorProfitFraction();
+    error ZeroTokenExitRegistryAddress();
+    error TimeLockNotExpired();
+    error NoExitSet();
+    error PurchaseTooExpensive();
+
     /// lead investors and their carry fractions
     LeadInvestor[] public leadInvestors;
     /// base price per token in bits of the current currency (always expressed in current currency's decimals)
@@ -77,15 +85,15 @@ contract CoinvestedPosition is TokenSwapBase {
     function initialize(CoinvestedPositionInitializerArguments memory _arguments) external initializer {
         _initializeBase(_arguments.owner, 0, _arguments.baseCurrency, _arguments.token, _arguments.receiver);
 
-        require(_arguments.leadInvestors.length > 0, "There must be at least one lead investor");
+        require(_arguments.leadInvestors.length > 0, NoLeadInvestors());
         uint64 profitFractionsSum = 0;
         for (uint256 i = 0; i < _arguments.leadInvestors.length; i++) {
-            require(_arguments.leadInvestors[i].account != address(0), "lead investor can not be zero address");
-            require(_arguments.leadInvestors[i].profitFraction > 0, "lead investor profit fraction can not be zero");
+            require(_arguments.leadInvestors[i].account != address(0), ZeroLeadInvestorAddress());
+            require(_arguments.leadInvestors[i].profitFraction > 0, ZeroLeadInvestorProfitFraction());
             profitFractionsSum += _arguments.leadInvestors[i].profitFraction; // reverts on overflow, thus avoiding profitFractionsSum > 100%
             leadInvestors.push(_arguments.leadInvestors[i]);
         }
-        require(address(_arguments.tokenExitRegistry) != address(0), "tokenExitRegistry can not be zero address");
+        require(address(_arguments.tokenExitRegistry) != address(0), ZeroTokenExitRegistryAddress());
         basePrice = _arguments.basePrice;
         lockedUntil = _arguments.lockedUntil;
         tokenExitRegistry = _arguments.tokenExitRegistry;
@@ -98,8 +106,8 @@ contract CoinvestedPosition is TokenSwapBase {
      * @notice Unpause the contract. Blocked until lockedUntil has passed.
      */
     function unpause() external override onlyOwner {
-        require(tokenPrice != 0, "tokenPrice must be set before unpausing");
-        require(block.timestamp >= lockedUntil, "timelock has not expired");
+        require(tokenPrice != 0, ZeroPrice());
+        require(block.timestamp >= lockedUntil, TimeLockNotExpired());
         _unpause();
     }
 
@@ -109,13 +117,13 @@ contract CoinvestedPosition is TokenSwapBase {
      * @param _basePrice base price expressed in the new currency's units; must be > 0
      */
     function setCurrency(IERC20 _currency, uint256 _basePrice) external onlyOwner {
-        require(block.timestamp >= lockedUntil, "timelock has not expired");
-        require(address(_currency) != address(0), "zero address");
-        require(address(_currency) != address(token), "currency cannot be the held token");
-        require(_basePrice > 0, "altBasePrice must be > 0");
+        require(block.timestamp >= lockedUntil, TimeLockNotExpired());
+        require(address(_currency) != address(0), ZeroCurrencyAddress());
+        require(address(_currency) != address(token), CurrencyEqualsToken());
+        require(_basePrice > 0, ZeroPrice());
         require(
             token.allowList().map(address(_currency)) == TRUSTED_CURRENCY,
-            "currency needs to be on the allowlist with TRUSTED_CURRENCY attribute"
+            UntrustedCurrency()
         );
         basePrice = _basePrice;
         currency = _currency;
@@ -135,7 +143,7 @@ contract CoinvestedPosition is TokenSwapBase {
         // rounding up to the next whole number. Buyer is charged up to one currency bit more in case of a fractional currency bit.
         uint256 currencyAmount = Math.ceilDiv(_tokenAmount * tokenPrice, 10 ** token.decimals());
 
-        require(currencyAmount <= _maxCurrencyAmount, "Purchase more expensive than _maxCurrencyAmount");
+        require(currencyAmount <= _maxCurrencyAmount, PurchaseTooExpensive());
 
         // pull full amount to this contract first, then distribute from here
         currency.safeTransferFrom(_msgSender(), address(this), currencyAmount);
@@ -170,7 +178,7 @@ contract CoinvestedPosition is TokenSwapBase {
      * @param _currency the ERC20 token to use as currency for the settlement
      */
     function _settle(uint256 profit, IERC20 _currency) internal {
-        require(address(_currency) != address(token), "currency cannot be the held token");
+        require(address(_currency) != address(token), CurrencyEqualsToken());
         for (uint256 i = 0; i < leadInvestors.length; i++) {
             uint256 carryFraction = (uint256(leadInvestors[i].profitFraction) * profit) / type(uint64).max;
             if (carryFraction != 0) {
@@ -191,7 +199,7 @@ contract CoinvestedPosition is TokenSwapBase {
         IERC20 dividendCurrency = _dist.currency();
         require(
             token.allowList().map(address(dividendCurrency)) == TRUSTED_CURRENCY,
-            "dividend currency must be a trusted currency"
+            UntrustedCurrency()
         );
         uint256 before = dividendCurrency.balanceOf(address(this));
         _dist.claim(address(this), _minPayout);
@@ -212,9 +220,9 @@ contract CoinvestedPosition is TokenSwapBase {
      */
     function claimExit(uint256 _minCurrencyAmount, uint256 _basePrice) external onlyOwner nonReentrant {
         Exit _exit = tokenExitRegistry.exits(token);
-        require(address(_exit) != address(0), "no exit set in tokenExitRegistry");
+        require(address(_exit) != address(0), NoExitSet());
         uint256 tokenBalance = token.balanceOf(address(this));
-        require(tokenBalance > 0, "no tokens to claim");
+        require(tokenBalance > 0, ZeroAmount());
 
         IERC20 exitCurrency = _exit.currency();
         uint256 effectiveBasePrice;
@@ -225,7 +233,7 @@ contract CoinvestedPosition is TokenSwapBase {
             if (rate > 0) {
                 effectiveBasePrice = (basePrice * rate) / 10 ** IERC20Metadata(address(currency)).decimals();
             } else {
-                require(_basePrice > 0, "altBasePrice must be > 0");
+                require(_basePrice > 0, ZeroPrice());
                 effectiveBasePrice = _basePrice;
             }
         }

--- a/contracts/CoinvestedPosition.sol
+++ b/contracts/CoinvestedPosition.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";

--- a/contracts/CoinvestedPosition.sol
+++ b/contracts/CoinvestedPosition.sol
@@ -51,13 +51,8 @@ struct CoinvestedPositionInitializerArguments {
 contract CoinvestedPosition is TokenSwapBase {
     using SafeERC20 for IERC20;
 
-    error NoLeadInvestors();
     error ZeroLeadInvestorAddress();
     error ZeroLeadInvestorProfitFraction();
-    error ZeroTokenExitRegistryAddress();
-    error TimeLockNotExpired();
-    error NoExitSet();
-    error PurchaseTooExpensive();
 
     /// lead investors and their carry fractions
     LeadInvestor[] public leadInvestors;

--- a/contracts/CoinvestedPosition.sol
+++ b/contracts/CoinvestedPosition.sol
@@ -116,10 +116,7 @@ contract CoinvestedPosition is TokenSwapBase {
         require(address(_currency) != address(0), ZeroCurrencyAddress());
         require(address(_currency) != address(token), CurrencyEqualsToken());
         require(_basePrice > 0, ZeroPrice());
-        require(
-            token.allowList().map(address(_currency)) == TRUSTED_CURRENCY,
-            UntrustedCurrency()
-        );
+        require(token.allowList().map(address(_currency)) == TRUSTED_CURRENCY, UntrustedCurrency());
         basePrice = _basePrice;
         currency = _currency;
     }
@@ -158,7 +155,7 @@ contract CoinvestedPosition is TokenSwapBase {
         _settle(profit, currency);
 
         // transfer tokens from this contract to the buyer's receiver
-        token.transfer(_tokenReceiver, _tokenAmount);
+        IERC20(address(token)).safeTransfer(_tokenReceiver, _tokenAmount);
 
         emit TokensBought(_msgSender(), _tokenAmount, currencyAmount);
     }
@@ -192,10 +189,7 @@ contract CoinvestedPosition is TokenSwapBase {
      */
     function claimDistribution(Distribution _dist, uint256 _minPayout) external onlyOwner nonReentrant {
         IERC20 dividendCurrency = _dist.currency();
-        require(
-            token.allowList().map(address(dividendCurrency)) == TRUSTED_CURRENCY,
-            UntrustedCurrency()
-        );
+        require(token.allowList().map(address(dividendCurrency)) == TRUSTED_CURRENCY, UntrustedCurrency());
         uint256 before = dividendCurrency.balanceOf(address(this));
         _dist.claim(address(this), _minPayout);
         uint256 profit = dividendCurrency.balanceOf(address(this)) - before;

--- a/contracts/Crowdinvesting.sol
+++ b/contracts/Crowdinvesting.sol
@@ -175,10 +175,7 @@ contract Crowdinvesting is
         require(_arguments.currencyReceiver != address(0), ZeroReceiverAddress());
         require(address(_arguments.currency) != address(0), ZeroCurrencyAddress());
         require(address(_arguments.token) != address(0), ZeroTokenAddress());
-        require(
-            _arguments.minAmountPerBuyer <= _arguments.maxAmountPerBuyer,
-            MinAmountExceedsMaxAmount()
-        );
+        require(_arguments.minAmountPerBuyer <= _arguments.maxAmountPerBuyer, MinAmountExceedsMaxAmount());
         require(_arguments.minAmountPerBuyer != 0, ZeroAmount());
         require(_arguments.tokenPrice != 0, ZeroPrice());
         require(_arguments.maxAmountOfTokenToBeSold != 0, ZeroAmount());
@@ -273,10 +270,7 @@ contract Crowdinvesting is
     function _checkAndDeliver(uint256 _amount, address _tokenReceiver) internal {
         require(tokensSold + _amount <= maxAmountOfTokenToBeSold, MaxAmountOfTokenToBeSoldExceeded());
         require(tokensBought[_tokenReceiver] + _amount >= minAmountPerBuyer, MinAmountPerBuyerNotReached());
-        require(
-            tokensBought[_tokenReceiver] + _amount <= maxAmountPerBuyer,
-            MaxAmountPerBuyerExceeded()
-        );
+        require(tokensBought[_tokenReceiver] + _amount <= maxAmountPerBuyer, MaxAmountPerBuyerExceeded());
 
         if (lastBuyDate != 0 && block.timestamp > lastBuyDate) {
             revert LastBuyDatePassed();
@@ -286,7 +280,7 @@ contract Crowdinvesting is
         tokensBought[_tokenReceiver] += _amount;
 
         if (tokenHolder != address(0)) {
-            token.transferFrom(tokenHolder, _tokenReceiver, _amount);
+            IERC20(address(token)).safeTransferFrom(tokenHolder, _tokenReceiver, _amount);
         } else {
             token.mint(_tokenReceiver, _amount);
         }
@@ -429,10 +423,7 @@ contract Crowdinvesting is
     function setCurrencyAndTokenPrice(IERC20 _currency, uint256 _tokenPrice) external onlyOwner whenPaused {
         require(address(_currency) != address(0), ZeroCurrencyAddress());
         require(_tokenPrice != 0, ZeroPrice());
-        require(
-            token.allowList().map(address(_currency)) == TRUSTED_CURRENCY,
-            UntrustedCurrency()
-        );
+        require(token.allowList().map(address(_currency)) == TRUSTED_CURRENCY, UntrustedCurrency());
 
         priceOracle = IPriceDynamic(address(0)); // deactivate dynamic pricing because price changed, so min and max need to be updated
         priceBase = _tokenPrice;

--- a/contracts/Crowdinvesting.sol
+++ b/contracts/Crowdinvesting.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts/utils/math/Math.sol";
 
 import "./Token.sol";
 import "./common/IPriceDynamic.sol";
+import "./common/Errors.sol";
 
 /// this struct is used to circumvent the stack too deep error that occurs when passing too many arguments to a function
 struct CrowdinvestingInitializerArguments {
@@ -60,6 +61,20 @@ contract Crowdinvesting is
     ReentrancyGuardUpgradeable
 {
     using SafeERC20 for IERC20;
+
+    error MinAmountExceedsMaxAmount();
+    error ZeroPriceOracleAddress();
+    error PriceMinExceedsPriceBase();
+    error PriceMaxBelowPriceBase();
+    error MaxAmountOfTokenToBeSoldExceeded();
+    error MinAmountPerBuyerNotReached();
+    error MaxAmountPerBuyerExceeded();
+    error LastBuyDatePassed();
+    error PurchaseTooExpensive();
+    error OnlyCurrencyContract();
+    error PurchaseYieldsTooFewTokens();
+    error LastBuyDateNotInFuture();
+    error CoolDownNotOver();
 
     /// @notice Minimum waiting time between pause or parameter change and unpause.
     /// @dev delay is calculated from parameter change to unpause.
@@ -155,23 +170,23 @@ contract Crowdinvesting is
      * @param _arguments Struct containing all arguments for the initializer
      */
     function initialize(CrowdinvestingInitializerArguments memory _arguments) external initializer {
-        require(_arguments.owner != address(0), "owner can not be zero address");
+        require(_arguments.owner != address(0), ZeroOwnerAddress());
         __Ownable2Step_init(); // sets msgSender() as owner
         _transferOwnership(_arguments.owner); // sets owner as owner
 
-        require(_arguments.currencyReceiver != address(0), "currencyReceiver can not be zero address");
-        require(address(_arguments.currency) != address(0), "currency can not be zero address");
-        require(address(_arguments.token) != address(0), "token can not be zero address");
+        require(_arguments.currencyReceiver != address(0), ZeroReceiverAddress());
+        require(address(_arguments.currency) != address(0), ZeroCurrencyAddress());
+        require(address(_arguments.token) != address(0), ZeroTokenAddress());
         require(
             _arguments.minAmountPerBuyer <= _arguments.maxAmountPerBuyer,
-            "_minAmountPerBuyer needs to be smaller or equal to _maxAmountPerBuyer"
+            MinAmountExceedsMaxAmount()
         );
-        require(_arguments.minAmountPerBuyer != 0, "_minAmountPerBuyer needs to be larger than zero");
-        require(_arguments.tokenPrice != 0, "_tokenPrice needs to be a non-zero amount");
-        require(_arguments.maxAmountOfTokenToBeSold != 0, "_maxAmountOfTokenToBeSold needs to be larger than zero");
+        require(_arguments.minAmountPerBuyer != 0, ZeroAmount());
+        require(_arguments.tokenPrice != 0, ZeroPrice());
+        require(_arguments.maxAmountOfTokenToBeSold != 0, ZeroAmount());
         require(
             _arguments.token.allowList().map(address(_arguments.currency)) == TRUSTED_CURRENCY,
-            "currency needs to be on the allowlist with TRUSTED_CURRENCY attribute"
+            UntrustedCurrency()
         );
         currencyReceiver = _arguments.currencyReceiver;
         minAmountPerBuyer = _arguments.minAmountPerBuyer;
@@ -211,11 +226,11 @@ contract Crowdinvesting is
      * @param _priceMax price will never be more than this
      */
     function _activateDynamicPricing(IPriceDynamic _priceOracle, uint256 _priceMin, uint256 _priceMax) internal {
-        require(address(_priceOracle) != address(0), "_priceOracle can not be zero address");
+        require(address(_priceOracle) != address(0), ZeroPriceOracleAddress());
         priceOracle = _priceOracle;
-        require(_priceMin <= priceBase, "priceMin needs to be smaller or equal to priceBase");
+        require(_priceMin <= priceBase, PriceMinExceedsPriceBase());
         priceMin = _priceMin;
-        require(priceBase <= _priceMax, "priceMax needs to be larger or equal to priceBase");
+        require(priceBase <= _priceMax, PriceMaxBelowPriceBase());
         priceMax = _priceMax;
         coolDownStart = block.timestamp;
 
@@ -258,15 +273,15 @@ contract Crowdinvesting is
      * @param _tokenReceiver address that will receive the tokens
      */
     function _checkAndDeliver(uint256 _amount, address _tokenReceiver) internal {
-        require(tokensSold + _amount <= maxAmountOfTokenToBeSold, "Not enough tokens to sell left");
-        require(tokensBought[_tokenReceiver] + _amount >= minAmountPerBuyer, "Buyer needs to buy at least minAmount");
+        require(tokensSold + _amount <= maxAmountOfTokenToBeSold, MaxAmountOfTokenToBeSoldExceeded());
+        require(tokensBought[_tokenReceiver] + _amount >= minAmountPerBuyer, MinAmountPerBuyerNotReached());
         require(
             tokensBought[_tokenReceiver] + _amount <= maxAmountPerBuyer,
-            "Total amount of bought tokens needs to be lower than or equal to maxAmount"
+            MaxAmountPerBuyerExceeded()
         );
 
         if (lastBuyDate != 0 && block.timestamp > lastBuyDate) {
-            revert("Last buy date has passed: not selling tokens anymore.");
+            revert LastBuyDatePassed();
         }
 
         tokensSold += _amount;
@@ -313,7 +328,7 @@ contract Crowdinvesting is
         // rounding up to the next whole number. Investor is charged up to one currency bit more in case of a fractional currency bit.
         uint256 currencyAmount = Math.ceilDiv(_tokenAmount * getPrice(), 10 ** token.decimals());
 
-        require(currencyAmount <= _maxCurrencyAmount, "Purchase more expensive than _maxCurrencyAmount");
+        require(currencyAmount <= _maxCurrencyAmount, PurchaseTooExpensive());
 
         IERC20 _currency = currency;
 
@@ -344,7 +359,7 @@ contract Crowdinvesting is
         uint256 _currencyAmount,
         bytes calldata _data
     ) external whenNotPaused nonReentrant returns (bool) {
-        require(_msgSender() == address(currency), "Only currency contract can call onTokenTransfer");
+        require(_msgSender() == address(currency), OnlyCurrencyContract());
 
         // if a recipient address was provided in data, use it as receiver. Otherwise, use _from as receiver.
         address tokenReceiver;
@@ -357,7 +372,7 @@ contract Crowdinvesting is
 
         // if a minimum amount was provided in data, enforce it.
         if (_data.length >= 64) {
-            require(amount >= abi.decode(_data[32:64], (uint256)), "Purchase yields less tokens than demanded.");
+            require(amount >= abi.decode(_data[32:64], (uint256)), PurchaseYieldsTooFewTokens());
         }
 
         // move payment to currencyReceiver and feeCollector
@@ -378,7 +393,7 @@ contract Crowdinvesting is
      * @param _currencyReceiver new currencyReceiver
      */
     function setCurrencyReceiver(address _currencyReceiver) external onlyOwner whenPaused {
-        require(_currencyReceiver != address(0), "receiver can not be zero address");
+        require(_currencyReceiver != address(0), ZeroReceiverAddress());
         currencyReceiver = _currencyReceiver;
         emit CurrencyReceiverChanged(_currencyReceiver);
         coolDownStart = block.timestamp;
@@ -389,8 +404,8 @@ contract Crowdinvesting is
      * @param _minAmountPerBuyer new minAmountPerBuyer
      */
     function setMinAmountPerBuyer(uint256 _minAmountPerBuyer) external onlyOwner whenPaused {
-        require(_minAmountPerBuyer <= maxAmountPerBuyer, "_minAmount needs to be smaller or equal to maxAmount");
-        require(_minAmountPerBuyer != 0, "_minAmountPerBuyer needs to be larger than zero");
+        require(_minAmountPerBuyer <= maxAmountPerBuyer, MinAmountExceedsMaxAmount());
+        require(_minAmountPerBuyer != 0, ZeroAmount());
         minAmountPerBuyer = _minAmountPerBuyer;
         emit MinAmountPerBuyerChanged(_minAmountPerBuyer);
         coolDownStart = block.timestamp;
@@ -401,7 +416,7 @@ contract Crowdinvesting is
      * @param _maxAmountPerBuyer new maxAmountPerBuyer
      */
     function setMaxAmountPerBuyer(uint256 _maxAmountPerBuyer) external onlyOwner whenPaused {
-        require(minAmountPerBuyer <= _maxAmountPerBuyer, "_maxAmount needs to be larger or equal to minAmount");
+        require(minAmountPerBuyer <= _maxAmountPerBuyer, MinAmountExceedsMaxAmount());
         maxAmountPerBuyer = _maxAmountPerBuyer;
         emit MaxAmountPerBuyerChanged(_maxAmountPerBuyer);
         coolDownStart = block.timestamp;
@@ -414,11 +429,11 @@ contract Crowdinvesting is
      * @param _tokenPrice new tokenPrice
      */
     function setCurrencyAndTokenPrice(IERC20 _currency, uint256 _tokenPrice) external onlyOwner whenPaused {
-        require(address(_currency) != address(0), "currency can not be zero address");
-        require(_tokenPrice != 0, "_tokenPrice needs to be a non-zero amount");
+        require(address(_currency) != address(0), ZeroCurrencyAddress());
+        require(_tokenPrice != 0, ZeroPrice());
         require(
             token.allowList().map(address(_currency)) == TRUSTED_CURRENCY,
-            "currency needs to be on the allowlist with TRUSTED_CURRENCY attribute"
+            UntrustedCurrency()
         );
 
         priceOracle = IPriceDynamic(address(0)); // deactivate dynamic pricing because price changed, so min and max need to be updated
@@ -433,7 +448,7 @@ contract Crowdinvesting is
      * @param _maxAmountOfTokenToBeSold new maxAmountOfTokenToBeSold
      */
     function setMaxAmountOfTokenToBeSold(uint256 _maxAmountOfTokenToBeSold) external onlyOwner whenPaused {
-        require(_maxAmountOfTokenToBeSold != 0, "_maxAmountOfTokenToBeSold needs to be larger than zero");
+        require(_maxAmountOfTokenToBeSold != 0, ZeroAmount());
         maxAmountOfTokenToBeSold = _maxAmountOfTokenToBeSold;
         emit MaxAmountOfTokenToBeSoldChanged(_maxAmountOfTokenToBeSold);
         coolDownStart = block.timestamp;
@@ -448,7 +463,7 @@ contract Crowdinvesting is
     /// set auto pause date
     function _setLastBuyDate(uint256 _lastBuyDate) internal {
         if (_lastBuyDate != 0) {
-            require(_lastBuyDate > block.timestamp, "lastBuyDate needs to be 0 or in the future");
+            require(_lastBuyDate > block.timestamp, LastBuyDateNotInFuture());
         }
         lastBuyDate = _lastBuyDate;
         emit SetLastBuyDate(_lastBuyDate);
@@ -471,7 +486,7 @@ contract Crowdinvesting is
      * @notice unpause the contract
      */
     function unpause() external onlyOwner {
-        require(block.timestamp > coolDownStart + delay, "There needs to be at minimum one day to change parameters");
+        require(block.timestamp > coolDownStart + delay, CoolDownNotOver());
         _unpause();
     }
 

--- a/contracts/Crowdinvesting.sol
+++ b/contracts/Crowdinvesting.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";

--- a/contracts/Crowdinvesting.sol
+++ b/contracts/Crowdinvesting.sol
@@ -70,11 +70,9 @@ contract Crowdinvesting is
     error MinAmountPerBuyerNotReached();
     error MaxAmountPerBuyerExceeded();
     error LastBuyDatePassed();
-    error PurchaseTooExpensive();
     error OnlyCurrencyContract();
     error PurchaseYieldsTooFewTokens();
     error LastBuyDateNotInFuture();
-    error CoolDownNotOver();
 
     /// @notice Minimum waiting time between pause or parameter change and unpause.
     /// @dev delay is calculated from parameter change to unpause.

--- a/contracts/Distribution.sol
+++ b/contracts/Distribution.sol
@@ -39,6 +39,14 @@ struct DistributionInitializerArguments {
  *      based on a snapshot of Token.sol
  */
 contract Distribution is PayoutBase {
+    /// @notice Reverted when the snapshot has no tokens (totalSupply == 0).
+    error EmptySnapshot();
+
+    /// @notice Reverted when the reassignment amount exceeds the sender's gross eligible amount.
+    error ReassignmentExceedsEligible();
+
+    /// @notice Reverted when reassign() is called before lockedUntil has elapsed.
+    error ReassignmentNotYetAvailable();
     using SafeERC20 for IERC20;
 
     uint256 public snapshotId;
@@ -67,11 +75,11 @@ contract Distribution is PayoutBase {
         address _currencyProvider,
         uint256 _initialFundingAmount
     ) external initializer {
-        require(_arguments.pricePerToken > 0, "price must be positive");
-        require(address(_arguments.currency) != address(_arguments.token), "currency and token must be different");
+        require(_arguments.pricePerToken > 0, ZeroPrice());
+        require(address(_arguments.currency) != address(_arguments.token), CurrencyEqualsToken());
         require(
             _arguments.token.allowList().map(address(_arguments.currency)) == TRUSTED_CURRENCY,
-            "currency needs to be on the allowlist with TRUSTED_CURRENCY attribute"
+            UntrustedCurrency()
         );
         __PayoutBase_init(
             _arguments.owner,
@@ -82,7 +90,7 @@ contract Distribution is PayoutBase {
         );
         snapshotId = _arguments.snapshotId;
         // totalSupply 0 would make every claim revert
-        require(token.totalSupplyAt(snapshotId) > 0, "snapshot has no tokens");
+        require(token.totalSupplyAt(snapshotId) > 0, EmptySnapshot());
         if (_initialFundingAmount > 0) {
             _arguments.currency.safeTransferFrom(_currencyProvider, address(this), _initialFundingAmount);
         }
@@ -130,7 +138,7 @@ contract Distribution is PayoutBase {
      * @param _amount amount of currency to reassign; must not exceed eligible(_from)
      */
     function reassign(address _from, address _to, uint256 _amount) external onlyOwner {
-        require(block.timestamp >= lockedUntil, "reassignment not yet available");
+        require(block.timestamp >= lockedUntil, ReassignmentNotYetAvailable());
         _reassign(_from, _to, _amount);
     }
 
@@ -141,9 +149,9 @@ contract Distribution is PayoutBase {
      * @param _amount Amount of currency to reassign
      */
     function _reassign(address _from, address _to, uint256 _amount) internal {
-        require(_to != address(0), "to can not be zero address");
-        require(_amount > 0, "amount must be positive");
-        require(_amount <= _grossEligible(_from), "amount exceeds eligible");
+        require(_to != address(0), ZeroReceiverAddress());
+        require(_amount > 0, ZeroAmount());
+        require(_amount <= _grossEligible(_from), ReassignmentExceedsEligible());
         paidOut[_from] += _amount;
         extraCredit[_to] += _amount;
         emit Reassigned(_from, _to, _amount);
@@ -156,11 +164,11 @@ contract Distribution is PayoutBase {
      */
     function claim(address _recipient, uint256 _minPayout) external override nonReentrant {
         uint256 gross = _grossEligible(_msgSender());
-        require(gross > 0, "nothing to claim");
+        require(gross > 0, NothingToClaim());
         paidOut[_msgSender()] += gross;
         (uint256 fee, address feeCollector) = _feeInfo(FeeTypes.DISTRIBUTION, gross);
         uint256 net = gross - fee;
-        require(net >= _minPayout, "payout below minimum");
+        require(net >= _minPayout, PayoutBelowMinimum());
         if (fee != 0) {
             currency.safeTransfer(feeCollector, fee);
         }

--- a/contracts/Distribution.sol
+++ b/contracts/Distribution.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/Exit.sol
+++ b/contracts/Exit.sol
@@ -93,7 +93,10 @@ contract Exit is PayoutBase {
         require(_arguments.referenceCurrencies.length == _arguments.referenceToExitRates.length, ArrayLengthMismatch());
         for (uint256 i = 0; i < _arguments.referenceCurrencies.length; i++) {
             require(address(_arguments.referenceCurrencies[i]) != address(0), ZeroCurrencyAddress());
-            require(_arguments.referenceCurrencies[i] != _arguments.currency, ReferenceCurrencyEqualsExitCurrency());
+            require(
+                address(_arguments.referenceCurrencies[i]) != address(_arguments.currency),
+                ReferenceCurrencyEqualsExitCurrency()
+            );
             require(_arguments.referenceToExitRates[i] > 0, ZeroPrice());
             referenceToExitRate[_arguments.referenceCurrencies[i]] = _arguments.referenceToExitRates[i];
         }

--- a/contracts/Exit.sol
+++ b/contracts/Exit.sol
@@ -44,6 +44,8 @@ struct ExitInitializerArguments {
  *  owner after lockedUntil.
  */
 contract Exit is PayoutBase {
+    /// @notice Reverted when a reference currency equals the exit currency.
+    error ReferenceCurrencyEqualsExitCurrency();
     using SafeERC20 for IERC20;
 
     /// @notice Exchange rate from a reference currency to the exit currency.
@@ -74,12 +76,12 @@ contract Exit is PayoutBase {
         address _currencyProvider,
         uint256 _initialFundingAmount
     ) external initializer {
-        require(_arguments.pricePerToken > 0, "price must be positive");
-        require(_arguments.lockedUntil > block.timestamp, "lockedUntil must be in the future");
-        require(address(_arguments.currency) != address(_arguments.token), "currency and token must be different");
+        require(_arguments.pricePerToken > 0, ZeroPrice());
+        require(_arguments.lockedUntil > block.timestamp, LockedUntilNotInFuture());
+        require(address(_arguments.currency) != address(_arguments.token), CurrencyEqualsToken());
         require(
             _arguments.token.allowList().map(address(_arguments.currency)) == TRUSTED_CURRENCY,
-            "currency needs to be on the allowlist with TRUSTED_CURRENCY attribute"
+            UntrustedCurrency()
         );
         __PayoutBase_init(
             _arguments.owner,
@@ -88,20 +90,11 @@ contract Exit is PayoutBase {
             _arguments.pricePerToken,
             _arguments.lockedUntil
         );
-        require(
-            _arguments.referenceCurrencies.length == _arguments.referenceToExitRates.length,
-            "referenceCurrencies and referenceToExitRates must have the same length"
-        );
+        require(_arguments.referenceCurrencies.length == _arguments.referenceToExitRates.length, ArrayLengthMismatch());
         for (uint256 i = 0; i < _arguments.referenceCurrencies.length; i++) {
-            require(
-                address(_arguments.referenceCurrencies[i]) != address(0),
-                "referenceCurrency can not be zero address"
-            );
-            require(
-                _arguments.referenceCurrencies[i] != _arguments.currency,
-                "referenceCurrency can not be the exit currency"
-            );
-            require(_arguments.referenceToExitRates[i] > 0, "referenceToExitRate must be positive");
+            require(address(_arguments.referenceCurrencies[i]) != address(0), ZeroCurrencyAddress());
+            require(_arguments.referenceCurrencies[i] != _arguments.currency, ReferenceCurrencyEqualsExitCurrency());
+            require(_arguments.referenceToExitRates[i] > 0, ZeroPrice());
             referenceToExitRate[_arguments.referenceCurrencies[i]] = _arguments.referenceToExitRates[i];
         }
         _arguments.currency.safeTransferFrom(_currencyProvider, address(this), _initialFundingAmount);
@@ -126,11 +119,11 @@ contract Exit is PayoutBase {
      */
     function claim(address _recipient, uint256 _minPayout) external override nonReentrant {
         uint256 tokenAmount = token.balanceOf(_msgSender());
-        require(tokenAmount > 0, "nothing to claim");
+        require(tokenAmount > 0, NothingToClaim());
         IERC20(address(token)).safeTransferFrom(_msgSender(), address(this), tokenAmount);
         uint256 currencyAmount = (tokenAmount * pricePerToken) / 10 ** token.decimals();
         (uint256 fee, address feeCollector) = _feeInfo(FeeTypes.EXIT, currencyAmount);
-        require(currencyAmount - fee >= _minPayout, "payout below minimum");
+        require(currencyAmount - fee >= _minPayout, PayoutBelowMinimum());
         if (fee != 0) {
             currency.safeTransfer(feeCollector, fee);
         }

--- a/contracts/Exit.sol
+++ b/contracts/Exit.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/FeeDistributor.sol
+++ b/contracts/FeeDistributor.sol
@@ -8,7 +8,7 @@ import "./CoinvestedPosition.sol";
 import "./common/Errors.sol";
 
 /**
- * @title FeeSplitter
+ * @title FeeDistributor
  * @author malteish
  * @notice Pulls a one-time syndicate fee from a payer and distributes it proportionally among the
  *      lead investors of a CoinvestedPosition according to their carry fractions.
@@ -17,7 +17,7 @@ import "./common/Errors.sol";
  *      payFee() call. Approve for exactly feeAmount — any excess remains as a live allowance on
  *      the deployed contract and can be drained by anyone.
  */
-contract FeeSplitter {
+contract FeeDistributor {
     using SafeERC20 for IERC20;
 
     /// @notice Reverted when the feePayer address argument is zero.

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeabl
 import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";
 
 import "./common/IFeeSettings.sol";
+import "./common/Errors.sol";
 
 /**
  * @title FeeSettings
@@ -25,21 +26,18 @@ contract FeeSettings is
     // Errors
     // -------------------------------------------------------------------------
 
-    error ZeroOwnerAddress();
     error ZeroFeeType();
     error ZeroMaxNumerator();
     error MaxNumeratorTooLarge();
-    error FeeTypeAlreadyRegistered(bytes32 feeType);
+    error FeeTypeAlreadyRegistered();
     error DefaultNumeratorExceedsMax();
     error ZeroCollectorAddress();
-    error UnknownFeeType(bytes32 feeType);
+    error UnknownFeeType();
     error NumeratorExceedsMax();
     error FeeIncreaseNeedsDelay();
-    error NoProposedFeeChange(bytes32 feeType);
+    error NoProposedFeeChange();
     error ActivationDateNotReached();
-    error ZeroTokenAddress();
     error ValidityDateNotInFuture();
-    error OnlyManagers();
 
     // -------------------------------------------------------------------------
     // Constants
@@ -225,7 +223,7 @@ contract FeeSettings is
         require(_feeType != bytes32(0), ZeroFeeType());
         require(_maxNumerator > 0, ZeroMaxNumerator());
         require(_maxNumerator < FEE_DENOMINATOR, MaxNumeratorTooLarge());
-        require(feeTypeConfigs[_feeType].maxNumerator == 0, FeeTypeAlreadyRegistered(_feeType));
+        require(feeTypeConfigs[_feeType].maxNumerator == 0, FeeTypeAlreadyRegistered());
         require(_defaultNumerator <= _maxNumerator, DefaultNumeratorExceedsMax());
         require(_collector != address(0), ZeroCollectorAddress());
         feeTypeConfigs[_feeType] = FeeTypeConfig({maxNumerator: _maxNumerator, defaultNumerator: _defaultNumerator});
@@ -246,7 +244,7 @@ contract FeeSettings is
      */
     function planFeeChange(bytes32 _feeType, uint32 _numerator, uint64 _activationDate) external onlyOwner {
         FeeTypeConfig storage config = feeTypeConfigs[_feeType];
-        require(config.maxNumerator > 0, UnknownFeeType(_feeType));
+        require(config.maxNumerator > 0, UnknownFeeType());
         require(_numerator <= config.maxNumerator, NumeratorExceedsMax());
         if (_numerator > config.defaultNumerator) {
             require(_activationDate > block.timestamp + 12 weeks, FeeIncreaseNeedsDelay());
@@ -265,7 +263,7 @@ contract FeeSettings is
      */
     function executeFeeChange(bytes32 _feeType) external onlyOwner {
         ProposedFeeChange memory proposal = proposedFeeChanges[_feeType];
-        require(proposal.activationDate != 0, NoProposedFeeChange(_feeType));
+        require(proposal.activationDate != 0, NoProposedFeeChange());
         require(block.timestamp >= proposal.activationDate, ActivationDateNotReached());
         feeTypeConfigs[_feeType].defaultNumerator = proposal.numerator;
         delete proposedFeeChanges[_feeType];
@@ -290,7 +288,7 @@ contract FeeSettings is
         uint32 _numerator,
         uint64 _validityDate
     ) external onlyManager {
-        require(feeTypeConfigs[_feeType].maxNumerator > 0, UnknownFeeType(_feeType));
+        require(feeTypeConfigs[_feeType].maxNumerator > 0, UnknownFeeType());
         require(_token != address(0), ZeroTokenAddress());
         require(_numerator <= feeTypeConfigs[_feeType].maxNumerator, NumeratorExceedsMax());
         require(_validityDate > block.timestamp, ValidityDateNotInFuture());
@@ -319,7 +317,7 @@ contract FeeSettings is
      * @param _collector The collector address (must not be address(0))
      */
     function setDefaultFeeCollector(bytes32 _feeType, address _collector) external onlyOwner {
-        require(feeTypeConfigs[_feeType].maxNumerator > 0, UnknownFeeType(_feeType));
+        require(feeTypeConfigs[_feeType].maxNumerator > 0, UnknownFeeType());
         require(_collector != address(0), ZeroCollectorAddress());
         collectors[_feeType][address(0)] = _collector;
         emit FeeCollectorSet(_feeType, address(0), _collector);
@@ -332,7 +330,7 @@ contract FeeSettings is
      * @param _collector The collector address (must not be address(0))
      */
     function setCustomFeeCollector(bytes32 _feeType, address _token, address _collector) external onlyManager {
-        require(feeTypeConfigs[_feeType].maxNumerator > 0, UnknownFeeType(_feeType));
+        require(feeTypeConfigs[_feeType].maxNumerator > 0, UnknownFeeType());
         require(_token != address(0), ZeroTokenAddress());
         require(_collector != address(0), ZeroCollectorAddress());
         collectors[_feeType][_token] = _collector;
@@ -477,7 +475,7 @@ contract FeeSettings is
     }
 
     modifier onlyManager() {
-        require(managers[_msgSender()], OnlyManagers());
+        require(managers[_msgSender()], CallerNotManager());
         _;
     }
 

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";

--- a/contracts/FeeSettings.sol
+++ b/contracts/FeeSettings.sol
@@ -22,6 +22,26 @@ contract FeeSettings is
     IFeeSettingsV3
 {
     // -------------------------------------------------------------------------
+    // Errors
+    // -------------------------------------------------------------------------
+
+    error ZeroOwnerAddress();
+    error ZeroFeeType();
+    error ZeroMaxNumerator();
+    error MaxNumeratorTooLarge();
+    error FeeTypeAlreadyRegistered(bytes32 feeType);
+    error DefaultNumeratorExceedsMax();
+    error ZeroCollectorAddress();
+    error UnknownFeeType(bytes32 feeType);
+    error NumeratorExceedsMax();
+    error FeeIncreaseNeedsDelay();
+    error NoProposedFeeChange(bytes32 feeType);
+    error ActivationDateNotReached();
+    error ZeroTokenAddress();
+    error ValidityDateNotInFuture();
+    error OnlyManagers();
+
+    // -------------------------------------------------------------------------
     // Constants
     // -------------------------------------------------------------------------
 
@@ -144,7 +164,7 @@ contract FeeSettings is
      * @param _feeTypes  Array of fee type configurations to register on deployment
      */
     function initialize(address _owner, FeeTypeInit[] memory _feeTypes) external initializer {
-        require(_owner != address(0), "owner can not be zero address");
+        require(_owner != address(0), ZeroOwnerAddress());
         managers[_owner] = true;
         _transferOwnership(_owner);
 
@@ -202,12 +222,12 @@ contract FeeSettings is
         uint32 _defaultNumerator,
         address _collector
     ) internal {
-        require(_feeType != bytes32(0), "feeType cannot be 0");
-        require(_maxNumerator > 0, "maxNumerator cannot be 0");
-        require(_maxNumerator < FEE_DENOMINATOR, "maxNumerator too large");
-        require(feeTypeConfigs[_feeType].maxNumerator == 0, "fee type already registered");
-        require(_defaultNumerator <= _maxNumerator, "default exceeds max");
-        require(_collector != address(0), "Fee collector cannot be 0x0");
+        require(_feeType != bytes32(0), ZeroFeeType());
+        require(_maxNumerator > 0, ZeroMaxNumerator());
+        require(_maxNumerator < FEE_DENOMINATOR, MaxNumeratorTooLarge());
+        require(feeTypeConfigs[_feeType].maxNumerator == 0, FeeTypeAlreadyRegistered(_feeType));
+        require(_defaultNumerator <= _maxNumerator, DefaultNumeratorExceedsMax());
+        require(_collector != address(0), ZeroCollectorAddress());
         feeTypeConfigs[_feeType] = FeeTypeConfig({maxNumerator: _maxNumerator, defaultNumerator: _defaultNumerator});
         collectors[_feeType][address(0)] = _collector;
         emit FeeTypeRegistered(_feeType, _maxNumerator, _defaultNumerator);
@@ -226,10 +246,10 @@ contract FeeSettings is
      */
     function planFeeChange(bytes32 _feeType, uint32 _numerator, uint64 _activationDate) external onlyOwner {
         FeeTypeConfig storage config = feeTypeConfigs[_feeType];
-        require(config.maxNumerator > 0, "unknown fee type");
-        require(_numerator <= config.maxNumerator, "exceeds max numerator");
+        require(config.maxNumerator > 0, UnknownFeeType(_feeType));
+        require(_numerator <= config.maxNumerator, NumeratorExceedsMax());
         if (_numerator > config.defaultNumerator) {
-            require(_activationDate > block.timestamp + 12 weeks, "fee increase needs 12 week delay");
+            require(_activationDate > block.timestamp + 12 weeks, FeeIncreaseNeedsDelay());
         }
         // activationDate=0 means "immediately" — store block.timestamp so executeFeeChange sentinel works
         if (_activationDate == 0) {
@@ -245,8 +265,8 @@ contract FeeSettings is
      */
     function executeFeeChange(bytes32 _feeType) external onlyOwner {
         ProposedFeeChange memory proposal = proposedFeeChanges[_feeType];
-        require(proposal.activationDate != 0, "no proposed fee change");
-        require(block.timestamp >= proposal.activationDate, "activation date not reached");
+        require(proposal.activationDate != 0, NoProposedFeeChange(_feeType));
+        require(block.timestamp >= proposal.activationDate, ActivationDateNotReached());
         feeTypeConfigs[_feeType].defaultNumerator = proposal.numerator;
         delete proposedFeeChanges[_feeType];
         emit FeeChanged(_feeType, proposal.numerator);
@@ -270,10 +290,10 @@ contract FeeSettings is
         uint32 _numerator,
         uint64 _validityDate
     ) external onlyManager {
-        require(feeTypeConfigs[_feeType].maxNumerator > 0, "unknown fee type");
-        require(_token != address(0), "token cannot be 0x0");
-        require(_numerator <= feeTypeConfigs[_feeType].maxNumerator, "numerator exceeds max");
-        require(_validityDate > block.timestamp, "validity date must be in the future");
+        require(feeTypeConfigs[_feeType].maxNumerator > 0, UnknownFeeType(_feeType));
+        require(_token != address(0), ZeroTokenAddress());
+        require(_numerator <= feeTypeConfigs[_feeType].maxNumerator, NumeratorExceedsMax());
+        require(_validityDate > block.timestamp, ValidityDateNotInFuture());
         customFees[_feeType][_token] = CustomFee({numerator: _numerator, validityDate: _validityDate});
         emit CustomFeeSet(_feeType, _token, _numerator, _validityDate);
     }
@@ -284,7 +304,7 @@ contract FeeSettings is
      * @param _token   The token address
      */
     function removeCustomFee(bytes32 _feeType, address _token) external onlyManager {
-        require(_token != address(0), "token cannot be 0x0");
+        require(_token != address(0), ZeroTokenAddress());
         delete customFees[_feeType][_token];
         emit CustomFeeRemoved(_feeType, _token);
     }
@@ -299,8 +319,8 @@ contract FeeSettings is
      * @param _collector The collector address (must not be address(0))
      */
     function setDefaultFeeCollector(bytes32 _feeType, address _collector) external onlyOwner {
-        require(feeTypeConfigs[_feeType].maxNumerator > 0, "unknown fee type");
-        require(_collector != address(0), "collector cannot be 0x0");
+        require(feeTypeConfigs[_feeType].maxNumerator > 0, UnknownFeeType(_feeType));
+        require(_collector != address(0), ZeroCollectorAddress());
         collectors[_feeType][address(0)] = _collector;
         emit FeeCollectorSet(_feeType, address(0), _collector);
     }
@@ -312,9 +332,9 @@ contract FeeSettings is
      * @param _collector The collector address (must not be address(0))
      */
     function setCustomFeeCollector(bytes32 _feeType, address _token, address _collector) external onlyManager {
-        require(feeTypeConfigs[_feeType].maxNumerator > 0, "unknown fee type");
-        require(_token != address(0), "token cannot be 0x0");
-        require(_collector != address(0), "collector cannot be 0x0");
+        require(feeTypeConfigs[_feeType].maxNumerator > 0, UnknownFeeType(_feeType));
+        require(_token != address(0), ZeroTokenAddress());
+        require(_collector != address(0), ZeroCollectorAddress());
         collectors[_feeType][_token] = _collector;
         emit FeeCollectorSet(_feeType, _token, _collector);
     }
@@ -325,7 +345,7 @@ contract FeeSettings is
      * @param _token   The token address (must not be address(0))
      */
     function removeCustomFeeCollector(bytes32 _feeType, address _token) external onlyManager {
-        require(_token != address(0), "token cannot be 0x0");
+        require(_token != address(0), ZeroTokenAddress());
         delete collectors[_feeType][_token];
         emit CustomFeeCollectorRemoved(_feeType, _token);
     }
@@ -457,7 +477,7 @@ contract FeeSettings is
     }
 
     modifier onlyManager() {
-        require(managers[_msgSender()], "Only managers can call this function");
+        require(managers[_msgSender()], OnlyManagers());
         _;
     }
 

--- a/contracts/FeeSplitter.sol
+++ b/contracts/FeeSplitter.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "./CoinvestedPosition.sol";
+import "./common/Errors.sol";
 
 /**
  * @title FeeSplitter
@@ -16,6 +17,9 @@ import "./CoinvestedPosition.sol";
  */
 contract FeeSplitter {
     using SafeERC20 for IERC20;
+
+    /// @notice Reverted when the lead investor list of the CoinvestedPosition is empty.
+    error NoLeadInvestors();
 
     /// @notice Emitted once when the fee has been pulled and distributed.
     event FeeDistributed(address indexed feePayer, address indexed currency, uint256 feeAmount);
@@ -36,13 +40,13 @@ contract FeeSplitter {
         uint256 feeAmount,
         CoinvestedPosition coinvestedPosition
     ) external {
-        require(feePayer != address(0), "feePayer can not be zero address");
-        require(address(currency) != address(0), "currency can not be zero address");
-        require(feeAmount != 0, "feeAmount can not be zero");
-        require(address(coinvestedPosition) != address(0), "coinvestedPosition can not be zero address");
+        require(feePayer != address(0), ZeroAddress());
+        require(address(currency) != address(0), ZeroAddress());
+        require(feeAmount != 0, ZeroAmount());
+        require(address(coinvestedPosition) != address(0), ZeroAddress());
 
         uint256 investorCount = coinvestedPosition.getLeadInvestorsCount();
-        require(investorCount > 0, "no lead investors");
+        require(investorCount > 0, NoLeadInvestors());
 
         currency.safeTransferFrom(feePayer, address(this), feeAmount);
 

--- a/contracts/FeeSplitter.sol
+++ b/contracts/FeeSplitter.sol
@@ -12,8 +12,10 @@ import "./common/Errors.sol";
  * @author malteish
  * @notice Pulls a one-time syndicate fee from a payer and distributes it proportionally among the
  *      lead investors of a CoinvestedPosition according to their carry fractions.
- * @dev Uses clone/proxy pattern for deterministic address derivation. payFee() can only succeed
- *      once per clone because the feePayer's allowance is consumed on the first call.
+ * @dev Uses clone/proxy pattern for deterministic address derivation. To prevent frontrunning,
+ *      either approve a counterfactual address (before deployment) or batch the approval with the
+ *      payFee() call. Approve for exactly feeAmount — any excess remains as a live allowance on
+ *      the deployed contract and can be drained by anyone.
  */
 contract FeeSplitter {
     using SafeERC20 for IERC20;
@@ -29,9 +31,10 @@ contract FeeSplitter {
 
     /**
      * @notice Pulls feeAmount of currency from feePayer and distributes it proportionally among the
-     *      lead investors of coinvestedPosition by their carry fractions. The first lead investor
+     *      lead investors of coinvestedPosition by their carry fractions. The last lead investor
      *      absorbs any rounding dust so the full feeAmount is always distributed.
-     *      feePayer must have pre-approved this contract's address for at least feeAmount of currency.
+     *      feePayer must have pre-approved this contract's address for exactly feeAmount of currency;
+     *      any excess approval remains live on this contract and can be drained by anyone.
      * @param feePayer address from which the fee is pulled; must have pre-approved this contract
      * @param currency ERC20 token in which the fee is denominated
      * @param feeAmount total fee to distribute, in currency bits

--- a/contracts/FeeSplitter.sol
+++ b/contracts/FeeSplitter.sol
@@ -18,6 +18,12 @@ import "./common/Errors.sol";
 contract FeeSplitter {
     using SafeERC20 for IERC20;
 
+    /// @notice Reverted when the feePayer address argument is zero.
+    error ZeroFeePayerAddress();
+
+    /// @notice Reverted when the coinvestedPosition address argument is zero.
+    error ZeroCoinvestedPositionAddress();
+
     /// @notice Reverted when the lead investor list of the CoinvestedPosition is empty.
     error NoLeadInvestors();
 
@@ -40,10 +46,10 @@ contract FeeSplitter {
         uint256 feeAmount,
         CoinvestedPosition coinvestedPosition
     ) external {
-        require(feePayer != address(0), ZeroAddress());
-        require(address(currency) != address(0), ZeroAddress());
+        require(feePayer != address(0), ZeroFeePayerAddress());
+        require(address(currency) != address(0), ZeroCurrencyAddress());
         require(feeAmount != 0, ZeroAmount());
-        require(address(coinvestedPosition) != address(0), ZeroAddress());
+        require(address(coinvestedPosition) != address(0), ZeroCoinvestedPositionAddress());
 
         uint256 investorCount = coinvestedPosition.getLeadInvestorsCount();
         require(investorCount > 0, NoLeadInvestors());

--- a/contracts/FeeSplitter.sol
+++ b/contracts/FeeSplitter.sol
@@ -24,9 +24,6 @@ contract FeeSplitter {
     /// @notice Reverted when the coinvestedPosition address argument is zero.
     error ZeroCoinvestedPositionAddress();
 
-    /// @notice Reverted when the lead investor list of the CoinvestedPosition is empty.
-    error NoLeadInvestors();
-
     /// @notice Emitted once when the fee has been pulled and distributed.
     event FeeDistributed(address indexed feePayer, address indexed currency, uint256 feeAmount);
 

--- a/contracts/FeeSplitter.sol
+++ b/contracts/FeeSplitter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/GlobalTokenExitRegistry.sol
+++ b/contracts/GlobalTokenExitRegistry.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";
 

--- a/contracts/GlobalTokenExitRegistry.sol
+++ b/contracts/GlobalTokenExitRegistry.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol
 
 import "./Exit.sol";
 import "./Token.sol";
+import "./common/Errors.sol";
 
 interface IOwnable {
     function owner() external view returns (address);
@@ -18,6 +19,15 @@ interface IOwnable {
  *         Once set, an exit cannot be changed.
  */
 contract GlobalTokenExitRegistry is ERC2771ContextUpgradeable {
+    /// @notice Reverted when the exit address argument is zero.
+    error ZeroExitAddress();
+
+    /// @notice Reverted when the caller holds neither DEFAULT_ADMIN_ROLE nor owner() on the token.
+    error NotTokenAdminOrOwner();
+
+    /// @notice Reverted when an exit has already been set for the token and a second set is attempted.
+    error ExitAlreadySet();
+
     /// @notice The authorized exit contract per token.
     mapping(Token => Exit) public exits;
 
@@ -37,10 +47,10 @@ contract GlobalTokenExitRegistry is ERC2771ContextUpgradeable {
      * @param _exit the exit contract to authorize; must not be zero address
      */
     function setExit(Token _token, Exit _exit) external {
-        require(address(_token) != address(0), "token can not be zero address");
-        require(address(_exit) != address(0), "exit can not be zero address");
-        require(address(exits[_token]) == address(0), "exit has already been set");
-        require(_isTokenAdminOrOwner(_token, _msgSender()), "caller is not token admin or owner");
+        require(address(_token) != address(0), ZeroTokenAddress());
+        require(address(_exit) != address(0), ZeroExitAddress());
+        require(address(exits[_token]) == address(0), ExitAlreadySet());
+        require(_isTokenAdminOrOwner(_token, _msgSender()), NotTokenAdminOrOwner());
         exits[_token] = _exit;
         emit ExitSet(_token, _exit);
     }

--- a/contracts/PriceLinear.sol
+++ b/contracts/PriceLinear.sol
@@ -5,6 +5,7 @@ import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./common/IPriceDynamic.sol";
+import "./common/Errors.sol";
 
 struct Linear {
     /// numerator of slope of linear function, e.g. a where slope == a/b
@@ -29,6 +30,20 @@ struct Linear {
  * @dev The contract inherits from ERC2771Context in order to be usable with Gas Station Network (GSN) https://docs.opengsn.org/faq/troubleshooting.html#my-contract-is-using-openzeppelin-how-do-i-add-gsn-support
  */
 contract PriceLinear is ERC2771ContextUpgradeable, Ownable2StepUpgradeable, IPriceDynamic {
+    /// @notice Reverted when the slopeEnumerator argument is zero.
+    error ZeroSlopeEnumerator();
+
+    /// @notice Reverted when the slopeDenominator argument is zero.
+    error ZeroSlopeDenominator();
+
+    /// @notice Reverted when the start time or block number is not strictly in the future.
+    error StartNotInFuture();
+
+    /// @notice Reverted when the stepDuration argument is zero.
+    error ZeroStepDuration();
+
+    /// @notice Reverted when getPrice() is called during the cool-down period after a parameter update.
+    error CoolDownNotOver();
     uint32 public constant COOL_DOWN_DURATION = 1 hours;
 
     Linear public parameters;
@@ -62,7 +77,7 @@ contract PriceLinear is ERC2771ContextUpgradeable, Ownable2StepUpgradeable, IPri
         bool _isBlockBased,
         bool _isRising
     ) external initializer {
-        require(_owner != address(0), "owner can not be zero address");
+        require(_owner != address(0), ZeroOwnerAddress());
         __Ownable2Step_init(); // sets msgSender() as owner
         _transferOwnership(_owner); // sets owner as owner
         _updateParameters(
@@ -121,14 +136,14 @@ contract PriceLinear is ERC2771ContextUpgradeable, Ownable2StepUpgradeable, IPri
         bool _isBlockBased,
         bool _isRising
     ) internal {
-        require(_slopeEnumerator != 0, "slopeEnumerator can not be zero");
-        require(_slopeDenominator != 0, "slopeDenominator can not be zero");
+        require(_slopeEnumerator != 0, ZeroSlopeEnumerator());
+        require(_slopeDenominator != 0, ZeroSlopeDenominator());
         if (_isBlockBased) {
-            require(_startTimeOrBlockNumber > block.number, "start must be in the future");
+            require(_startTimeOrBlockNumber > block.number, StartNotInFuture());
         } else {
-            require(_startTimeOrBlockNumber > block.timestamp, "start must be in the future");
+            require(_startTimeOrBlockNumber > block.timestamp, StartNotInFuture());
         }
-        require(_stepDuration != 0, "stepDuration can not be zero");
+        require(_stepDuration != 0, ZeroStepDuration());
         parameters = Linear({
             slopeEnumerator: _slopeEnumerator,
             slopeDenominator: _slopeDenominator,
@@ -146,7 +161,7 @@ contract PriceLinear is ERC2771ContextUpgradeable, Ownable2StepUpgradeable, IPri
      * @return The price of the token at the current time or block height
      */
     function getPrice(uint256 basePrice) public view returns (uint256) {
-        require(coolDownStart + COOL_DOWN_DURATION < block.timestamp, "PriceLinear: cool down period not over yet");
+        require(coolDownStart + COOL_DOWN_DURATION < block.timestamp, CoolDownNotOver());
         Linear memory _parameters = parameters;
         uint256 current = _parameters.isBlockBased ? block.number : block.timestamp;
 

--- a/contracts/PriceLinear.sol
+++ b/contracts/PriceLinear.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";

--- a/contracts/PriceLinear.sol
+++ b/contracts/PriceLinear.sol
@@ -42,8 +42,6 @@ contract PriceLinear is ERC2771ContextUpgradeable, Ownable2StepUpgradeable, IPri
     /// @notice Reverted when the stepDuration argument is zero.
     error ZeroStepDuration();
 
-    /// @notice Reverted when getPrice() is called during the cool-down period after a parameter update.
-    error CoolDownNotOver();
     uint32 public constant COOL_DOWN_DURATION = 1 hours;
 
     Linear public parameters;

--- a/contracts/PrivateOffer.sol
+++ b/contracts/PrivateOffer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";

--- a/contracts/PrivateOffer.sol
+++ b/contracts/PrivateOffer.sol
@@ -119,7 +119,11 @@ contract PrivateOffer {
         );
 
         if (_arguments.tokenHolder != address(0)) {
-            _arguments.token.transferFrom(_arguments.tokenHolder, _arguments.tokenReceiver, _arguments.tokenAmount);
+            IERC20(address(_arguments.token)).safeTransferFrom(
+                _arguments.tokenHolder,
+                _arguments.tokenReceiver,
+                _arguments.tokenAmount
+            );
         } else {
             _arguments.token.mint(_arguments.tokenReceiver, _arguments.tokenAmount);
         }

--- a/contracts/PrivateOffer.sol
+++ b/contracts/PrivateOffer.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.34;
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "./Token.sol";
+import "./common/Errors.sol";
 /**
  * @notice Contains all information necessary to execute a PrivateOffer.
  */
@@ -50,6 +51,17 @@ struct PrivateOfferArguments {
  *     minted tokens will be transferred to the buyer and the currency will be transferred to the company's receiver address.
  */
 contract PrivateOffer {
+    /// @notice Reverted when the currencyPayer address argument is zero.
+    error ZeroCurrencyPayerAddress();
+
+    /// @notice Reverted when the tokenReceiver address argument is zero.
+    error ZeroTokenReceiverAddress();
+
+    /// @notice Reverted when the currencyReceiver address argument is zero.
+    error ZeroCurrencyReceiverAddress();
+
+    /// @notice Reverted when the offer has expired (block.timestamp > expiration).
+    error DealExpired();
     using SafeERC20 for IERC20;
 
     /**
@@ -72,17 +84,17 @@ contract PrivateOffer {
     );
 
     constructor(PrivateOfferArguments memory _arguments) {
-        require(_arguments.currencyPayer != address(0), "_arguments.currencyPayer can not be zero address");
-        require(_arguments.tokenReceiver != address(0), "_arguments.tokenReceiver can not be zero address");
-        require(_arguments.currencyReceiver != address(0), "_arguments.currencyReceiver can not be zero address");
-        require(_arguments.tokenPrice != 0, "_arguments.tokenPrice can not be zero"); // a simple mint from the token contract will do in that case
-        require(block.timestamp <= _arguments.expiration, "Deal expired");
-        require(_arguments.token != Token(address(0)), "_arguments.token can not be zero address");
-        require(_arguments.currency != IERC20(address(0)), "_arguments.currency can not be zero address");
-        require(_arguments.tokenAmount != 0, "_arguments.tokenAmount can not be zero");
+        require(_arguments.currencyPayer != address(0), ZeroCurrencyPayerAddress());
+        require(_arguments.tokenReceiver != address(0), ZeroTokenReceiverAddress());
+        require(_arguments.currencyReceiver != address(0), ZeroCurrencyReceiverAddress());
+        require(_arguments.tokenPrice != 0, ZeroPrice()); // a simple mint from the token contract will do in that case
+        require(block.timestamp <= _arguments.expiration, DealExpired());
+        require(_arguments.token != Token(address(0)), ZeroTokenAddress());
+        require(_arguments.currency != IERC20(address(0)), ZeroCurrencyAddress());
+        require(_arguments.tokenAmount != 0, ZeroAmount());
         require(
             _arguments.token.allowList().map(address(_arguments.currency)) == TRUSTED_CURRENCY,
-            "currency needs to be on the allowlist with TRUSTED_CURRENCY attribute"
+            UntrustedCurrency()
         );
 
         // rounding up to the next whole number. Investor is charged up to one currency bit more in case of a fractional currency bit.

--- a/contracts/PrivateOffer.sol
+++ b/contracts/PrivateOffer.sol
@@ -89,8 +89,8 @@ contract PrivateOffer {
         require(_arguments.currencyReceiver != address(0), ZeroCurrencyReceiverAddress());
         require(_arguments.tokenPrice != 0, ZeroPrice()); // a simple mint from the token contract will do in that case
         require(block.timestamp <= _arguments.expiration, DealExpired());
-        require(_arguments.token != Token(address(0)), ZeroTokenAddress());
-        require(_arguments.currency != IERC20(address(0)), ZeroCurrencyAddress());
+        require(address(_arguments.token) != address(0), ZeroTokenAddress());
+        require(address(_arguments.currency) != address(0), ZeroCurrencyAddress());
         require(_arguments.tokenAmount != 0, ZeroAmount());
         require(
             _arguments.token.allowList().map(address(_arguments.currency)) == TRUSTED_CURRENCY,

--- a/contracts/TimeLock.sol
+++ b/contracts/TimeLock.sol
@@ -20,6 +20,20 @@ import "./GlobalTokenExitRegistry.sol";
  * @dev Uses clone/proxy pattern. Constructor disables initializers, separate initialize().
  */
 contract TimeLock is Initializable, OwnableUpgradeable, ERC2771ContextUpgradeable, ReentrancyGuardUpgradeable {
+    /// @notice Reverted when the tokenExitRegistry address argument is zero.
+    error ZeroTokenExitRegistryAddress();
+
+    /// @notice Reverted when claimExit() is called but no exit is set in tokenExitRegistry for the token.
+    error NoExitSet();
+
+    /// @notice Reverted when claimExit() is called but this contract holds no tokens.
+    error NoTokensToExit();
+
+    /// @notice Reverted when drain() is called before lockedUntil has elapsed.
+    error TimeLockNotExpired();
+
+    /// @notice Reverted when drain() is called but this contract holds no tokens.
+    error NoTokensToDrain();
     using SafeERC20 for IERC20;
 
     /// unix timestamp before which drain() is blocked
@@ -51,9 +65,9 @@ contract TimeLock is Initializable, OwnableUpgradeable, ERC2771ContextUpgradeabl
         uint64 _lockedUntil,
         GlobalTokenExitRegistry _tokenExitRegistry
     ) public initializer {
-        require(_owner != address(0), "owner can not be zero address");
-        require(_lockedUntil > block.timestamp, "lockedUntil must be in the future");
-        require(address(_tokenExitRegistry) != address(0), "tokenExitRegistry can not be zero address");
+        require(_owner != address(0), ZeroOwnerAddress());
+        require(_lockedUntil > block.timestamp, LockedUntilNotInFuture());
+        require(address(_tokenExitRegistry) != address(0), ZeroTokenExitRegistryAddress());
         __Ownable_init();
         __ReentrancyGuard_init();
         _transferOwnership(_owner);
@@ -71,7 +85,7 @@ contract TimeLock is Initializable, OwnableUpgradeable, ERC2771ContextUpgradeabl
         address _recipient,
         uint256 _minPayout
     ) external onlyOwner nonReentrant {
-        require(_recipient != address(0), "recipient can not be zero address");
+        require(_recipient != address(0), ZeroReceiverAddress());
         _dist.claim(_recipient, _minPayout);
         emit DividendsDistributed(_dist, _recipient);
     }
@@ -85,10 +99,10 @@ contract TimeLock is Initializable, OwnableUpgradeable, ERC2771ContextUpgradeabl
      */
     function claimExit(Token _token, address _recipient, uint256 _minPayout) external onlyOwner nonReentrant {
         Exit exit = tokenExitRegistry.exits(_token);
-        require(address(exit) != address(0), "no exit set in tokenExitRegistry");
-        require(_recipient != address(0), "recipient can not be zero address");
+        require(address(exit) != address(0), NoExitSet());
+        require(_recipient != address(0), ZeroReceiverAddress());
         uint256 tokenBalance = _token.balanceOf(address(this));
-        require(tokenBalance > 0, "no tokens to exit");
+        require(tokenBalance > 0, NoTokensToExit());
         IERC20(address(_token)).approve(address(exit), tokenBalance);
         exit.claim(_recipient, _minPayout);
         emit ExitDistributed(exit, _recipient, tokenBalance);
@@ -100,10 +114,10 @@ contract TimeLock is Initializable, OwnableUpgradeable, ERC2771ContextUpgradeabl
      * @param _recipient address to send the tokens to
      */
     function drain(IERC20 _token, address _recipient) external onlyOwner {
-        require(block.timestamp >= lockedUntil, "timelock has not expired");
-        require(_recipient != address(0), "recipient can not be zero address");
+        require(block.timestamp >= lockedUntil, TimeLockNotExpired());
+        require(_recipient != address(0), ZeroReceiverAddress());
         uint256 balance = _token.balanceOf(address(this));
-        require(balance > 0, "no tokens to drain");
+        require(balance > 0, NoTokensToDrain());
         _token.safeTransfer(_recipient, balance);
         emit Drained(_token, _recipient, balance);
     }

--- a/contracts/TimeLock.sol
+++ b/contracts/TimeLock.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "./Distribution.sol";
 import "./Exit.sol";
 import "./GlobalTokenExitRegistry.sol";
+import "./common/Errors.sol";
 
 /**
  * @title TimeLock
@@ -20,17 +21,8 @@ import "./GlobalTokenExitRegistry.sol";
  * @dev Uses clone/proxy pattern. Constructor disables initializers, separate initialize().
  */
 contract TimeLock is Initializable, OwnableUpgradeable, ERC2771ContextUpgradeable, ReentrancyGuardUpgradeable {
-    /// @notice Reverted when the tokenExitRegistry address argument is zero.
-    error ZeroTokenExitRegistryAddress();
-
-    /// @notice Reverted when claimExit() is called but no exit is set in tokenExitRegistry for the token.
-    error NoExitSet();
-
     /// @notice Reverted when claimExit() is called but this contract holds no tokens.
     error NoTokensToExit();
-
-    /// @notice Reverted when drain() is called before lockedUntil has elapsed.
-    error TimeLockNotExpired();
 
     /// @notice Reverted when drain() is called but this contract holds no tokens.
     error NoTokensToDrain();

--- a/contracts/TimeLock.sol
+++ b/contracts/TimeLock.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PermitUpgradeable.sol";

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -253,7 +253,7 @@ contract Token is
         // Checking that the suggestedFeeSettings is not 0x0 would work, too, but this check is used in other places, too.
         _checkIfFeeSettingsImplementsInterface(_feeSettings);
 
-        require(_feeSettings == suggestedFeeSettings, OnlySuggestedFeeSettings());
+        require(address(_feeSettings) == address(suggestedFeeSettings), OnlySuggestedFeeSettings());
         feeSettings = suggestedFeeSettings;
         emit FeeSettingsChanged(_feeSettings);
     }

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -47,6 +47,24 @@ contract Token is
     /// @notice The role that can create snapshots of the token balances
     bytes32 public constant SNAPSHOTCREATOR_ROLE = keccak256("SNAPSHOTCREATOR_ROLE");
 
+    /// @notice Reverted when the AllowList address argument is zero.
+    error ZeroAllowListAddress();
+
+    /// @notice Reverted when someone other than the feeSettings owner tries to suggest a fee settings update.
+    error OnlyFeeSettingsOwner();
+
+    /// @notice Reverted when acceptNewFeeSettings is called with a contract other than the current suggestion.
+    error OnlySuggestedFeeSettings();
+
+    /// @notice Reverted when mint() is called with an amount exceeding the caller's mintingAllowance.
+    error MintingAllowanceTooLow();
+
+    /// @notice Reverted when a transfer involves an address that does not meet the token's requirements.
+    error NotAllowedToTransact();
+
+    /// @notice Reverted when a feeSettings contract does not implement the required interface.
+    error FeeSettingsInterfaceNotSupported();
+
     /**
      * @dev This empty reserved space is put in place to allow future versions to inherit
      * from contracts that need storage. This mimics openzeppelin's approach.
@@ -165,7 +183,7 @@ contract Token is
         feeSettings = _feeSettings;
 
         // set up allowList
-        require(address(_allowList) != address(0), "AllowList must not be zero address");
+        require(address(_allowList) != address(0), ZeroAllowListAddress());
         allowList = _allowList;
 
         // set requirements (can be 0 to allow everyone to send and receive tokens)
@@ -195,7 +213,7 @@ contract Token is
      * @param _allowList new AllowList contract
      */
     function setAllowList(AllowList _allowList) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        require(address(_allowList) != address(0), "AllowList must not be zero address");
+        require(address(_allowList) != address(0), ZeroAllowListAddress());
         allowList = _allowList;
         emit AllowListChanged(_allowList);
     }
@@ -217,7 +235,7 @@ contract Token is
      * @param _feeSettings the new feeSettings contract
      */
     function suggestNewFeeSettings(IFeeSettingsV2 _feeSettings) external {
-        require(_msgSender() == feeSettings.owner(), "Only fee settings owner can suggest fee settings update");
+        require(_msgSender() == feeSettings.owner(), OnlyFeeSettingsOwner());
         _checkIfFeeSettingsImplementsInterface(_feeSettings);
         suggestedFeeSettings = _feeSettings;
         emit NewFeeSettingsSuggested(_feeSettings);
@@ -235,7 +253,7 @@ contract Token is
         // Checking that the suggestedFeeSettings is not 0x0 would work, too, but this check is used in other places, too.
         _checkIfFeeSettingsImplementsInterface(_feeSettings);
 
-        require(_feeSettings == suggestedFeeSettings, "Only suggested fee settings can be accepted");
+        require(_feeSettings == suggestedFeeSettings, OnlySuggestedFeeSettings());
         feeSettings = suggestedFeeSettings;
         emit FeeSettingsChanged(_feeSettings);
     }
@@ -274,7 +292,7 @@ contract Token is
      */
     function mint(address _to, uint256 _amount) external {
         if (!hasRole(MINTALLOWER_ROLE, _msgSender())) {
-            require(mintingAllowance[_msgSender()] >= _amount, "MintingAllowance too low");
+            require(mintingAllowance[_msgSender()] >= _amount, MintingAllowanceTooLow());
             mintingAllowance[_msgSender()] -= _amount;
         }
         // this check is executed here, because later minting of the buy amount can not be differentiated from minting of the fee amount
@@ -344,7 +362,7 @@ contract Token is
             requirements == 0 ||
                 hasRole(TRANSFERER_ROLE, _address) ||
                 allowList.map(_address) & requirements == requirements,
-            "Sender or Receiver is not allowed to transact. Either locally issue the role as a TRANSFERER or they must meet requirements as defined in the allowList"
+            NotAllowedToTransact()
         );
     }
 
@@ -356,15 +374,12 @@ contract Token is
      */
     function _checkIfFeeSettingsImplementsInterface(IFeeSettingsV2 _feeSettings) internal view {
         // step 1: needs to return true if EIP165 is supported
-        require(_feeSettings.supportsInterface(0x01ffc9a7) == true, "FeeSettings must implement IFeeSettingsV2");
+        require(_feeSettings.supportsInterface(0x01ffc9a7) == true, FeeSettingsInterfaceNotSupported());
         // step 2: needs to return false if EIP165 is supported
-        require(_feeSettings.supportsInterface(0xffffffff) == false, "FeeSettings must implement IFeeSettingsV2");
+        require(_feeSettings.supportsInterface(0xffffffff) == false, FeeSettingsInterfaceNotSupported());
         // now we know EIP165 is supported
         // step 3: needs to return true if IFeeSettingsV2 is supported
-        require(
-            _feeSettings.supportsInterface(type(IFeeSettingsV2).interfaceId),
-            "FeeSettings must implement IFeeSettingsV2"
-        );
+        require(_feeSettings.supportsInterface(type(IFeeSettingsV2).interfaceId), FeeSettingsInterfaceNotSupported());
     }
 
     /**

--- a/contracts/TokenSwap.sol
+++ b/contracts/TokenSwap.sol
@@ -111,7 +111,7 @@ contract TokenSwap is TokenSwapBase {
         }
 
         currency.safeTransferFrom(_msgSender(), receiver, currencyAmount - fee);
-        token.transferFrom(holder, _tokenReceiver, _tokenAmount);
+        IERC20(address(token)).safeTransferFrom(holder, _tokenReceiver, _tokenAmount);
 
         emit TokensBought(_msgSender(), _tokenAmount, currencyAmount);
     }
@@ -142,7 +142,7 @@ contract TokenSwap is TokenSwapBase {
         currency.safeTransferFrom(holder, _currencyReceiver, currencyAmount - fee);
 
         // get the tokens the caller just sold to us
-        token.transferFrom(_msgSender(), receiver, _tokenAmount);
+        IERC20(address(token)).safeTransferFrom(_msgSender(), receiver, _tokenAmount);
 
         emit TokensSold(_msgSender(), _tokenAmount, currencyAmount);
     }

--- a/contracts/TokenSwap.sol
+++ b/contracts/TokenSwap.sol
@@ -39,6 +39,14 @@ struct TokenSwapInitializerArguments {
  * @dev The contract inherits from ERC2771Context in order to be usable with Gas Station Network (GSN) https://docs.opengsn.org/faq/troubleshooting.html#my-contract-is-using-openzeppelin-how-do-i-add-gsn-support
  */
 contract TokenSwap is TokenSwapBase {
+    /// @notice Reverted when the holder address argument is zero.
+    error ZeroHolderAddress();
+
+    /// @notice Reverted when the currency amount for a buy exceeds the caller's _maxCurrencyAmount.
+    error PurchaseTooExpensive();
+
+    /// @notice Reverted when the payout after fees is below the caller's _minCurrencyAmount.
+    error PayoutTooLow();
     using SafeERC20 for IERC20;
 
     /// holder. Tokens/currency will be transferred from this address.
@@ -71,7 +79,7 @@ contract TokenSwap is TokenSwapBase {
      * @param _arguments Struct containing all arguments for the initializer
      */
     function initialize(TokenSwapInitializerArguments memory _arguments) external initializer {
-        require(_arguments.tokenPrice != 0, "_tokenPrice needs to be a non-zero amount");
+        require(_arguments.tokenPrice != 0, ZeroPrice());
         _initializeBase(
             _arguments.owner,
             _arguments.tokenPrice,
@@ -80,7 +88,7 @@ contract TokenSwap is TokenSwapBase {
             _arguments.receiver
         );
 
-        require(_arguments.holder != address(0), "holder can not be zero address");
+        require(_arguments.holder != address(0), ZeroHolderAddress());
         holder = _arguments.holder;
     }
 
@@ -98,7 +106,7 @@ contract TokenSwap is TokenSwapBase {
         // rounding up to the next whole number. Investor is charged up to one currency bit more in case of a fractional currency bit.
         uint256 currencyAmount = Math.ceilDiv(_tokenAmount * tokenPrice, 10 ** token.decimals());
 
-        require(currencyAmount <= _maxCurrencyAmount, "Purchase more expensive than _maxCurrencyAmount");
+        require(currencyAmount <= _maxCurrencyAmount, PurchaseTooExpensive());
 
         (uint256 fee, address feeCollector) = _getFeeAndFeeReceiver(currencyAmount);
         if (fee != 0) {
@@ -131,7 +139,7 @@ contract TokenSwap is TokenSwapBase {
         }
 
         // the payout after fees needs to be at least as high as the minimum currency amount
-        require(currencyAmount - fee >= _minCurrencyAmount, "Payout too low");
+        require(currencyAmount - fee >= _minCurrencyAmount, PayoutTooLow());
 
         // pay out the currency after fees to the token seller's _currencyReceiver address
         currency.safeTransferFrom(holder, _currencyReceiver, currencyAmount - fee);

--- a/contracts/TokenSwap.sol
+++ b/contracts/TokenSwap.sol
@@ -42,9 +42,6 @@ contract TokenSwap is TokenSwapBase {
     /// @notice Reverted when the holder address argument is zero.
     error ZeroHolderAddress();
 
-    /// @notice Reverted when the currency amount for a buy exceeds the caller's _maxCurrencyAmount.
-    error PurchaseTooExpensive();
-
     /// @notice Reverted when the payout after fees is below the caller's _minCurrencyAmount.
     error PayoutTooLow();
     using SafeERC20 for IERC20;

--- a/contracts/TokenSwap.sol
+++ b/contracts/TokenSwap.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/utils/math/Math.sol";
 

--- a/contracts/Vesting.sol
+++ b/contracts/Vesting.sol
@@ -9,6 +9,7 @@ import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
+import "./common/Errors.sol";
 
 /**
  * @dev a token must implement this interface to be used with the Vesting contract and mintable vestings
@@ -46,6 +47,16 @@ struct VestingPlan {
  * must happen before the tokens can be released.
  */
 contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable, ReentrancyGuardUpgradeable {
+    error ZeroHash();
+    error InvalidHash();
+    error CommitmentRevokedBeforeCliff();
+    error EndTimeAfterVestingEnd();
+    error EndTimeNotInFuture();
+    error NewStartTimeNotAfterEndTime();
+    error OnlyBeneficiary();
+    error NotAllowedToChangeBeneficiary();
+    error CallerNotManager();
+
     event Commit(bytes32 hash);
     event ERC20Released(uint64 id, uint256 amount);
     event Revoke(bytes32 hash, uint64 endVestingTime);
@@ -82,8 +93,8 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @param _token address of the token to be vested
      */
     function initialize(address _owner, address _token) public initializer {
-        require(_owner != address(0), "Owner must not be zero address");
-        require(_token != address(0), "Token must not be zero address");
+        require(_owner != address(0), ZeroOwnerAddress());
+        require(_token != address(0), ZeroTokenAddress());
         __Ownable_init();
         transferOwnership(_owner);
         managers[_owner] = true;
@@ -165,7 +176,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @param _hash commitment hash
      */
     function commit(bytes32 _hash) external onlyManager {
-        require(_hash != bytes32(0), "hash must not be zero");
+        require(_hash != bytes32(0), ZeroHash());
         // the value is interpreted as maximum end date of the vesting
         // for real world use cases, type(uint64).max is "unlimited"
         commitments[_hash] = type(uint64).max;
@@ -178,7 +189,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @param _end new latest end date
      */
     function revoke(bytes32 _hash, uint64 _end) external onlyManager {
-        require(commitments[_hash] != 0, "invalid-hash");
+        require(commitments[_hash] != 0, InvalidHash());
         // already vested tokens can not be taken away (except of burning in the token contract itself)
         _end = uint64(block.timestamp) > _end ? uint64(block.timestamp) : _end;
         commitments[_hash] = _end;
@@ -209,12 +220,12 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
         require(
             _hash ==
                 keccak256(abi.encodePacked(_allocation, _beneficiary, _start, _cliff, _duration, _isMintable, _salt)),
-            "invalid-hash"
+            InvalidHash()
         );
         uint64 maxEndDate = commitments[_hash];
-        require(maxEndDate > 0, "invalid-hash");
+        require(maxEndDate > 0, InvalidHash());
         // if a commitment has been revoked with end date before cliff, it can never be revealed
-        require(_start + _cliff <= maxEndDate, "commitment revoked before cliff ended");
+        require(_start + _cliff <= maxEndDate, CommitmentRevokedBeforeCliff());
 
         if (_start + _duration <= maxEndDate) {
             // the commitment has not been revoked, or the end date of the commitment is after the end of the vesting
@@ -296,8 +307,8 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
         uint64 _duration,
         bool _isMintable
     ) internal returns (uint64 id) {
-        require(_allocation > 0, "Allocation must be greater than zero");
-        require(_beneficiary != address(0), "Beneficiary must not be zero address");
+        require(_allocation > 0, ZeroAmount());
+        require(_beneficiary != address(0), ZeroReceiverAddress());
 
         // cliff longer than duration is not valid and can only happen by mistake.
         // We heal this by extending the duration to match the cliff, thus balancing
@@ -327,7 +338,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
     function stopVesting(uint64 _id, uint64 _endTime) public onlyManager {
         // already vested tokens can not be taken away (except of burning in the token contract itself)
         _endTime = _endTime < uint64(block.timestamp) ? uint64(block.timestamp) : _endTime;
-        require(_endTime < start(_id) + duration(_id), "endTime must be before vesting end");
+        require(_endTime < start(_id) + duration(_id), EndTimeAfterVestingEnd());
 
         if (start(_id) + cliff(_id) > _endTime) {
             delete vestings[_id];
@@ -351,9 +362,9 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
         uint64 _endTime,
         uint64 _newStartTime
     ) external onlyManager returns (uint64 newId) {
-        require(_endTime > uint64(block.timestamp), "endTime must be in the future");
-        require(_endTime < start(_id) + duration(_id), "endTime must be before vesting end");
-        require(_newStartTime > _endTime, "newStartTime must be after endTime");
+        require(_endTime > uint64(block.timestamp), EndTimeNotInFuture());
+        require(_endTime < start(_id) + duration(_id), EndTimeAfterVestingEnd());
+        require(_newStartTime > _endTime, NewStartTimeNotAfterEndTime());
 
         uint256 allocationRemainder = allocation(_id) - vestedAmount(_id, _endTime);
         uint64 timeVested = _endTime - start(_id);
@@ -388,7 +399,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @param _amount maximum amount of tokens to be released
      */
     function release(uint64 _id, uint256 _amount) public nonReentrant {
-        require(_msgSender() == beneficiary(_id), "Only beneficiary can release tokens");
+        require(_msgSender() == beneficiary(_id), OnlyBeneficiary());
         _amount = releasable(_id) < _amount ? releasable(_id) : _amount;
         vestings[_id].released += _amount;
         if (isMintable(_id)) {
@@ -430,9 +441,9 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
         require(
             _msgSender() == beneficiary(_id) ||
                 ((_msgSender() == owner()) && uint64(block.timestamp) > start(_id) + duration(_id) + 365 days),
-            "Only beneficiary can change beneficiary, or owner 1 year after vesting end"
+            NotAllowedToChangeBeneficiary()
         );
-        require(_newBeneficiary != address(0), "Beneficiary must not be zero address");
+        require(_newBeneficiary != address(0), ZeroReceiverAddress());
         vestings[_id].beneficiary = _newBeneficiary;
         emit BeneficiaryChanged(_id, _newBeneficiary);
     }
@@ -459,7 +470,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @dev Throws if called by an account that is not a manager.
      */
     modifier onlyManager() {
-        require(managers[_msgSender()], "Caller is not a manager");
+        require(managers[_msgSender()], CallerNotManager());
         _;
     }
 

--- a/contracts/Vesting.sol
+++ b/contracts/Vesting.sol
@@ -2,7 +2,7 @@
 // derived from OpenZeppelin Contracts (last updated v4.9.0) (finance/VestingWallet.sol)
 /// @author cjentzsch, malteish
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/token/ERC20/utils/SafeERC20Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";

--- a/contracts/Vesting.sol
+++ b/contracts/Vesting.sol
@@ -55,7 +55,6 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
     error NewStartTimeNotAfterEndTime();
     error OnlyBeneficiary();
     error NotAllowedToChangeBeneficiary();
-    error CallerNotManager();
 
     event Commit(bytes32 hash);
     event ERC20Released(uint64 id, uint256 amount);

--- a/contracts/common/Errors.sol
+++ b/contracts/common/Errors.sol
@@ -18,3 +18,15 @@ error ZeroAmount();
 
 /// @notice Reverted when two array arguments that must have the same length do not.
 error ArrayLengthMismatch();
+
+/// @notice Reverted when a price or rate argument that must be positive is zero.
+error ZeroPrice();
+
+/// @notice Reverted when a currency is not on the token's allowList with the TRUSTED_CURRENCY attribute.
+error UntrustedCurrency();
+
+/// @notice Reverted when a currency argument equals the token address (they must differ).
+error CurrencyEqualsToken();
+
+/// @notice Reverted when a lockedUntil timestamp is not strictly in the future.
+error LockedUntilNotInFuture();

--- a/contracts/common/Errors.sol
+++ b/contracts/common/Errors.sol
@@ -1,8 +1,20 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.34;
 
-/// @notice Reverted when an address argument that must not be zero is zero.
-error ZeroAddress();
+/// @notice Reverted when an owner address argument is zero.
+error ZeroOwnerAddress();
+
+/// @notice Reverted when a token address argument is zero.
+error ZeroTokenAddress();
+
+/// @notice Reverted when a currency address argument is zero.
+error ZeroCurrencyAddress();
+
+/// @notice Reverted when a receiver/recipient address argument is zero.
+error ZeroReceiverAddress();
 
 /// @notice Reverted when an amount argument that must not be zero is zero.
 error ZeroAmount();
+
+/// @notice Reverted when two array arguments that must have the same length do not.
+error ArrayLengthMismatch();

--- a/contracts/common/Errors.sol
+++ b/contracts/common/Errors.sol
@@ -30,3 +30,24 @@ error CurrencyEqualsToken();
 
 /// @notice Reverted when a lockedUntil timestamp is not strictly in the future.
 error LockedUntilNotInFuture();
+
+/// @notice Reverted when the cooldown period has not yet elapsed.
+error CoolDownNotOver();
+
+/// @notice Reverted when the purchase cost exceeds the caller's maximum.
+error PurchaseTooExpensive();
+
+/// @notice Reverted when the caller is not a manager.
+error CallerNotManager();
+
+/// @notice Reverted when a time lock has not yet expired.
+error TimeLockNotExpired();
+
+/// @notice Reverted when no exit is set in the registry for a token.
+error NoExitSet();
+
+/// @notice Reverted when a tokenExitRegistry address argument is zero.
+error ZeroTokenExitRegistryAddress();
+
+/// @notice Reverted when a lead investor list is empty.
+error NoLeadInvestors();

--- a/contracts/common/Errors.sol
+++ b/contracts/common/Errors.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.34;
+
+/// @notice Reverted when an address argument that must not be zero is zero.
+error ZeroAddress();
+
+/// @notice Reverted when an amount argument that must not be zero is zero.
+error ZeroAmount();

--- a/contracts/common/IFeeSettings.sol
+++ b/contracts/common/IFeeSettings.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/utils/introspection/ERC165.sol";
 

--- a/contracts/common/IPriceDynamic.sol
+++ b/contracts/common/IPriceDynamic.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 /**
  * @title IPriceDynamic

--- a/contracts/common/PayoutBase.sol
+++ b/contracts/common/PayoutBase.sol
@@ -22,6 +22,12 @@ import "./Errors.sol";
 /// @notice Reverted when drain() is called before lockedUntil has elapsed.
 error DrainNotYetAvailable();
 
+/// @notice Reverted when claim() is called but the caller has nothing to claim.
+error NothingToClaim();
+
+/// @notice Reverted when the net payout after fees is below the caller's minimum.
+error PayoutBelowMinimum();
+
 abstract contract PayoutBase is ERC2771ContextUpgradeable, Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     using SafeERC20 for IERC20;
 

--- a/contracts/common/PayoutBase.sol
+++ b/contracts/common/PayoutBase.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 import "../Token.sol";
 import "./IFeeSettings.sol";
+import "./Errors.sol";
 
 /**
  * @title tokenize.it PayoutBase
@@ -18,6 +19,9 @@ import "./IFeeSettings.sol";
  *      Provides common state (token, currency, pricePerToken, lockedUntil), fee computation,
  *      and the drain function.
  */
+/// @notice Reverted when drain() is called before lockedUntil has elapsed.
+error DrainNotYetAvailable();
+
 abstract contract PayoutBase is ERC2771ContextUpgradeable, Ownable2StepUpgradeable, ReentrancyGuardUpgradeable {
     using SafeERC20 for IERC20;
 
@@ -88,7 +92,7 @@ abstract contract PayoutBase is ERC2771ContextUpgradeable, Ownable2StepUpgradeab
      * @param _erc20 ERC20 token to recover
      */
     function drain(address _recipient, IERC20 _erc20) external onlyOwner nonReentrant {
-        require(block.timestamp >= lockedUntil, "drain not yet available");
+        require(block.timestamp >= lockedUntil, DrainNotYetAvailable());
         _erc20.safeTransfer(_recipient, _erc20.balanceOf(address(this)));
     }
 

--- a/contracts/common/PayoutBase.sol
+++ b/contracts/common/PayoutBase.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/access/Ownable2StepUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";

--- a/contracts/common/TokenSwapBase.sol
+++ b/contracts/common/TokenSwapBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/metatx/ERC2771ContextUpgradeable.sol";

--- a/contracts/common/TokenSwapBase.sol
+++ b/contracts/common/TokenSwapBase.sol
@@ -10,6 +10,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/utils/math/Math.sol";
 
 import "../Token.sol";
+import "./Errors.sol";
 
 /**
  * @title TokenSwapBase
@@ -76,16 +77,13 @@ abstract contract TokenSwapBase is
         Token _token,
         address _receiver
     ) internal onlyInitializing {
-        require(_owner != address(0), "owner can not be zero address");
+        require(_owner != address(0), ZeroOwnerAddress());
         __Ownable_init();
         _transferOwnership(_owner);
-        require(address(_currency) != address(0), "currency can not be zero address");
-        require(address(_token) != address(0), "token can not be zero address");
-        require(
-            _token.allowList().map(address(_currency)) == TRUSTED_CURRENCY,
-            "currency needs to be on the allowlist with TRUSTED_CURRENCY attribute"
-        );
-        require(_receiver != address(0), "receiver can not be zero address");
+        require(address(_currency) != address(0), ZeroCurrencyAddress());
+        require(address(_token) != address(0), ZeroTokenAddress());
+        require(_token.allowList().map(address(_currency)) == TRUSTED_CURRENCY, UntrustedCurrency());
+        require(_receiver != address(0), ZeroReceiverAddress());
         tokenPrice = _tokenPrice;
         currency = _currency;
         token = _token;
@@ -97,7 +95,7 @@ abstract contract TokenSwapBase is
      * @param _receiver new receiver
      */
     function setReceiver(address _receiver) external onlyOwner {
-        require(_receiver != address(0), "receiver can not be zero address");
+        require(_receiver != address(0), ZeroReceiverAddress());
         receiver = _receiver;
         emit ReceiverChanged(_receiver);
     }
@@ -131,7 +129,7 @@ abstract contract TokenSwapBase is
      * @param _tokenPrice new tokenPrice
      */
     function setTokenPrice(uint256 _tokenPrice) external onlyOwner {
-        require(_tokenPrice != 0, "_tokenPrice needs to be a non-zero amount");
+        require(_tokenPrice != 0, ZeroPrice());
         tokenPrice = _tokenPrice;
         emit TokenPriceChanged(_tokenPrice);
     }

--- a/contracts/factories/AllowListCloneFactory.sol
+++ b/contracts/factories/AllowListCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../AllowList.sol";
 import "./CloneFactory.sol";

--- a/contracts/factories/AllowListCloneFactory.sol
+++ b/contracts/factories/AllowListCloneFactory.sol
@@ -28,10 +28,7 @@ contract AllowListCloneFactory is CloneFactory {
         bytes32 salt = _generateSalt(_rawSalt, _trustedForwarder, _owner);
         address clone = Clones.cloneDeterministic(implementation, salt);
         AllowList cloneAllowList = AllowList(clone);
-        require(
-            cloneAllowList.isTrustedForwarder(_trustedForwarder),
-            "AllowListCloneFactory: Unexpected trustedForwarder"
-        );
+        require(cloneAllowList.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         cloneAllowList.initialize(_owner);
         emit NewClone(clone);
         return clone;
@@ -55,10 +52,7 @@ contract AllowListCloneFactory is CloneFactory {
         bytes32 salt = _generateSalt(_rawSalt, _trustedForwarder, _owner);
         address clone = Clones.cloneDeterministic(implementation, salt);
         AllowList cloneAllowList = AllowList(clone);
-        require(
-            cloneAllowList.isTrustedForwarder(_trustedForwarder),
-            "AllowListCloneFactory: Unexpected trustedForwarder"
-        );
+        require(cloneAllowList.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         cloneAllowList.initialize(_owner, _addresses, _attributes);
         emit NewClone(clone);
         return clone;

--- a/contracts/factories/CloneFactory.sol
+++ b/contracts/factories/CloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import "./Factory.sol";

--- a/contracts/factories/CoinvestedPositionCloneFactory.sol
+++ b/contracts/factories/CoinvestedPositionCloneFactory.sol
@@ -28,10 +28,7 @@ contract CoinvestedPositionCloneFactory is CloneFactory {
     ) external returns (address) {
         bytes32 salt = _getSalt(_rawSalt, _trustedForwarder, _arguments);
         CoinvestedPosition clone = CoinvestedPosition(Clones.cloneDeterministic(implementation, salt));
-        require(
-            clone.isTrustedForwarder(_trustedForwarder),
-            "CoinvestedPositionCloneFactory: Unexpected trustedForwarder"
-        );
+        require(clone.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         clone.initialize(_arguments);
         emit NewClone(address(clone));
         return address(clone);

--- a/contracts/factories/CoinvestedPositionCloneFactory.sol
+++ b/contracts/factories/CoinvestedPositionCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/proxy/Clones.sol";
 

--- a/contracts/factories/CrowdinvestingCloneFactory.sol
+++ b/contracts/factories/CrowdinvestingCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../Crowdinvesting.sol";
 import "./CloneFactory.sol";

--- a/contracts/factories/CrowdinvestingCloneFactory.sol
+++ b/contracts/factories/CrowdinvestingCloneFactory.sol
@@ -27,10 +27,7 @@ contract CrowdinvestingCloneFactory is CloneFactory {
     ) external returns (address) {
         bytes32 salt = _getSalt(_rawSalt, _trustedForwarder, _arguments);
         Crowdinvesting crowdinvesting = Crowdinvesting(Clones.cloneDeterministic(implementation, salt));
-        require(
-            crowdinvesting.isTrustedForwarder(_trustedForwarder),
-            "CrowdinvestingCloneFactory: Unexpected trustedForwarder"
-        );
+        require(crowdinvesting.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         crowdinvesting.initialize(_arguments);
         emit NewClone(address(crowdinvesting));
         return address(crowdinvesting);

--- a/contracts/factories/DistributionCloneFactory.sol
+++ b/contracts/factories/DistributionCloneFactory.sol
@@ -38,7 +38,7 @@ contract DistributionCloneFactory is CloneFactory {
     ) external returns (address) {
         bytes32 salt = _getSalt(_rawSalt, _trustedForwarder, _arguments);
         Distribution clone = Distribution(Clones.cloneDeterministic(implementation, salt));
-        require(clone.isTrustedForwarder(_trustedForwarder), "DistributionCloneFactory: Unexpected trustedForwarder");
+        require(clone.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         clone.initialize(_arguments, _currencyProvider, _initialFundingAmount);
         emit NewClone(address(clone));
         return address(clone);

--- a/contracts/factories/DistributionCloneFactory.sol
+++ b/contracts/factories/DistributionCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/proxy/Clones.sol";
 

--- a/contracts/factories/ExitCloneFactory.sol
+++ b/contracts/factories/ExitCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/proxy/Clones.sol";
 

--- a/contracts/factories/ExitCloneFactory.sol
+++ b/contracts/factories/ExitCloneFactory.sol
@@ -37,7 +37,7 @@ contract ExitCloneFactory is CloneFactory {
     ) external returns (address) {
         bytes32 salt = _getSalt(_rawSalt, _trustedForwarder, _arguments);
         Exit clone = Exit(Clones.cloneDeterministic(implementation, salt));
-        require(clone.isTrustedForwarder(_trustedForwarder), "ExitCloneFactory: Unexpected trustedForwarder");
+        require(clone.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         clone.initialize(_arguments, _currencyProvider, _initialFundingAmount);
         emit NewClone(address(clone));
         return address(clone);

--- a/contracts/factories/Factory.sol
+++ b/contracts/factories/Factory.sol
@@ -14,6 +14,9 @@ abstract contract Factory {
     /// @notice Reverted when the implementation address passed to the constructor is zero.
     error ZeroImplementationAddress();
 
+    /// @notice Reverted when the clone's trusted forwarder does not match the expected one.
+    error UnexpectedTrustedForwarder();
+
     /// The address of the implementation contract
     address public immutable implementation;
 

--- a/contracts/factories/Factory.sol
+++ b/contracts/factories/Factory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 /**
  * @title Factory

--- a/contracts/factories/Factory.sol
+++ b/contracts/factories/Factory.sol
@@ -2,6 +2,8 @@
 
 pragma solidity 0.8.34;
 
+import "../common/Errors.sol";
+
 /**
  * @title Factory
  * @author malteish
@@ -9,11 +11,14 @@ pragma solidity 0.8.34;
  */
 
 abstract contract Factory {
+    /// @notice Reverted when the implementation address passed to the constructor is zero.
+    error ZeroImplementationAddress();
+
     /// The address of the implementation contract
     address public immutable implementation;
 
     constructor(address _implementation) {
-        require(_implementation != address(0), "Factory: implementation can not be zero");
+        require(_implementation != address(0), ZeroImplementationAddress());
         implementation = _implementation;
     }
 }

--- a/contracts/factories/FeeDistributorCloneFactory.sol
+++ b/contracts/factories/FeeDistributorCloneFactory.sol
@@ -6,22 +6,22 @@ import "@openzeppelin/contracts/proxy/Clones.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import "../CoinvestedPosition.sol";
-import "../FeeSplitter.sol";
+import "../FeeDistributor.sol";
 import "./CloneFactory.sol";
 
 /**
- * @title FeeSplitterCloneFactory
+ * @title FeeDistributorCloneFactory
  * @author malteish
- * @notice Use this contract to create deterministic clones of FeeSplitter contracts.
+ * @notice Use this contract to create deterministic clones of FeeDistributor contracts.
  *      Each clone pulls a one-time fee from a payer and distributes it among the lead investors
  *      of a CoinvestedPosition. The clone address is fully determined by the initialization
  *      parameters, allowing the feePayer to pre-approve the predicted address before deployment.
  */
-contract FeeSplitterCloneFactory is CloneFactory {
+contract FeeDistributorCloneFactory is CloneFactory {
     constructor(address _implementation) CloneFactory(_implementation) {}
 
     /**
-     * @notice Create a new FeeSplitter clone and initialize it. The clone immediately pulls
+     * @notice Create a new FeeDistributor clone and initialize it. The clone immediately pulls
      *      feeAmount of currency from feePayer and distributes it among the lead investors of
      *      coinvestedPosition. feePayer must have pre-approved this clone's address before calling.
      *      Use predictCloneAddress to obtain the address beforehand.
@@ -31,7 +31,7 @@ contract FeeSplitterCloneFactory is CloneFactory {
      * @param _feeAmount total fee to distribute, in currency bits
      * @param _coinvestedPosition source of lead investor accounts and carry fractions
      */
-    function createFeeSplitterClone(
+    function createFeeDistributorClone(
         bytes32 _rawSalt,
         address _feePayer,
         IERC20 _currency,
@@ -39,7 +39,7 @@ contract FeeSplitterCloneFactory is CloneFactory {
         CoinvestedPosition _coinvestedPosition
     ) external returns (address) {
         bytes32 salt = _getSalt(_rawSalt, _feePayer, _currency, _feeAmount, _coinvestedPosition);
-        FeeSplitter clone = FeeSplitter(Clones.cloneDeterministic(implementation, salt));
+        FeeDistributor clone = FeeDistributor(Clones.cloneDeterministic(implementation, salt));
         clone.payFee(_feePayer, _currency, _feeAmount, _coinvestedPosition);
         emit NewClone(address(clone));
         return address(clone);

--- a/contracts/factories/FeeSettingsCloneFactory.sol
+++ b/contracts/factories/FeeSettingsCloneFactory.sol
@@ -30,10 +30,7 @@ contract FeeSettingsCloneFactory is CloneFactory {
         bytes32 salt = _generateSalt(_rawSalt, _trustedForwarder, _owner, _feeTypes);
         address clone = Clones.cloneDeterministic(implementation, salt);
         FeeSettings cloneFeeSettings = FeeSettings(clone);
-        require(
-            cloneFeeSettings.isTrustedForwarder(_trustedForwarder),
-            "FeeSettingsCloneFactory: Unexpected trustedForwarder"
-        );
+        require(cloneFeeSettings.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         cloneFeeSettings.initialize(_owner, _feeTypes);
         emit NewClone(clone);
         return clone;

--- a/contracts/factories/FeeSettingsCloneFactory.sol
+++ b/contracts/factories/FeeSettingsCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../FeeSettings.sol";
 import "./CloneFactory.sol";

--- a/contracts/factories/FeeSplitterCloneFactory.sol
+++ b/contracts/factories/FeeSplitterCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/proxy/Clones.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";

--- a/contracts/factories/PriceLinearCloneFactory.sol
+++ b/contracts/factories/PriceLinearCloneFactory.sol
@@ -50,10 +50,7 @@ contract PriceLinearCloneFactory is CloneFactory {
         );
         address clone = Clones.cloneDeterministic(implementation, salt);
         PriceLinear clonePriceOracle = PriceLinear(clone);
-        require(
-            clonePriceOracle.isTrustedForwarder(_trustedForwarder),
-            "PriceLinearCloneFactory: Unexpected trustedForwarder"
-        );
+        require(clonePriceOracle.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         clonePriceOracle.initialize(
             _owner,
             _slopeEnumerator,

--- a/contracts/factories/PriceLinearCloneFactory.sol
+++ b/contracts/factories/PriceLinearCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../PriceLinear.sol";
 import "./CloneFactory.sol";

--- a/contracts/factories/PrivateOfferFactory.sol
+++ b/contracts/factories/PrivateOfferFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/utils/Create2.sol";
 import "../PrivateOffer.sol";

--- a/contracts/factories/PrivateOfferFactory.sol
+++ b/contracts/factories/PrivateOfferFactory.sol
@@ -15,6 +15,15 @@ import "./TimeLockCloneFactory.sol";
  * @dev One deployment of this contract can be used for deployment of any number of PrivateOffers using create2.
  */
 contract PrivateOfferFactory {
+    /// @notice Reverted when the TimeLockCloneFactory address passed to the constructor is zero.
+    error ZeroTimeLockCloneFactoryAddress();
+
+    /// @notice Reverted when the CoinvestedPositionCloneFactory address passed to the constructor is zero.
+    error ZeroCoinvestedPositionCloneFactoryAddress();
+
+    /// @notice Reverted when the token balance of the destination contract does not match the expected amount after deployment.
+    error TokenDeliveryFailed();
+
     event Deploy(address indexed privateOffer);
     event NewPrivateOfferWithTimeLock(address privateOffer, address timeLock);
     event NewPrivateOfferWithCoinvestedPosition(address privateOffer, address coinvestedPosition);
@@ -26,8 +35,8 @@ contract PrivateOfferFactory {
         TimeLockCloneFactory _timeLockCloneFactory,
         CoinvestedPositionCloneFactory _coinvestedPositionCloneFactory
     ) {
-        require(address(_timeLockCloneFactory) != address(0), "TimeLockCloneFactory must not be 0");
-        require(address(_coinvestedPositionCloneFactory) != address(0), "CoinvestedPositionCloneFactory must not be 0");
+        require(address(_timeLockCloneFactory) != address(0), ZeroTimeLockCloneFactoryAddress());
+        require(address(_coinvestedPositionCloneFactory) != address(0), ZeroCoinvestedPositionCloneFactoryAddress());
         timeLockCloneFactory = _timeLockCloneFactory;
         coinvestedPositionCloneFactory = _coinvestedPositionCloneFactory;
     }
@@ -79,7 +88,7 @@ contract PrivateOfferFactory {
         // deploy the private offer, which mints tokens directly into the time lock
         address privateOffer = _deployPrivateOffer(_rawSalt, arguments);
 
-        require(_arguments.token.balanceOf(address(timeLock)) == _arguments.tokenAmount, "Execution failed");
+        require(_arguments.token.balanceOf(address(timeLock)) == _arguments.tokenAmount, TokenDeliveryFailed());
         emit NewPrivateOfferWithTimeLock(privateOffer, address(timeLock));
         return address(timeLock);
     }
@@ -160,10 +169,7 @@ contract PrivateOfferFactory {
         // deploy the private offer, which delivers tokens into the coinvested position
         address privateOfferAddress = _deployPrivateOffer(_rawSalt, arguments);
 
-        require(
-            _arguments.token.balanceOf(coinvestedPositionAddress) == _arguments.tokenAmount,
-            "token delivery failed"
-        );
+        require(_arguments.token.balanceOf(coinvestedPositionAddress) == _arguments.tokenAmount, TokenDeliveryFailed());
         emit NewPrivateOfferWithCoinvestedPosition(privateOfferAddress, coinvestedPositionAddress);
     }
 

--- a/contracts/factories/TimeLockCloneFactory.sol
+++ b/contracts/factories/TimeLockCloneFactory.sol
@@ -33,7 +33,7 @@ contract TimeLockCloneFactory is CloneFactory {
     ) external returns (address) {
         bytes32 salt = _getSalt(_rawSalt, _trustedForwarder, _owner, _lockedUntil, _tokenExitRegistry);
         TimeLock clone = TimeLock(Clones.cloneDeterministic(implementation, salt));
-        require(clone.isTrustedForwarder(_trustedForwarder), "TimeLockCloneFactory: Unexpected trustedForwarder");
+        require(clone.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         clone.initialize(_owner, _lockedUntil, _tokenExitRegistry);
         emit NewClone(address(clone));
         return address(clone);

--- a/contracts/factories/TimeLockCloneFactory.sol
+++ b/contracts/factories/TimeLockCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/proxy/Clones.sol";
 

--- a/contracts/factories/TokenProxyFactory.sol
+++ b/contracts/factories/TokenProxyFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../Token.sol";
 import "./Factory.sol";

--- a/contracts/factories/TokenProxyFactory.sol
+++ b/contracts/factories/TokenProxyFactory.sol
@@ -52,7 +52,7 @@ contract TokenProxyFactory is Factory {
         address proxyAddress = Create2.deploy(0, salt, getBytecode());
         ERC1967Proxy proxy = ERC1967Proxy(payable(proxyAddress));
         Token cloneToken = Token(address(proxy));
-        require(cloneToken.isTrustedForwarder(_trustedForwarder), "TokenProxyFactory: Unexpected trustedForwarder");
+        require(cloneToken.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         cloneToken.initialize(_feeSettings, _admin, _allowList, _requirements, _name, _symbol);
         emit NewProxy(address(proxy));
         return address(proxy);

--- a/contracts/factories/TokenSwapCloneFactory.sol
+++ b/contracts/factories/TokenSwapCloneFactory.sol
@@ -27,7 +27,7 @@ contract TokenSwapCloneFactory is CloneFactory {
     ) external returns (address) {
         bytes32 salt = _getSalt(_rawSalt, _trustedForwarder, _arguments);
         TokenSwap tokenSwap = TokenSwap(Clones.cloneDeterministic(implementation, salt));
-        require(tokenSwap.isTrustedForwarder(_trustedForwarder), "TokenSwapCloneFactory: Unexpected trustedForwarder");
+        require(tokenSwap.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         tokenSwap.initialize(_arguments);
         emit NewClone(address(tokenSwap));
         return address(tokenSwap);

--- a/contracts/factories/TokenSwapCloneFactory.sol
+++ b/contracts/factories/TokenSwapCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../TokenSwap.sol";
 import "./CloneFactory.sol";

--- a/contracts/factories/VestingCloneFactory.sol
+++ b/contracts/factories/VestingCloneFactory.sol
@@ -30,7 +30,7 @@ contract VestingCloneFactory is CloneFactory {
         bytes32 salt = keccak256(abi.encode(_rawSalt, _trustedForwarder, _owner, _token));
         address clone = Clones.cloneDeterministic(implementation, salt);
         Vesting vesting = Vesting(clone);
-        require(vesting.isTrustedForwarder(_trustedForwarder), "VestingCloneFactory: Unexpected trustedForwarder");
+        require(vesting.isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         vesting.initialize(_owner, _token);
         emit NewClone(clone);
         return clone;
@@ -108,10 +108,7 @@ contract VestingCloneFactory is CloneFactory {
         address _owner,
         address _token
     ) external view returns (address) {
-        require(
-            Vesting(implementation).isTrustedForwarder(_trustedForwarder),
-            "VestingCloneFactory: Unexpected trustedForwarder"
-        );
+        require(Vesting(implementation).isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         bytes32 salt = keccak256(abi.encode(_rawSalt, _trustedForwarder, _owner, _token));
         return Clones.predictDeterministicAddress(implementation, salt);
     }
@@ -139,10 +136,7 @@ contract VestingCloneFactory is CloneFactory {
         uint64 _cliff,
         uint64 _duration
     ) external view returns (address) {
-        require(
-            Vesting(implementation).isTrustedForwarder(_trustedForwarder),
-            "VestingCloneFactory: Unexpected trustedForwarder"
-        );
+        require(Vesting(implementation).isTrustedForwarder(_trustedForwarder), UnexpectedTrustedForwarder());
         bytes32 salt = keccak256(
             abi.encode(
                 _rawSalt,

--- a/contracts/factories/VestingCloneFactory.sol
+++ b/contracts/factories/VestingCloneFactory.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../Vesting.sol";
 import "./CloneFactory.sol";

--- a/docs/bestpractices.md
+++ b/docs/bestpractices.md
@@ -29,6 +29,22 @@
 - Use `@notice` for high-level descriptions, `@dev` for implementation notes, `@param` for parameters
 - Include security considerations and invariants in contract-level `@dev` comments
 
+### Custom Errors
+
+- Use custom errors instead of string reverts.
+- Use the `require(condition, CustomError(args))` syntax (available since Solidity 0.8.26 via-ir / 0.8.27 legacy pipeline).
+- **Generic errors** (e.g. `ZeroAddress`, `ZeroAmount`) are declared as top-level file-level errors in `contracts/common/Errors.sol` and imported where needed.
+- **Contract-specific errors** are declared inside the contract that uses them.
+- Do not declare errors in interfaces.
+- In tests, match custom errors by selector; for errors with parameters also encode the argument values:
+  ```solidity
+  // parameter-less error
+  vm.expectRevert(ZeroAddress.selector);
+  vm.expectRevert(MyContract.NoLeadInvestors.selector);
+  // error with parameters — verify the argument value too
+  vm.expectRevert(abi.encodeWithSelector(MyContract.UnknownFeeType.selector, feeTypeId));
+  ```
+
 ### Architecture
 
 - Use structs to avoid "stack too deep" errors in functions with many parameters

--- a/docs/bestpractices.md
+++ b/docs/bestpractices.md
@@ -36,6 +36,7 @@
 - **Generic errors** (e.g. `ZeroAddress`, `ZeroAmount`) are declared as top-level file-level errors in `contracts/common/Errors.sol` and imported where needed.
 - **Contract-specific errors** are declared inside the contract that uses them.
 - Do not declare errors in interfaces.
+- Only add arguments to a custom error when they give the caller information they could not already derive from the call context (e.g. the function arguments or their own address). Redundant arguments add gas cost and noise.
 - In tests, match custom errors by selector; for errors with parameters also encode the argument values:
   ```solidity
   // parameter-less error

--- a/docs/dev_overview.md
+++ b/docs/dev_overview.md
@@ -168,7 +168,7 @@ Holds ERC20 tokens on behalf of an owner and blocks withdrawals until a configur
 - `claimExit(token, recipient, minPayout)` looks up the registered Exit for `token` in `tokenExitRegistry`, approves it, and redeems the full token balance. Also available during the lock period.
 - `tokenExitRegistry`: the GlobalTokenExitRegistry that `claimExit()` consults to find the authorized exit for a token. If no exit is registered, the call reverts.
 
-### FeeSplitter (FeeSplitter.sol)
+### FeeDistributor (FeeDistributor.sol)
 
 Helper that collects an upfront syndication fee from the co-investor and distributes it proportionally among the lead investors of a CoinvestedPosition.
 
@@ -180,7 +180,7 @@ Helper that collects an upfront syndication fee from the co-investor and distrib
 
 ### Approaches for use
 
-The core risk is granting a standing approval to a live FeeSplitter: anyone can call `payFee` and drain it. There are two safe patterns:
+The core risk is granting a standing approval to a live FeeDistributor: anyone can call `payFee` and drain it. There are two safe patterns:
 
 **Counterfactual (one-shot):** Grant approval to the predicted address before deployment. The contract does not exist yet, so the approval can only be consumed by deploying it — fixing all execution parameters up front. Approve for **exactly** `feeAmount`: any excess becomes a live allowance on the deployed contract and can be drained.
 
@@ -189,7 +189,7 @@ The core risk is granting a standing approval to a live FeeSplitter: anyone can 
 - batch execution through a Safe
 - batch execution through multicall
 
-FeeSplitter is a convenience helper, not a required component. The same outcome can be achieved by calculating each lead investor's share off-chain and sending transfers directly. If this contract does not fit the platform's or a user's needs, it can and should be replaced or adapted.
+FeeDistributor is a convenience helper, not a required component. The same outcome can be achieved by calculating each lead investor's share off-chain and sending transfers directly. If this contract does not fit the platform's or a user's needs, it can and should be replaced or adapted.
 
 ## Employee participation
 

--- a/docs/dev_overview.md
+++ b/docs/dev_overview.md
@@ -170,13 +170,26 @@ Holds ERC20 tokens on behalf of an owner and blocks withdrawals until a configur
 
 ### FeeSplitter (FeeSplitter.sol)
 
-A one-shot helper that collects an upfront syndication fee from the co-investor and distributes it proportionally among the lead investors of a CoinvestedPosition.
+Helper that collects an upfront syndication fee from the co-investor and distributes it proportionally among the lead investors of a CoinvestedPosition.
 
 **Key details:**
 
 - `payFee(feePayer, currency, feeAmount, coinvestedPosition)` pulls `feeAmount` of `currency` from `feePayer` (which must have pre-approved this contract) and splits it among the lead investors in proportion to their `profitFraction`. The last investor absorbs any rounding dust so the full amount is always distributed.
-- Each clone is safe to use once. After the feePayer's allowance is consumed, it task is done. Reusing it to split fees for the same or other coinvestors and lead investors is only safe if the new approval is granted and used in the same transaction (frontrunning risk).
 - The contract holds no state of its own — it reads the lead investor list directly from the CoinvestedPosition at call time.
+- **Important**: Approving more than `_feeAmount` puts the approved funds at risk and will eventually result in them being stolen!
+
+### Approaches for use
+
+The core risk is granting a standing approval to a live FeeSplitter: anyone can call `payFee` and drain it. There are two safe patterns:
+
+**Counterfactual (one-shot):** Grant approval to the predicted address before deployment. The contract does not exist yet, so the approval can only be consumed by deploying it — fixing all execution parameters up front. Approve for **exactly** `feeAmount`: any excess becomes a live allowance on the deployed contract and can be drained.
+
+**Batched reuse:** Grant approval to a deployed contract and call `payFee` in the same transaction, so the allowance is never exposed between blocks. Several mechanisms support this, e.g.:
+
+- batch execution through a Safe
+- batch execution through multicall
+
+FeeSplitter is a convenience helper, not a required component. The same outcome can be achieved by calculating each lead investor's share off-chain and sending transfers directly. If this contract does not fit the platform's or a user's needs, it can and should be replaced or adapted.
 
 ## Employee participation
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -25,7 +25,7 @@ task('accounts', 'Prints the list of accounts', async (taskArgs, hre) => {
  */
 const config: HardhatUserConfig = {
   solidity: {
-    version: '0.8.23',
+    version: '0.8.34',
     settings: {
       // optimizer: {
       //   enabled: true,

--- a/script/CheckToken.sol
+++ b/script/CheckToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 // taken from https://moveseventyeight.com/deploy-your-first-nft-contract-with-foundry#heading-prepare-a-basic-deployment-script
 

--- a/script/DeployCompany.sol
+++ b/script/DeployCompany.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 // taken from https://moveseventyeight.com/deploy-your-first-nft-contract-with-foundry#heading-prepare-a-basic-deployment-script
 

--- a/script/DeployPlatform.s.sol
+++ b/script/DeployPlatform.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 // taken from https://moveseventyeight.com/deploy-your-first-nft-contract-with-foundry#heading-prepare-a-basic-deployment-script
 

--- a/script/DeployTokenFromScratch.s.sol
+++ b/script/DeployTokenFromScratch.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 // taken from https://moveseventyeight.com/deploy-your-first-nft-contract-with-foundry#heading-prepare-a-basic-deployment-script
 

--- a/test/AllowList.t.sol
+++ b/test/AllowList.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/AllowList.t.sol
+++ b/test/AllowList.t.sol
@@ -31,7 +31,7 @@ contract AllowListTest is Test {
     }
 
     function testOwner0Reverts() public {
-        vm.expectRevert("owner can not be zero address");
+        vm.expectRevert(ZeroOwnerAddress.selector);
         factory.createAllowListClone("salt", trustedForwarder, address(0));
     }
 
@@ -137,7 +137,7 @@ contract AllowListTest is Test {
         uint256[] memory attributes = new uint256[](1);
         attributes[0] = attributesX;
         vm.prank(owner);
-        vm.expectRevert("lengths do not match");
+        vm.expectRevert(ArrayLengthMismatch.selector);
         list.set(addresses, attributes);
     }
 

--- a/test/AllowListCloneFactory.t.sol
+++ b/test/AllowListCloneFactory.t.sol
@@ -47,7 +47,7 @@ contract AllowListCloneFactoryTest is Test {
         vm.assume(_owner != address(0));
 
         // using a different owner should fail
-        vm.expectRevert("owner can not be zero address");
+        vm.expectRevert(ZeroOwnerAddress.selector);
         factory.createAllowListClone(bytes32(uint256(0)), trustedForwarder, address(0));
 
         // using the correct owner should succeed
@@ -112,7 +112,7 @@ contract AllowListCloneFactoryTest is Test {
     }
 
     function testFactoryRevertsIfImplementationZero() public {
-        vm.expectRevert("Factory: implementation can not be zero");
+        vm.expectRevert(Factory.ZeroImplementationAddress.selector);
         new AllowListCloneFactory(address(0));
     }
 
@@ -120,7 +120,7 @@ contract AllowListCloneFactoryTest is Test {
         address[] memory addresses = new address[](0);
         uint256[] memory attributes = new uint256[](0);
 
-        vm.expectRevert("owner can not be zero address");
+        vm.expectRevert(ZeroOwnerAddress.selector);
         factory.createAllowListClone(bytes32(uint256(0)), trustedForwarder, address(0), addresses, attributes);
     }
 }

--- a/test/AllowListCloneFactory.t.sol
+++ b/test/AllowListCloneFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/AllowListCloneFactory.t.sol
+++ b/test/AllowListCloneFactory.t.sol
@@ -36,7 +36,7 @@ contract AllowListCloneFactoryTest is Test {
         vm.assume(_wrongTrustedForwarder != address(0));
 
         // using a different trustedForwarder should fail
-        vm.expectRevert("AllowListCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         factory.createAllowListClone(bytes32(uint256(0)), _wrongTrustedForwarder, companyAdmin);
 
         // using the correct trustedForwarder should succeed
@@ -107,7 +107,7 @@ contract AllowListCloneFactoryTest is Test {
         address[] memory addresses = new address[](0);
         uint256[] memory attributes = new uint256[](0);
 
-        vm.expectRevert("AllowListCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         factory.createAllowListClone(bytes32(uint256(1)), _wrongTrustedForwarder, companyAdmin, addresses, attributes);
     }
 

--- a/test/AllowListERC2771.t.sol
+++ b/test/AllowListERC2771.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/CoinvestedPosition.t.sol
+++ b/test/CoinvestedPosition.t.sol
@@ -269,7 +269,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
             lockedUntil: 0,
             tokenExitRegistry: tokenExitRegistry
         });
-        vm.expectRevert("There must be at least one lead investor");
+        vm.expectRevert(CoinvestedPosition.NoLeadInvestors.selector);
         factory.createCoinvestedPositionClone(bytes32(0), TRUSTED_FORWARDER, args);
     }
 
@@ -286,7 +286,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
             lockedUntil: 0,
             tokenExitRegistry: tokenExitRegistry
         });
-        vm.expectRevert("lead investor can not be zero address");
+        vm.expectRevert(CoinvestedPosition.ZeroLeadInvestorAddress.selector);
         factory.createCoinvestedPositionClone(bytes32(0), TRUSTED_FORWARDER, args);
     }
 
@@ -303,7 +303,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
             lockedUntil: 0,
             tokenExitRegistry: tokenExitRegistry
         });
-        vm.expectRevert("lead investor profit fraction can not be zero");
+        vm.expectRevert(CoinvestedPosition.ZeroLeadInvestorProfitFraction.selector);
         factory.createCoinvestedPositionClone(bytes32(0), TRUSTED_FORWARDER, args);
     }
 
@@ -359,7 +359,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         FakePaymentToken nonTrusted = new FakePaymentToken(0, 6);
         // not on allowList → 0 attributes, no TRUSTED_CURRENCY bit
         vm.prank(OWNER);
-        vm.expectRevert("currency needs to be on the allowlist with TRUSTED_CURRENCY attribute");
+        vm.expectRevert(UntrustedCurrency.selector);
         coinvestedPosition.setCurrency(IERC20(address(nonTrusted)), 1);
     }
 
@@ -411,7 +411,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         // tokenPrice is 0 after init
         assertEq(coinvestedPosition.tokenPrice(), 0);
         vm.prank(OWNER);
-        vm.expectRevert("tokenPrice must be set before unpausing");
+        vm.expectRevert(ZeroPrice.selector);
         coinvestedPosition.unpause();
     }
 
@@ -482,7 +482,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         _setupBuy(10e18, 200e6);
         _fundBuyer(eurc, 200e6);
         vm.prank(BUYER);
-        vm.expectRevert("Purchase more expensive than _maxCurrencyAmount");
+        vm.expectRevert(CoinvestedPosition.PurchaseTooExpensive.selector);
         coinvestedPosition.buy(1e18, 100e6, TOKEN_RECEIVER); // needs 200e6 but max=100e6
     }
 
@@ -1359,7 +1359,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         allowList.set(address(token), TRUSTED_CURRENCY);
 
         // setCurrency itself must reject the held token as currency
-        vm.expectRevert("currency cannot be the held token");
+        vm.expectRevert(CurrencyEqualsToken.selector);
         vm.prank(OWNER);
         coinvestedPosition.setCurrency(IERC20(address(token)), 1);
     }
@@ -1420,7 +1420,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
             lockedUntil: 0,
             tokenExitRegistry: GlobalTokenExitRegistry(address(0))
         });
-        vm.expectRevert("tokenExitRegistry can not be zero address");
+        vm.expectRevert(CoinvestedPosition.ZeroTokenExitRegistryAddress.selector);
         factory.createCoinvestedPositionClone(bytes32(0), TRUSTED_FORWARDER, args);
     }
 
@@ -1444,19 +1444,19 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         locked.setTokenPrice(200e6);
 
         vm.prank(OWNER);
-        vm.expectRevert("timelock has not expired");
+        vm.expectRevert(CoinvestedPosition.TimeLockNotExpired.selector);
         locked.unpause();
     }
 
     function testSetCurrencyRevertsIfZeroAddress() public {
         vm.prank(OWNER);
-        vm.expectRevert("zero address");
+        vm.expectRevert(ZeroCurrencyAddress.selector);
         coinvestedPosition.setCurrency(IERC20(address(0)), 1e6);
     }
 
     function testSetCurrencyRevertsIfBasePriceZero() public {
         vm.prank(OWNER);
-        vm.expectRevert("altBasePrice must be > 0");
+        vm.expectRevert(ZeroPrice.selector);
         coinvestedPosition.setCurrency(IERC20(address(eure)), 0);
     }
 
@@ -1465,7 +1465,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         token.mint(address(coinvestedPosition), 100e18);
 
         vm.prank(OWNER);
-        vm.expectRevert("no exit set in tokenExitRegistry");
+        vm.expectRevert(CoinvestedPosition.NoExitSet.selector);
         coinvestedPosition.claimExit(0, 0);
     }
 }

--- a/test/CoinvestedPosition.t.sol
+++ b/test/CoinvestedPosition.t.sol
@@ -230,7 +230,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
             lockedUntil: 0,
             tokenExitRegistry: tokenExitRegistry
         });
-        vm.expectRevert("currency needs to be on the allowlist with TRUSTED_CURRENCY attribute");
+        vm.expectRevert(UntrustedCurrency.selector);
         factory.createCoinvestedPositionClone(bytes32(0), TRUSTED_FORWARDER, args);
     }
 
@@ -417,7 +417,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
 
     function testSetTokenPriceZeroReverts() public {
         vm.prank(OWNER);
-        vm.expectRevert("_tokenPrice needs to be a non-zero amount");
+        vm.expectRevert(ZeroPrice.selector);
         coinvestedPosition.setTokenPrice(0);
     }
 
@@ -451,7 +451,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
 
     function testSetReceiverZeroAddressReverts() public {
         vm.prank(OWNER);
-        vm.expectRevert("receiver can not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         coinvestedPosition.setReceiver(address(0));
     }
 

--- a/test/CoinvestedPosition.t.sol
+++ b/test/CoinvestedPosition.t.sol
@@ -269,7 +269,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
             lockedUntil: 0,
             tokenExitRegistry: tokenExitRegistry
         });
-        vm.expectRevert(CoinvestedPosition.NoLeadInvestors.selector);
+        vm.expectRevert(NoLeadInvestors.selector);
         factory.createCoinvestedPositionClone(bytes32(0), TRUSTED_FORWARDER, args);
     }
 
@@ -482,7 +482,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         _setupBuy(10e18, 200e6);
         _fundBuyer(eurc, 200e6);
         vm.prank(BUYER);
-        vm.expectRevert(CoinvestedPosition.PurchaseTooExpensive.selector);
+        vm.expectRevert(PurchaseTooExpensive.selector);
         coinvestedPosition.buy(1e18, 100e6, TOKEN_RECEIVER); // needs 200e6 but max=100e6
     }
 
@@ -1420,7 +1420,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
             lockedUntil: 0,
             tokenExitRegistry: GlobalTokenExitRegistry(address(0))
         });
-        vm.expectRevert(CoinvestedPosition.ZeroTokenExitRegistryAddress.selector);
+        vm.expectRevert(ZeroTokenExitRegistryAddress.selector);
         factory.createCoinvestedPositionClone(bytes32(0), TRUSTED_FORWARDER, args);
     }
 
@@ -1444,7 +1444,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         locked.setTokenPrice(200e6);
 
         vm.prank(OWNER);
-        vm.expectRevert(CoinvestedPosition.TimeLockNotExpired.selector);
+        vm.expectRevert(TimeLockNotExpired.selector);
         locked.unpause();
     }
 
@@ -1465,7 +1465,7 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         token.mint(address(coinvestedPosition), 100e18);
 
         vm.prank(OWNER);
-        vm.expectRevert(CoinvestedPosition.NoExitSet.selector);
+        vm.expectRevert(NoExitSet.selector);
         coinvestedPosition.claimExit(0, 0);
     }
 }

--- a/test/CoinvestedPosition.t.sol
+++ b/test/CoinvestedPosition.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "./resources/CoinvestedPositionTestBase.sol";
 

--- a/test/CoinvestedPositionCloneFactory.t.sol
+++ b/test/CoinvestedPositionCloneFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";

--- a/test/CoinvestedPositionCloneFactory.t.sol
+++ b/test/CoinvestedPositionCloneFactory.t.sol
@@ -183,7 +183,7 @@ contract CoinvestedPositionCloneFactoryTest is Test {
 
     function testCreateWithWrongForwarderReverts() public {
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
-        vm.expectRevert("CoinvestedPositionCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         factory.createCoinvestedPositionClone(EXAMPLE_SALT, address(0xBAD), args);
     }
 

--- a/test/CoinvestedPositionCloneFactory.t.sol
+++ b/test/CoinvestedPositionCloneFactory.t.sol
@@ -286,7 +286,7 @@ contract CoinvestedPositionCloneFactoryTest is Test {
         // not on allowList → 0 attributes, no TRUSTED_CURRENCY bit
         CoinvestedPositionInitializerArguments memory args = _baseArgs();
         args.baseCurrency = IERC20(address(badCurrency));
-        vm.expectRevert("currency needs to be on the allowlist with TRUSTED_CURRENCY attribute");
+        vm.expectRevert(UntrustedCurrency.selector);
         factory.createCoinvestedPositionClone(bytes32(0), TRUSTED_FORWARDER, args);
     }
 

--- a/test/CoinvestedPositionDistribution.t.sol
+++ b/test/CoinvestedPositionDistribution.t.sol
@@ -564,7 +564,7 @@ contract CoinvestedPositionDistributionTest is Test {
         TokenTransferStub stub = new TokenTransferStub(IERC20(address(untrusted)), 0);
         IERC20 untrustedCurrency = IERC20(address(stub.currency()));
 
-        vm.expectRevert("dividend currency must be a trusted currency");
+        vm.expectRevert(UntrustedCurrency.selector);
         vm.prank(OWNER);
         coinvestedPosition.claimDistribution(Distribution(address(stub)), 0);
     }
@@ -953,7 +953,7 @@ contract CoinvestedPositionDistributionTest is Test {
         IERC20(address(token)).transfer(address(stub), stubAmount);
         IERC20 tokenCurrency = IERC20(address(stub.currency()));
 
-        vm.expectRevert("currency cannot be the held token");
+        vm.expectRevert(CurrencyEqualsToken.selector);
         vm.prank(OWNER);
         coinvestedPosition.claimDistribution(Distribution(address(stub)), 0);
     }

--- a/test/CoinvestedPositionDistribution.t.sol
+++ b/test/CoinvestedPositionDistribution.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 

--- a/test/CoinvestedPositionDistribution.t.sol
+++ b/test/CoinvestedPositionDistribution.t.sol
@@ -629,7 +629,7 @@ contract CoinvestedPositionDistributionTest is Test {
         assertEq(distribution.eligible(address(coinvestedPositionZero)), 0, "DI-VI: eligible not zero");
 
         // claimDistribution must revert because eligible = 0
-        vm.expectRevert("nothing to claim");
+        vm.expectRevert(NothingToClaim.selector);
         vm.prank(OWNER);
         coinvestedPositionZero.claimDistribution(Distribution(address(distribution)), 0);
     }
@@ -705,7 +705,7 @@ contract CoinvestedPositionDistributionTest is Test {
         uint256 holderYBalBefore = usdc.balanceOf(HOLDER_Y);
         // HOLDER_Y's eligible is 0 after full reassign → claim reverts
         vm.prank(HOLDER_Y);
-        vm.expectRevert("nothing to claim");
+        vm.expectRevert(NothingToClaim.selector);
         distribution.claim(HOLDER_Y, 0);
         assertEq(usdc.balanceOf(HOLDER_Y), holderYBalBefore, "DI-VII: HOLDER_Y received non-zero after reassign");
 
@@ -934,7 +934,7 @@ contract CoinvestedPositionDistributionTest is Test {
         vm.prank(CURRENCY_PROVIDER);
         token.approve(cloneAddr, 100e18);
 
-        vm.expectRevert("currency and token must be different");
+        vm.expectRevert(CurrencyEqualsToken.selector);
         distributionFactory.createDistributionClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 100e18);
     }
 

--- a/test/CoinvestedPositionERC2771.t.sol
+++ b/test/CoinvestedPositionERC2771.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "./resources/CoinvestedPositionTestBase.sol";
 import "./resources/ERC2771Helper.sol";

--- a/test/CoinvestedPositionExit.t.sol
+++ b/test/CoinvestedPositionExit.t.sol
@@ -260,7 +260,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(ADMIN);
         tokenExitRegistry.setExit(token, Exit(address(exitContract)));
 
-        vm.expectRevert("no tokens to claim");
+        vm.expectRevert(ZeroAmount.selector);
         vm.prank(OWNER);
         coinvestedPositionEmpty.claimExit(1, 0);
     }
@@ -1066,7 +1066,7 @@ contract CoinvestedPositionExitTest is Test {
 
         vm.prank(ADMIN);
         tokenExitRegistry.setExit(token, Exit(address(noOpExit)));
-        vm.expectRevert("currency cannot be the held token");
+        vm.expectRevert(CurrencyEqualsToken.selector);
         vm.prank(OWNER);
         coinvestedPosition.claimExit(0, 1);
     }
@@ -1336,7 +1336,7 @@ contract CoinvestedPositionExitTest is Test {
         tokenExitRegistry.setExit(token, Exit(address(exitContract)));
 
         // _basePrice=0 and no rate in exit → must revert
-        vm.expectRevert("altBasePrice must be > 0");
+        vm.expectRevert(ZeroPrice.selector);
         vm.prank(OWNER);
         coinvestedPosition.claimExit(1, 0);
 
@@ -1408,7 +1408,7 @@ contract CoinvestedPositionExitTest is Test {
         );
 
         // Before lock expires: setCurrency must revert
-        vm.expectRevert("timelock has not expired");
+        vm.expectRevert(CoinvestedPosition.TimeLockNotExpired.selector);
         vm.prank(OWNER);
         lockedCp.setCurrency(IERC20(address(eure)), 100e18);
 

--- a/test/CoinvestedPositionExit.t.sol
+++ b/test/CoinvestedPositionExit.t.sol
@@ -1408,7 +1408,7 @@ contract CoinvestedPositionExitTest is Test {
         );
 
         // Before lock expires: setCurrency must revert
-        vm.expectRevert(CoinvestedPosition.TimeLockNotExpired.selector);
+        vm.expectRevert(TimeLockNotExpired.selector);
         vm.prank(OWNER);
         lockedCp.setCurrency(IERC20(address(eure)), 100e18);
 

--- a/test/CoinvestedPositionExit.t.sol
+++ b/test/CoinvestedPositionExit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 

--- a/test/CoinvestedPositionExit.t.sol
+++ b/test/CoinvestedPositionExit.t.sol
@@ -1020,7 +1020,7 @@ contract CoinvestedPositionExitTest is Test {
         tokenExitRegistry.setExit(token, Exit(address(exitContract)));
 
         vm.prank(OWNER);
-        vm.expectRevert("payout below minimum");
+        vm.expectRevert(PayoutBelowMinimum.selector);
         coinvestedPosition.claimExit(totalCurrency + 1, 0);
     }
 
@@ -1093,7 +1093,7 @@ contract CoinvestedPositionExitTest is Test {
 
         vm.prank(OWNER);
         if (uint256(minCurrencyAmount) > received) {
-            vm.expectRevert("payout below minimum");
+            vm.expectRevert(PayoutBelowMinimum.selector);
         }
         coinvestedPositionFuzz.claimExit(uint256(minCurrencyAmount), 0);
     }
@@ -1360,7 +1360,7 @@ contract CoinvestedPositionExitTest is Test {
             referenceCurrencies: referenceCurrencies,
             referenceToExitRates: rates
         });
-        vm.expectRevert("referenceCurrencies and referenceToExitRates must have the same length");
+        vm.expectRevert(ArrayLengthMismatch.selector);
         exitFactory.createExitClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 
@@ -1385,7 +1385,7 @@ contract CoinvestedPositionExitTest is Test {
         eure.mint(CURRENCY_PROVIDER, totalCurrency);
         vm.prank(CURRENCY_PROVIDER);
         eure.approve(cloneAddr, totalCurrency);
-        vm.expectRevert("referenceToExitRate must be positive");
+        vm.expectRevert(ZeroPrice.selector);
         exitFactory.createExitClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, totalCurrency);
     }
 

--- a/test/CoinvestedPositionPrivateOffer.t.sol
+++ b/test/CoinvestedPositionPrivateOffer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/utils/math/Math.sol";
 import "../lib/forge-std/src/Test.sol";

--- a/test/CoinvestedPositionPrivateOffer.t.sol
+++ b/test/CoinvestedPositionPrivateOffer.t.sol
@@ -7,9 +7,9 @@ import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/factories/CoinvestedPositionCloneFactory.sol";
 import "../contracts/factories/PrivateOfferFactory.sol";
 import "../contracts/factories/TimeLockCloneFactory.sol";
-import "../contracts/factories/FeeSplitterCloneFactory.sol";
+import "../contracts/factories/FeeDistributorCloneFactory.sol";
 import "../contracts/CoinvestedPosition.sol";
-import "../contracts/FeeSplitter.sol";
+import "../contracts/FeeDistributor.sol";
 import "../contracts/TimeLock.sol";
 import "../contracts/GlobalTokenExitRegistry.sol";
 import "./resources/CoinvestedPositionTestBase.sol";
@@ -25,7 +25,7 @@ contract CoinvestedPositionPrivateOfferTest is CoinvestedPositionTestBase {
 
     // ── Shared state ──────────────────────────────────────────────────────────
     CoinvestedPositionCloneFactory coinvestedPositionCloneFactory;
-    FeeSplitterCloneFactory feeSplitterCloneFactory;
+    FeeDistributorCloneFactory feeDistributorCloneFactory;
     PrivateOfferFactory privateOfferFactory;
 
     function setUp() public {
@@ -53,7 +53,7 @@ contract CoinvestedPositionPrivateOfferTest is CoinvestedPositionTestBase {
         CoinvestedPosition coinvestedPositionLogic = new CoinvestedPosition(TRUSTED_FORWARDER);
         coinvestedPositionCloneFactory = new CoinvestedPositionCloneFactory(address(coinvestedPositionLogic));
 
-        feeSplitterCloneFactory = new FeeSplitterCloneFactory(address(new FeeSplitter()));
+        feeDistributorCloneFactory = new FeeDistributorCloneFactory(address(new FeeDistributor()));
 
         TimeLock timeLockLogic = new TimeLock(TRUSTED_FORWARDER);
         TimeLockCloneFactory timeLockCloneFactory = new TimeLockCloneFactory(address(timeLockLogic));
@@ -163,15 +163,15 @@ contract CoinvestedPositionPrivateOfferTest is CoinvestedPositionTestBase {
     }
 
     /**
-     * @notice Demonstrates the FeeSplitter flow for paying a one-time syndicate fee:
+     * @notice Demonstrates the FeeDistributor flow for paying a one-time syndicate fee:
      *   1. A CoinvestedPosition is deployed (provides the lead investor roster)
-     *   2. Platform predicts the FeeSplitter address
-     *   3. Fee payer approves the predicted FeeSplitter for the fee amount
-     *   4. Anyone calls createFeeSplitterClone — immediately:
-     *      - FeeSplitter pulls the fee from the payer
+     *   2. Platform predicts the FeeDistributor address
+     *   3. Fee payer approves the predicted FeeDistributor for the fee amount
+     *   4. Anyone calls createFeeDistributorClone — immediately:
+     *      - FeeDistributor pulls the fee from the payer
      *      - Fee is split proportionally among lead investors by carry fraction
      */
-    function testFeeSplitter() public {
+    function testFeeDistributor() public {
         uint256 tokenAmount = 1000e18;
         uint256 tokenPrice = 100e6;
         uint256 investmentAmount = Math.ceilDiv(tokenAmount * tokenPrice, 10 ** token.decimals());
@@ -194,9 +194,9 @@ contract CoinvestedPositionPrivateOfferTest is CoinvestedPositionTestBase {
             )
         );
 
-        // ── Predict FeeSplitter address ───────────────────────────────────────
+        // ── Predict FeeDistributor address ────────────────────────────────────
 
-        address expectedFeeSplitter = feeSplitterCloneFactory.predictCloneAddress(
+        address expectedFeeDistributor = feeDistributorCloneFactory.predictCloneAddress(
             bytes32("1"),
             RECEIVER,
             IERC20(address(eurc)),
@@ -208,11 +208,11 @@ contract CoinvestedPositionPrivateOfferTest is CoinvestedPositionTestBase {
 
         eurc.mint(RECEIVER, feeAmount);
         vm.prank(RECEIVER);
-        eurc.approve(expectedFeeSplitter, feeAmount);
+        eurc.approve(expectedFeeDistributor, feeAmount);
 
-        // ── Execute: deploy FeeSplitter, which immediately distributes the fee ─
+        // ── Execute: deploy FeeDistributor, which immediately distributes the fee
 
-        address feeSplitterAddress = feeSplitterCloneFactory.createFeeSplitterClone(
+        address feeDistributorAddress = feeDistributorCloneFactory.createFeeDistributorClone(
             bytes32("1"),
             RECEIVER,
             IERC20(address(eurc)),
@@ -222,7 +222,7 @@ contract CoinvestedPositionPrivateOfferTest is CoinvestedPositionTestBase {
 
         // ── Assert ────────────────────────────────────────────────────────────
 
-        assertEq(feeSplitterAddress, expectedFeeSplitter, "FeeSplitter address mismatch");
+        assertEq(feeDistributorAddress, expectedFeeDistributor, "FeeDistributor address mismatch");
 
         uint256 profitFractionsSum = uint256(CARRY_10PCT) + uint256(CARRY_5PCT);
         uint256 LEAD_AShare = (uint256(CARRY_10PCT) * feeAmount) / profitFractionsSum;

--- a/test/CrowdinvestingCloneFactory.t.sol
+++ b/test/CrowdinvestingCloneFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/CrowdinvestingCloneFactory.t.sol
+++ b/test/CrowdinvestingCloneFactory.t.sol
@@ -470,7 +470,7 @@ contract CrowdinvestingCloneFactoryTest is Test {
             address(0)
         );
 
-        vm.expectRevert("currency needs to be on the allowlist with TRUSTED_CURRENCY attribute");
+        vm.expectRevert(UntrustedCurrency.selector);
         fundraisingFactory.createCrowdinvestingClone("salt", TRUSTED_FORWARDER, arguments);
 
         // test deployment succeeds with trusted currency

--- a/test/CrowdinvestingDynamicPricing.t.sol
+++ b/test/CrowdinvestingDynamicPricing.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/CrowdinvestingERC2771.t.sol
+++ b/test/CrowdinvestingERC2771.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/CrowdinvestingERC677.t.sol
+++ b/test/CrowdinvestingERC677.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/CrowdinvestingERC677.t.sol
+++ b/test/CrowdinvestingERC677.t.sol
@@ -269,7 +269,7 @@ contract CrowdinvestingTest is Test {
         uint256 paymentTokenBalanceBefore = paymentToken.balanceOf(BUYER);
 
         vm.prank(BUYER);
-        vm.expectRevert("Total amount of bought tokens needs to be lower than or equal to maxAmount");
+        vm.expectRevert(Crowdinvesting.MaxAmountPerBuyerExceeded.selector);
         paymentToken.transferAndCall(address(crowdinvesting), costInPaymentToken, new bytes(0));
         assertTrue(paymentToken.balanceOf(BUYER) == paymentTokenBalanceBefore);
         assertTrue(token.balanceOf(BUYER) == 0);
@@ -361,7 +361,7 @@ contract CrowdinvestingTest is Test {
             );
         } else {
             vm.startPrank(addressWithFunds);
-            vm.expectRevert("Purchase yields less tokens than demanded.");
+            vm.expectRevert(Crowdinvesting.PurchaseYieldsTooFewTokens.selector);
             paymentToken.transferAndCall(address(crowdinvesting), currencyAmount, data);
             vm.stopPrank();
         }
@@ -430,7 +430,7 @@ contract CrowdinvestingTest is Test {
         bytes memory data = abi.encode(addressForTokens, type(uint256).max);
 
         vm.startPrank(addressWithFunds);
-        vm.expectRevert("Purchase yields less tokens than demanded.");
+        vm.expectRevert(Crowdinvesting.PurchaseYieldsTooFewTokens.selector);
         paymentToken.transferAndCall(address(crowdinvesting), currencyAmount, data);
         vm.stopPrank();
     }
@@ -454,7 +454,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(person1);
         paymentToken.transferAndCall(address(crowdinvesting), amountToSpend, new bytes(0));
         vm.prank(person2);
-        vm.expectRevert("Not enough tokens to sell left");
+        vm.expectRevert(Crowdinvesting.MaxAmountOfTokenToBeSoldExceeded.selector);
         paymentToken.transferAndCall(address(crowdinvesting), amountToSpend, new bytes(0));
     }
 
@@ -484,7 +484,7 @@ contract CrowdinvestingTest is Test {
         console.log("Buying second batch of tokens");
 
         vm.startPrank(person1);
-        vm.expectRevert("Total amount of bought tokens needs to be lower than or equal to maxAmount");
+        vm.expectRevert(Crowdinvesting.MaxAmountPerBuyerExceeded.selector);
         paymentToken.transferAndCall(address(crowdinvesting), amountToPay, data);
         vm.stopPrank();
     }
@@ -535,7 +535,7 @@ contract CrowdinvestingTest is Test {
         );
 
         vm.startPrank(BUYER);
-        vm.expectRevert("Buyer needs to buy at least minAmount");
+        vm.expectRevert(Crowdinvesting.MinAmountPerBuyerNotReached.selector);
         paymentToken.transferAndCall(address(crowdinvesting), currencyAmount, new bytes(0));
         assertTrue(paymentToken.balanceOf(BUYER) == paymentTokenBalanceBefore);
         assertTrue(token.balanceOf(BUYER) == 0);
@@ -547,7 +547,7 @@ contract CrowdinvestingTest is Test {
     function testOnlyCurrencyContractCanCallOnTokenTransfer(address rando) public {
         vm.assume(rando != address(paymentToken));
         vm.prank(rando);
-        vm.expectRevert("Only currency contract can call onTokenTransfer");
+        vm.expectRevert(Crowdinvesting.OnlyCurrencyContract.selector);
         crowdinvesting.onTokenTransfer(rando, 0, new bytes(0));
     }
 }

--- a/test/CrowdinvestingIntegration.t.sol
+++ b/test/CrowdinvestingIntegration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/CrowdinvestingMint.t.sol
+++ b/test/CrowdinvestingMint.t.sol
@@ -193,68 +193,68 @@ contract CrowdinvestingTest is Test {
             address(0),
             address(0)
         );
-        vm.expectRevert("CrowdinvestingCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         Crowdinvesting(factory.createCrowdinvestingClone(0, address(0), arguments));
 
         // OWNER 0
         CrowdinvestingInitializerArguments memory tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.owner = address(0);
-        vm.expectRevert("owner can not be zero address");
+        vm.expectRevert(ZeroOwnerAddress.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // RECEIVER 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.currencyReceiver = address(0);
-        vm.expectRevert("currencyReceiver can not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // token minAmount > MAX_AMOUNT_PER_BUYER
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.minAmountPerBuyer = MAX_AMOUNT_PER_BUYER + 1;
-        vm.expectRevert("_minAmountPerBuyer needs to be smaller or equal to _maxAmountPerBuyer");
+        vm.expectRevert(Crowdinvesting.MinAmountExceedsMaxAmount.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // token minAmount 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.minAmountPerBuyer = 0;
-        vm.expectRevert("_minAmountPerBuyer needs to be larger than zero");
+        vm.expectRevert(ZeroAmount.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // PRICE 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.tokenPrice = 0;
-        vm.expectRevert("_tokenPrice needs to be a non-zero amount");
+        vm.expectRevert(ZeroPrice.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // max PRICE 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.priceMax = 0;
         tempArgs.priceOracle = address(3);
-        vm.expectRevert("priceMax needs to be larger or equal to priceBase");
+        vm.expectRevert(Crowdinvesting.PriceMaxBelowPriceBase.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // min PRICE too high
         tempArgs.priceMax = PRICE;
         tempArgs.priceMin = PRICE + 1;
-        vm.expectRevert("priceMin needs to be smaller or equal to priceBase");
+        vm.expectRevert(Crowdinvesting.PriceMinExceedsPriceBase.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // token maxAmountToBeSold 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.maxAmountOfTokenToBeSold = 0;
-        vm.expectRevert("_maxAmountOfTokenToBeSold needs to be larger than zero");
+        vm.expectRevert(ZeroAmount.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // currency 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.currency = IERC20(address(0));
-        vm.expectRevert("currency can not be zero address");
+        vm.expectRevert(ZeroCurrencyAddress.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // token 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.token = Token(address(0));
-        vm.expectRevert("token can not be zero address");
+        vm.expectRevert(ZeroTokenAddress.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
     }
 
@@ -428,7 +428,7 @@ contract CrowdinvestingTest is Test {
             assertTrue(crowdinvesting.tokensBought(BUYER) == tokenBuyAmount, "crowdinvesting has sold tokens to BUYER");
         } else {
             vm.prank(BUYER);
-            vm.expectRevert("Purchase more expensive than _maxCurrencyAmount");
+            vm.expectRevert(Crowdinvesting.PurchaseTooExpensive.selector);
             crowdinvesting.buy(tokenBuyAmount, maxCurrencyAmount, BUYER);
         }
     }
@@ -437,7 +437,7 @@ contract CrowdinvestingTest is Test {
         uint256 paymentTokenBalanceBefore = paymentToken.balanceOf(BUYER);
 
         vm.prank(BUYER);
-        vm.expectRevert("Total amount of bought tokens needs to be lower than or equal to maxAmount");
+        vm.expectRevert(Crowdinvesting.MaxAmountPerBuyerExceeded.selector);
         crowdinvesting.buy(MAX_AMOUNT_PER_BUYER + 10 ** 18, type(uint256).max, BUYER); //+ 10**token.decimals());
         assertTrue(paymentToken.balanceOf(BUYER) == paymentTokenBalanceBefore);
         assertTrue(token.balanceOf(BUYER) == 0);
@@ -505,7 +505,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(person1);
         crowdinvesting.buy(MAX_AMOUNT_OF_TOKEN_TO_BE_SOLD / 2, type(uint256).max, person1);
         vm.prank(person2);
-        vm.expectRevert("Not enough tokens to sell left");
+        vm.expectRevert(Crowdinvesting.MaxAmountOfTokenToBeSoldExceeded.selector);
         crowdinvesting.buy(10 ** 18, type(uint256).max, person2);
     }
 
@@ -529,7 +529,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(BUYER);
         crowdinvesting.buy(MAX_AMOUNT_OF_TOKEN_TO_BE_SOLD / 2, type(uint256).max, BUYER);
         vm.prank(person1);
-        vm.expectRevert("Total amount of bought tokens needs to be lower than or equal to maxAmount");
+        vm.expectRevert(Crowdinvesting.MaxAmountPerBuyerExceeded.selector);
         crowdinvesting.buy(MAX_AMOUNT_OF_TOKEN_TO_BE_SOLD / 2, type(uint256).max, BUYER);
     }
 
@@ -600,7 +600,7 @@ contract CrowdinvestingTest is Test {
         uint256 paymentTokenBalanceBefore = paymentToken.balanceOf(BUYER);
 
         vm.prank(BUYER);
-        vm.expectRevert("Buyer needs to buy at least minAmount");
+        vm.expectRevert(Crowdinvesting.MinAmountPerBuyerNotReached.selector);
         crowdinvesting.buy(MIN_AMOUNT_PER_BUYER / 2, type(uint256).max, BUYER);
         assertTrue(paymentToken.balanceOf(BUYER) == paymentTokenBalanceBefore);
         assertTrue(token.balanceOf(BUYER) == 0);
@@ -709,7 +709,7 @@ contract CrowdinvestingTest is Test {
     */
     function testBuyMoreThanMaxAmountPerBuyer() public {
         vm.prank(BUYER);
-        vm.expectRevert("Total amount of bought tokens needs to be lower than or equal to maxAmount");
+        vm.expectRevert(Crowdinvesting.MaxAmountPerBuyerExceeded.selector);
         crowdinvesting.buy(MAX_AMOUNT_PER_BUYER + 1, type(uint256).max, BUYER);
     }
 
@@ -718,7 +718,7 @@ contract CrowdinvestingTest is Test {
     */
     function testBuyLessThanMinAmountPerBuyer() public {
         vm.prank(BUYER);
-        vm.expectRevert("Buyer needs to buy at least minAmount");
+        vm.expectRevert(Crowdinvesting.MinAmountPerBuyerNotReached.selector);
         crowdinvesting.buy(MIN_AMOUNT_PER_BUYER - 1, type(uint256).max, BUYER);
     }
 
@@ -756,7 +756,7 @@ contract CrowdinvestingTest is Test {
         assertTrue(crowdinvesting.currencyReceiver() == address(BUYER));
 
         vm.prank(OWNER);
-        vm.expectRevert("receiver can not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         crowdinvesting.setCurrencyReceiver(address(0));
     }
 
@@ -785,11 +785,11 @@ contract CrowdinvestingTest is Test {
         assertTrue(crowdinvesting.minAmountPerBuyer() == newMinAmountPerBuyer);
 
         uint256 _maxAmountPerBuyer = crowdinvesting.maxAmountPerBuyer();
-        vm.expectRevert("_minAmount needs to be smaller or equal to maxAmount");
+        vm.expectRevert(Crowdinvesting.MinAmountExceedsMaxAmount.selector);
         vm.prank(OWNER);
         crowdinvesting.setMinAmountPerBuyer(_maxAmountPerBuyer + 1); //crowdinvesting.maxAmountPerBuyer() + 1);
 
-        vm.expectRevert("_minAmountPerBuyer needs to be larger than zero");
+        vm.expectRevert(ZeroAmount.selector);
         vm.prank(OWNER);
         crowdinvesting.setMinAmountPerBuyer(0); //crowdinvesting.maxAmountPerBuyer() + 1);
 
@@ -820,7 +820,7 @@ contract CrowdinvestingTest is Test {
         crowdinvesting.setMaxAmountPerBuyer(newMaxAmountPerBuyer);
         assertTrue(crowdinvesting.maxAmountPerBuyer() == newMaxAmountPerBuyer);
         uint256 _minAmountPerBuyer = crowdinvesting.minAmountPerBuyer();
-        vm.expectRevert("_maxAmount needs to be larger or equal to minAmount");
+        vm.expectRevert(Crowdinvesting.MinAmountExceedsMaxAmount.selector);
         vm.prank(OWNER);
         crowdinvesting.setMaxAmountPerBuyer(_minAmountPerBuyer - 1);
     }
@@ -856,7 +856,7 @@ contract CrowdinvestingTest is Test {
         assertTrue(crowdinvesting.priceBase() == newPrice);
         assertTrue(crowdinvesting.currency() == newPaymentToken);
         vm.prank(OWNER);
-        vm.expectRevert("_tokenPrice needs to be a non-zero amount");
+        vm.expectRevert(ZeroPrice.selector);
         crowdinvesting.setCurrencyAndTokenPrice(paymentToken, 0);
     }
 
@@ -883,7 +883,7 @@ contract CrowdinvestingTest is Test {
         crowdinvesting.setMaxAmountOfTokenToBeSold(newMaxAmountOfTokenToBeSold);
         assertTrue(crowdinvesting.maxAmountOfTokenToBeSold() == newMaxAmountOfTokenToBeSold);
         vm.prank(OWNER);
-        vm.expectRevert("_maxAmountOfTokenToBeSold needs to be larger than zero");
+        vm.expectRevert(ZeroAmount.selector);
         crowdinvesting.setMaxAmountOfTokenToBeSold(0);
     }
 
@@ -895,7 +895,7 @@ contract CrowdinvestingTest is Test {
         crowdinvesting.pause();
         assertTrue(crowdinvesting.paused());
         vm.prank(OWNER);
-        vm.expectRevert("There needs to be at minimum one day to change parameters");
+        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
         crowdinvesting.unpause();
     }
 
@@ -959,7 +959,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(OWNER);
         console.log("current time: ", block.timestamp);
         console.log("unpause at: ", startTime + changeDelay + unpauseDelay);
-        vm.expectRevert("There needs to be at minimum one day to change parameters");
+        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
         crowdinvesting.unpause(); // must fail because of the parameter update
     }
 
@@ -1013,7 +1013,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(OWNER);
         console.log("current time: ", block.timestamp);
         console.log("unpause at: ", startTime + changeDelay + unpauseDelay);
-        vm.expectRevert("There needs to be at minimum one day to change parameters");
+        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
         crowdinvesting.unpause(); // must fail because of the parameter update
     }
 
@@ -1068,7 +1068,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(OWNER);
         console.log("current time: ", block.timestamp);
         console.log("unpause at: ", startTime + changeDelay + unpauseDelay);
-        vm.expectRevert("There needs to be at minimum one day to change parameters");
+        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
         crowdinvesting.unpause(); // must fail because of the parameter update
     }
 
@@ -1122,7 +1122,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(OWNER);
         console.log("current time: ", block.timestamp);
         console.log("unpause at: ", startTime + changeDelay + unpauseDelay);
-        vm.expectRevert("There needs to be at minimum one day to change parameters");
+        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
         crowdinvesting.unpause(); // must fail because of the parameter update
     }
 
@@ -1176,7 +1176,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(OWNER);
         console.log("current time: ", block.timestamp);
         console.log("unpause at: ", startTime + changeDelay + unpauseDelay);
-        vm.expectRevert("There needs to be at minimum one day to change parameters");
+        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
         crowdinvesting.unpause(); // must fail because of the parameter update
     }
 
@@ -1252,7 +1252,7 @@ contract CrowdinvestingTest is Test {
 
         vm.startPrank(OWNER);
         crowdinvesting.pause();
-        vm.expectRevert("currency needs to be on the allowlist with TRUSTED_CURRENCY attribute");
+        vm.expectRevert(UntrustedCurrency.selector);
         crowdinvesting.setCurrencyAndTokenPrice(IERC20(someCurrency), 1);
 
         // check the settings works when the currency is on the allowlist with TRUSTED_CURRENCY attribute
@@ -1368,7 +1368,7 @@ contract CrowdinvestingTest is Test {
         console.log("LAST_BUY_DATE: ", _lastBuyDate);
 
         if (testDate > _lastBuyDate) {
-            vm.expectRevert("Last buy date has passed: not selling tokens anymore.");
+            vm.expectRevert(Crowdinvesting.LastBuyDatePassed.selector);
             vm.prank(BUYER);
             crowdinvesting.buy(tokenBuyAmount, type(uint256).max, BUYER);
         } else {
@@ -1414,7 +1414,7 @@ contract CrowdinvestingTest is Test {
             // auto-pause should trigger
             vm.startPrank(BUYER);
             paymentToken.approve(address(_crowdinvesting), type(uint256).max);
-            vm.expectRevert("Last buy date has passed: not selling tokens anymore.");
+            vm.expectRevert(Crowdinvesting.LastBuyDatePassed.selector);
             _crowdinvesting.buy(tokenBuyAmount, type(uint256).max, BUYER);
             vm.stopPrank();
         } else {
@@ -1449,7 +1449,7 @@ contract CrowdinvestingTest is Test {
         crowdinvesting.pause();
 
         vm.prank(OWNER);
-        vm.expectRevert("currency can not be zero address");
+        vm.expectRevert(ZeroCurrencyAddress.selector);
         crowdinvesting.setCurrencyAndTokenPrice(IERC20(address(0)), PRICE);
     }
 
@@ -1459,7 +1459,7 @@ contract CrowdinvestingTest is Test {
         crowdinvesting.pause();
 
         vm.prank(OWNER);
-        vm.expectRevert("lastBuyDate needs to be 0 or in the future");
+        vm.expectRevert(Crowdinvesting.LastBuyDateNotInFuture.selector);
         crowdinvesting.setLastBuyDate(999);
     }
 }

--- a/test/CrowdinvestingMint.t.sol
+++ b/test/CrowdinvestingMint.t.sol
@@ -428,7 +428,7 @@ contract CrowdinvestingTest is Test {
             assertTrue(crowdinvesting.tokensBought(BUYER) == tokenBuyAmount, "crowdinvesting has sold tokens to BUYER");
         } else {
             vm.prank(BUYER);
-            vm.expectRevert(Crowdinvesting.PurchaseTooExpensive.selector);
+            vm.expectRevert(PurchaseTooExpensive.selector);
             crowdinvesting.buy(tokenBuyAmount, maxCurrencyAmount, BUYER);
         }
     }
@@ -895,7 +895,7 @@ contract CrowdinvestingTest is Test {
         crowdinvesting.pause();
         assertTrue(crowdinvesting.paused());
         vm.prank(OWNER);
-        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
+        vm.expectRevert(CoolDownNotOver.selector);
         crowdinvesting.unpause();
     }
 
@@ -959,7 +959,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(OWNER);
         console.log("current time: ", block.timestamp);
         console.log("unpause at: ", startTime + changeDelay + unpauseDelay);
-        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
+        vm.expectRevert(CoolDownNotOver.selector);
         crowdinvesting.unpause(); // must fail because of the parameter update
     }
 
@@ -1013,7 +1013,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(OWNER);
         console.log("current time: ", block.timestamp);
         console.log("unpause at: ", startTime + changeDelay + unpauseDelay);
-        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
+        vm.expectRevert(CoolDownNotOver.selector);
         crowdinvesting.unpause(); // must fail because of the parameter update
     }
 
@@ -1068,7 +1068,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(OWNER);
         console.log("current time: ", block.timestamp);
         console.log("unpause at: ", startTime + changeDelay + unpauseDelay);
-        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
+        vm.expectRevert(CoolDownNotOver.selector);
         crowdinvesting.unpause(); // must fail because of the parameter update
     }
 
@@ -1122,7 +1122,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(OWNER);
         console.log("current time: ", block.timestamp);
         console.log("unpause at: ", startTime + changeDelay + unpauseDelay);
-        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
+        vm.expectRevert(CoolDownNotOver.selector);
         crowdinvesting.unpause(); // must fail because of the parameter update
     }
 
@@ -1176,7 +1176,7 @@ contract CrowdinvestingTest is Test {
         vm.prank(OWNER);
         console.log("current time: ", block.timestamp);
         console.log("unpause at: ", startTime + changeDelay + unpauseDelay);
-        vm.expectRevert(Crowdinvesting.CoolDownNotOver.selector);
+        vm.expectRevert(CoolDownNotOver.selector);
         crowdinvesting.unpause(); // must fail because of the parameter update
     }
 

--- a/test/CrowdinvestingMint.t.sol
+++ b/test/CrowdinvestingMint.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/CrowdinvestingMint.t.sol
+++ b/test/CrowdinvestingMint.t.sol
@@ -583,7 +583,7 @@ contract CrowdinvestingTest is Test {
         vm.stopPrank();
 
         vm.prank(BUYER);
-        vm.expectRevert("MintingAllowance too low");
+        vm.expectRevert(Token.MintingAllowanceTooLow.selector);
         crowdinvesting.buy(MAX_AMOUNT_PER_BUYER, type(uint256).max, BUYER); //+ 10**token.decimals());
         assertTrue(token.balanceOf(BUYER) == 0);
         assertTrue(paymentToken.balanceOf(RECEIVER) == 0);

--- a/test/CrowdinvestingPrice.t.sol
+++ b/test/CrowdinvestingPrice.t.sol
@@ -174,7 +174,7 @@ contract CrowdinvestingTest is Test {
         // activate dynamic pricing
         vm.startPrank(OWNER);
         crowdinvesting.pause();
-        vm.expectRevert("_priceOracle can not be zero address");
+        vm.expectRevert(Crowdinvesting.ZeroPriceOracleAddress.selector);
         crowdinvesting.activateDynamicPricing(IPriceDynamic(address(0)), PRICE_MIN, PRICE_MAX);
     }
 

--- a/test/CrowdinvestingPrice.t.sol
+++ b/test/CrowdinvestingPrice.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/CrowdinvestingTransfer.t.sol
+++ b/test/CrowdinvestingTransfer.t.sol
@@ -205,68 +205,68 @@ contract CrowdinvestingTransferTest is Test {
             address(0),
             TOKEN_HOLDER
         );
-        vm.expectRevert("CrowdinvestingCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         Crowdinvesting(factory.createCrowdinvestingClone(0, address(0), arguments));
 
         // OWNER 0
         CrowdinvestingInitializerArguments memory tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.owner = address(0);
-        vm.expectRevert("owner can not be zero address");
+        vm.expectRevert(ZeroOwnerAddress.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // RECEIVER 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.currencyReceiver = address(0);
-        vm.expectRevert("currencyReceiver can not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // token minAmount > MAX_AMOUNT_PER_BUYER
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.minAmountPerBuyer = MAX_AMOUNT_PER_BUYER + 1;
-        vm.expectRevert("_minAmountPerBuyer needs to be smaller or equal to _maxAmountPerBuyer");
+        vm.expectRevert(Crowdinvesting.MinAmountExceedsMaxAmount.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // token minAmount 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.minAmountPerBuyer = 0;
-        vm.expectRevert("_minAmountPerBuyer needs to be larger than zero");
+        vm.expectRevert(ZeroAmount.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // PRICE 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.tokenPrice = 0;
-        vm.expectRevert("_tokenPrice needs to be a non-zero amount");
+        vm.expectRevert(ZeroPrice.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // max PRICE 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.priceMax = 0;
         tempArgs.priceOracle = address(3);
-        vm.expectRevert("priceMax needs to be larger or equal to priceBase");
+        vm.expectRevert(Crowdinvesting.PriceMaxBelowPriceBase.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // min PRICE too high
         tempArgs.priceMax = PRICE;
         tempArgs.priceMin = PRICE + 1;
-        vm.expectRevert("priceMin needs to be smaller or equal to priceBase");
+        vm.expectRevert(Crowdinvesting.PriceMinExceedsPriceBase.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // token maxAmountToBeSold 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.maxAmountOfTokenToBeSold = 0;
-        vm.expectRevert("_maxAmountOfTokenToBeSold needs to be larger than zero");
+        vm.expectRevert(ZeroAmount.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // currency 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.currency = IERC20(address(0));
-        vm.expectRevert("currency can not be zero address");
+        vm.expectRevert(ZeroCurrencyAddress.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // token 0
         tempArgs = cloneCrowdinvestingInitializerArguments(arguments);
         tempArgs.token = Token(address(0));
-        vm.expectRevert("token can not be zero address");
+        vm.expectRevert(ZeroTokenAddress.selector);
         factory.createCrowdinvestingClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // TOKEN_HOLDER 0 -> this should not revert, as it is allowed to set TOKEN_HOLDER to 0
@@ -823,7 +823,7 @@ contract CrowdinvestingTransferTest is Test {
     //         vm.prank(OWNER);
     //         crowdinvesting.setMinAmountPerBuyer(_maxAmountPerBuyer + 1); //crowdinvesting.maxAmountPerBuyer() + 1);
 
-    //         vm.expectRevert("_minAmountPerBuyer needs to be larger than zero");
+    //         vm.expectRevert(ZeroAmount.selector);
     //         vm.prank(OWNER);
     //         crowdinvesting.setMinAmountPerBuyer(0); //crowdinvesting.maxAmountPerBuyer() + 1);
 
@@ -890,7 +890,7 @@ contract CrowdinvestingTransferTest is Test {
     //         assertTrue(crowdinvesting.priceBase() == newPrice);
     //         assertTrue(crowdinvesting.currency() == newPaymentToken);
     //         vm.prank(OWNER);
-    //         vm.expectRevert("_tokenPrice needs to be a non-zero amount");
+    //         vm.expectRevert(ZeroPrice.selector);
     //         crowdinvesting.setCurrencyAndTokenPrice(paymentToken, 0);
     //     }
 
@@ -917,7 +917,7 @@ contract CrowdinvestingTransferTest is Test {
     //         crowdinvesting.setMaxAmountOfTokenToBeSold(newMaxAmountOfTokenToBeSold);
     //         assertTrue(crowdinvesting.maxAmountOfTokenToBeSold() == newMaxAmountOfTokenToBeSold);
     //         vm.prank(OWNER);
-    //         vm.expectRevert("_maxAmountOfTokenToBeSold needs to be larger than zero");
+    //         vm.expectRevert(ZeroAmount.selector);
     //         crowdinvesting.setMaxAmountOfTokenToBeSold(0);
     //     }
 

--- a/test/CrowdinvestingTransfer.t.sol
+++ b/test/CrowdinvestingTransfer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/Distribution.t.sol
+++ b/test/Distribution.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";

--- a/test/Distribution.t.sol
+++ b/test/Distribution.t.sol
@@ -411,7 +411,7 @@ contract DistributionTest is Test {
     }
 
     function testDrainBeforeDeadlineReverts() public {
-        vm.expectRevert("drain not yet available");
+        vm.expectRevert(DrainNotYetAvailable.selector);
         vm.prank(OWNER);
         dist.drain(OWNER, currency);
     }
@@ -441,7 +441,7 @@ contract DistributionTest is Test {
         vm.assume(warpTo >= block.timestamp);
         vm.warp(warpTo);
         if (warpTo < lockedUntil) {
-            vm.expectRevert("drain not yet available");
+            vm.expectRevert(DrainNotYetAvailable.selector);
             vm.prank(OWNER);
             dist.drain(OWNER, currency);
         } else {

--- a/test/Distribution.t.sol
+++ b/test/Distribution.t.sol
@@ -142,7 +142,7 @@ contract DistributionTest is Test {
             lockedUntil: lockedUntil,
             initialReassignments: new Reassignment[](0)
         });
-        vm.expectRevert("currency needs to be on the allowlist with TRUSTED_CURRENCY attribute");
+        vm.expectRevert(UntrustedCurrency.selector);
         factory.createDistributionClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 
@@ -174,7 +174,7 @@ contract DistributionTest is Test {
             lockedUntil: lockedUntil,
             initialReassignments: new Reassignment[](0)
         });
-        vm.expectRevert("price must be positive");
+        vm.expectRevert(ZeroPrice.selector);
         factory.createDistributionClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 
@@ -219,7 +219,7 @@ contract DistributionTest is Test {
             lockedUntil: lockedUntil,
             initialReassignments: new Reassignment[](0)
         });
-        vm.expectRevert("snapshot has no tokens");
+        vm.expectRevert(Distribution.EmptySnapshot.selector);
         factory.createDistributionClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 
@@ -324,7 +324,7 @@ contract DistributionTest is Test {
     }
 
     function testClaimZeroEligibleReverts() public {
-        vm.expectRevert("nothing to claim");
+        vm.expectRevert(NothingToClaim.selector);
         dist.claim(RECIPIENT, 0); // address(this) has 0 snapshot balance
     }
 
@@ -339,7 +339,7 @@ contract DistributionTest is Test {
         vm.prank(HOLDER_A);
         dist.claim(HOLDER_A, 0);
         vm.prank(HOLDER_A);
-        vm.expectRevert("nothing to claim");
+        vm.expectRevert(NothingToClaim.selector);
         dist.claim(HOLDER_A, 0);
     }
 
@@ -463,7 +463,7 @@ contract DistributionTest is Test {
 
     function testReassignBeforeDeadlineReverts() public {
         uint256 amount = dist.eligible(HOLDER_A);
-        vm.expectRevert("reassignment not yet available");
+        vm.expectRevert(Distribution.ReassignmentNotYetAvailable.selector);
         vm.prank(OWNER);
         dist.reassign(HOLDER_A, HOLDER_B, amount);
     }
@@ -482,7 +482,7 @@ contract DistributionTest is Test {
         assertEq(dist.eligible(HOLDER_A), amount, "HOLDER_A eligible should be non-zero before reassign");
         assertEq(dist.eligible(HOLDER_B), 60e6, "HOLDER_B eligible should be own share before reassign");
         if (warpTo < lockedUntil) {
-            vm.expectRevert("reassignment not yet available");
+            vm.expectRevert(Distribution.ReassignmentNotYetAvailable.selector);
             vm.prank(OWNER);
             dist.reassign(HOLDER_A, HOLDER_B, amount);
             assertEq(dist.eligible(HOLDER_A), amount, "HOLDER_A eligible should be non-zero after revert");
@@ -498,21 +498,21 @@ contract DistributionTest is Test {
     function testReassignToZeroAddressReverts() public {
         vm.warp(lockedUntil);
         uint256 amount = dist.eligible(HOLDER_A);
-        vm.expectRevert("to can not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         vm.prank(OWNER);
         dist.reassign(HOLDER_A, address(0), amount);
     }
 
     function testReassignZeroAmountReverts() public {
         vm.warp(lockedUntil);
-        vm.expectRevert("amount must be positive");
+        vm.expectRevert(ZeroAmount.selector);
         vm.prank(OWNER);
         dist.reassign(HOLDER_A, HOLDER_B, 0);
     }
 
     function testReassignExceedsEligibleReverts() public {
         vm.warp(lockedUntil);
-        vm.expectRevert("amount exceeds eligible");
+        vm.expectRevert(Distribution.ReassignmentExceedsEligible.selector);
         vm.prank(OWNER);
         dist.reassign(address(42), HOLDER_B, 1); // address(42) has no balance
     }
@@ -577,7 +577,7 @@ contract DistributionTest is Test {
         vm.prank(HOLDER_A);
         dist.claim(HOLDER_A, 0); // eligible drops to 0
         vm.warp(lockedUntil);
-        vm.expectRevert("amount exceeds eligible");
+        vm.expectRevert(Distribution.ReassignmentExceedsEligible.selector);
         vm.prank(OWNER);
         dist.reassign(HOLDER_A, HOLDER_B, 1);
     }
@@ -587,7 +587,7 @@ contract DistributionTest is Test {
         uint256 amountA = dist.eligible(HOLDER_A);
         vm.prank(OWNER);
         dist.reassign(HOLDER_A, HOLDER_B, amountA);
-        vm.expectRevert("amount exceeds eligible");
+        vm.expectRevert(Distribution.ReassignmentExceedsEligible.selector);
         vm.prank(OWNER);
         dist.reassign(HOLDER_A, HOLDER_C, 1); // eligible = 0 after first reassign
     }
@@ -676,7 +676,7 @@ contract DistributionTest is Test {
         vm.prank(HOLDER_A);
         dist.claim(HOLDER_A, 0); // eligible(A) = 0
         vm.warp(lockedUntil);
-        vm.expectRevert("amount exceeds eligible");
+        vm.expectRevert(Distribution.ReassignmentExceedsEligible.selector);
         vm.prank(OWNER);
         dist.reassign(HOLDER_A, HOLDER_B, 1);
     }
@@ -695,7 +695,7 @@ contract DistributionTest is Test {
 
         // A's paidOut covers their share: A claims 0
         vm.prank(HOLDER_A);
-        vm.expectRevert("nothing to claim");
+        vm.expectRevert(NothingToClaim.selector);
         dist.claim(HOLDER_A, 0);
         assertEq(currency.balanceOf(HOLDER_A), 0, "HOLDER_A should receive nothing after full reassign");
 
@@ -890,7 +890,7 @@ contract DistributionTest is Test {
     function testClaimMinPayoutAboveEligibleReverts() public {
         uint256 expectedNet = dist.eligible(HOLDER_A);
         vm.prank(HOLDER_A);
-        vm.expectRevert("payout below minimum");
+        vm.expectRevert(PayoutBelowMinimum.selector);
         dist.claim(HOLDER_A, expectedNet + 1);
     }
 
@@ -908,7 +908,7 @@ contract DistributionTest is Test {
         Distribution d = _deployDistWithNonZeroFee();
         uint256 gross = (SUPPLY_A * PRICE_PER_TOKEN) / 1e18; // 120e6, before fee
         vm.prank(HOLDER_A);
-        vm.expectRevert("payout below minimum");
+        vm.expectRevert(PayoutBelowMinimum.selector);
         d.claim(HOLDER_A, gross); // gross > eligible() (net)
     }
 
@@ -920,7 +920,7 @@ contract DistributionTest is Test {
             dist.claim(HOLDER_A, minPayout);
             assertEq(currency.balanceOf(HOLDER_A), net, "HOLDER_A should receive eligible");
         } else {
-            vm.expectRevert("payout below minimum");
+            vm.expectRevert(PayoutBelowMinimum.selector);
             dist.claim(HOLDER_A, minPayout);
         }
     }
@@ -1061,7 +1061,7 @@ contract DistributionTest is Test {
 
         // ensure recipient cannot claim from original dist without reassignment
         vm.prank(RECIPIENT);
-        vm.expectRevert("nothing to claim");
+        vm.expectRevert(NothingToClaim.selector);
         dist.claim(RECIPIENT, 0);
 
         assertEq(currency.balanceOf(RECIPIENT), expectedRecipientCurrency, "RECIPIENT balance changed");

--- a/test/DistributionCloneFactory.t.sol
+++ b/test/DistributionCloneFactory.t.sol
@@ -330,7 +330,7 @@ contract DistributionCloneFactoryTest is Test {
         // not set on allowList → 0 bits
         DistributionInitializerArguments memory args = _baseArgs();
         args.currency = IERC20(address(badCurrency));
-        vm.expectRevert("currency needs to be on the allowlist with TRUSTED_CURRENCY attribute");
+        vm.expectRevert(UntrustedCurrency.selector);
         factory.createDistributionClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 

--- a/test/DistributionCloneFactory.t.sol
+++ b/test/DistributionCloneFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";

--- a/test/DistributionCloneFactory.t.sol
+++ b/test/DistributionCloneFactory.t.sol
@@ -222,7 +222,7 @@ contract DistributionCloneFactoryTest is Test {
         currency.mint(CURRENCY_PROVIDER, EXAMPLE_INITIAL_FUNDING);
         vm.prank(CURRENCY_PROVIDER);
         currency.approve(predicted, EXAMPLE_INITIAL_FUNDING);
-        vm.expectRevert("DistributionCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         factory.createDistributionClone(EXAMPLE_SALT, wrongForwarder, CURRENCY_PROVIDER, args, EXAMPLE_INITIAL_FUNDING);
     }
 

--- a/test/ERC2771DomainDemonstration.t.sol
+++ b/test/ERC2771DomainDemonstration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: UNLICENSED
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/Exit.t.sol
+++ b/test/Exit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";

--- a/test/Exit.t.sol
+++ b/test/Exit.t.sol
@@ -148,7 +148,7 @@ contract ExitTest is Test {
             referenceCurrencies: new IERC20[](0),
             referenceToExitRates: new uint256[](0)
         });
-        vm.expectRevert("price must be positive");
+        vm.expectRevert(ZeroPrice.selector);
         factory.createExitClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 
@@ -162,7 +162,7 @@ contract ExitTest is Test {
             referenceCurrencies: new IERC20[](0),
             referenceToExitRates: new uint256[](0)
         });
-        vm.expectRevert("lockedUntil must be in the future");
+        vm.expectRevert(LockedUntilNotInFuture.selector);
         factory.createExitClone("1", TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 
@@ -176,7 +176,7 @@ contract ExitTest is Test {
             referenceCurrencies: new IERC20[](0),
             referenceToExitRates: new uint256[](0)
         });
-        vm.expectRevert("currency and token must be different");
+        vm.expectRevert(CurrencyEqualsToken.selector);
         factory.createExitClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 
@@ -192,7 +192,7 @@ contract ExitTest is Test {
             referenceCurrencies: new IERC20[](0),
             referenceToExitRates: new uint256[](0)
         });
-        vm.expectRevert("currency needs to be on the allowlist with TRUSTED_CURRENCY attribute");
+        vm.expectRevert(UntrustedCurrency.selector);
         factory.createExitClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 
@@ -264,7 +264,7 @@ contract ExitTest is Test {
 
     function testClaimNothingRevertsWhenNoTokens() public {
         address stranger = address(42);
-        vm.expectRevert("nothing to claim");
+        vm.expectRevert(NothingToClaim.selector);
         vm.prank(stranger);
         exitContract.claim(stranger, 0);
     }
@@ -623,7 +623,7 @@ contract ExitTest is Test {
         uint256 expectedNet = TOTAL_CURRENCY;
 
         vm.prank(HOLDER);
-        vm.expectRevert("payout below minimum");
+        vm.expectRevert(PayoutBelowMinimum.selector);
         exitContract.claim(RECIPIENT, expectedNet + 1);
     }
 
@@ -645,7 +645,7 @@ contract ExitTest is Test {
         uint256 gross = (TOKEN_SUPPLY * PRICE_PER_TOKEN) / 10 ** feeToken.decimals();
 
         vm.prank(HOLDER);
-        vm.expectRevert("payout below minimum");
+        vm.expectRevert(PayoutBelowMinimum.selector);
         feeExit.claim(RECIPIENT, gross); // gross > net (gross - fee)
     }
 
@@ -665,7 +665,7 @@ contract ExitTest is Test {
         uint256 gross = (TOKEN_SUPPLY * PRICE_PER_TOKEN) / 10 ** feeToken.decimals();
 
         vm.prank(HOLDER);
-        vm.expectRevert("payout below minimum");
+        vm.expectRevert(PayoutBelowMinimum.selector);
         feeExit.claim(RECIPIENT, gross); // gross > eligible() (net)
     }
 
@@ -678,7 +678,7 @@ contract ExitTest is Test {
             exitContract.claim(RECIPIENT, minPayout);
             assertEq(currency.balanceOf(RECIPIENT), net, "RECIPIENT should receive net");
         } else {
-            vm.expectRevert("payout below minimum");
+            vm.expectRevert(PayoutBelowMinimum.selector);
             exitContract.claim(RECIPIENT, minPayout);
         }
     }
@@ -837,7 +837,7 @@ contract ExitTest is Test {
             referenceCurrencies: referenceCurrencies,
             referenceToExitRates: rates
         });
-        vm.expectRevert("referenceCurrencies and referenceToExitRates must have the same length");
+        vm.expectRevert(ArrayLengthMismatch.selector);
         factory.createExitClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 
@@ -861,7 +861,7 @@ contract ExitTest is Test {
             referenceCurrencies: referenceCurrencies,
             referenceToExitRates: rates
         });
-        vm.expectRevert("referenceToExitRate must be positive");
+        vm.expectRevert(ZeroPrice.selector);
         factory.createExitClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 
@@ -881,7 +881,7 @@ contract ExitTest is Test {
             referenceCurrencies: referenceCurrencies,
             referenceToExitRates: rates
         });
-        vm.expectRevert("referenceCurrency can not be the exit currency");
+        vm.expectRevert(Exit.ReferenceCurrencyEqualsExitCurrency.selector);
         factory.createExitClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 
@@ -938,7 +938,7 @@ contract ExitTest is Test {
         vm.prank(CURRENCY_PROVIDER);
         currency.approve(cloneAddr, TOTAL_CURRENCY);
 
-        vm.expectRevert("referenceCurrency can not be zero address");
+        vm.expectRevert(ZeroCurrencyAddress.selector);
         factory.createExitClone(bytes32("1"), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, TOTAL_CURRENCY);
     }
 }

--- a/test/Exit.t.sol
+++ b/test/Exit.t.sol
@@ -361,7 +361,7 @@ contract ExitTest is Test {
         vm.assume(timestamp < type(uint64).max - 1);
         vm.warp(timestamp);
         if (timestamp < lockedUntil) {
-            vm.expectRevert("drain not yet available");
+            vm.expectRevert(DrainNotYetAvailable.selector);
             vm.prank(OWNER);
             exitContract.drain(RECIPIENT, currency);
         } else {

--- a/test/ExitCloneFactory.t.sol
+++ b/test/ExitCloneFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../contracts/factories/TokenProxyFactory.sol";

--- a/test/ExitCloneFactory.t.sol
+++ b/test/ExitCloneFactory.t.sol
@@ -203,7 +203,7 @@ contract ExitCloneFactoryTest is Test {
         currency.mint(CURRENCY_PROVIDER, EXAMPLE_TOTAL_CURRENCY);
         vm.prank(CURRENCY_PROVIDER);
         currency.approve(predicted, EXAMPLE_TOTAL_CURRENCY);
-        vm.expectRevert("ExitCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         factory.createExitClone(EXAMPLE_SALT, wrongForwarder, CURRENCY_PROVIDER, args, EXAMPLE_TOTAL_CURRENCY);
     }
 

--- a/test/ExitCloneFactory.t.sol
+++ b/test/ExitCloneFactory.t.sol
@@ -287,7 +287,7 @@ contract ExitCloneFactoryTest is Test {
         // not on allowList → 0 attributes
         ExitInitializerArguments memory args = _baseArgs();
         args.currency = IERC20(address(badCurrency));
-        vm.expectRevert("currency needs to be on the allowlist with TRUSTED_CURRENCY attribute");
+        vm.expectRevert(UntrustedCurrency.selector);
         factory.createExitClone(bytes32(0), TRUSTED_FORWARDER, CURRENCY_PROVIDER, args, 0);
     }
 

--- a/test/FeeDistributor.t.sol
+++ b/test/FeeDistributor.t.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 
-import "../contracts/FeeSplitter.sol";
+import "../contracts/FeeDistributor.sol";
 import "../contracts/CoinvestedPosition.sol";
 import "../contracts/common/Errors.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
@@ -39,7 +39,7 @@ contract MockCoinvestedPosition {
     }
 }
 
-contract FeeSplitterTest is Test {
+contract FeeDistributorTest is Test {
     event FeeDistributed(address indexed feePayer, address indexed currency, uint256 feeAmount);
 
     // ── Well-known addresses ──────────────────────────────────────────────────
@@ -63,7 +63,7 @@ contract FeeSplitterTest is Test {
     uint256 public constant FEE_AMOUNT = 300e6; // 300 USDC
 
     // ── Shared state ──────────────────────────────────────────────────────────
-    FeeSplitter feeSplitter;
+    FeeDistributor feeDistributor;
     MockCoinvestedPosition mockPosition;
     FakePaymentToken usdc; // 6 decimals
 
@@ -80,7 +80,7 @@ contract FeeSplitterTest is Test {
     // ── setUp ─────────────────────────────────────────────────────────────────
 
     function setUp() public {
-        feeSplitter = new FeeSplitter();
+        feeDistributor = new FeeDistributor();
         mockPosition = new MockCoinvestedPosition();
 
         // USDC-like token (6 decimals)
@@ -129,10 +129,10 @@ contract FeeSplitterTest is Test {
 
     // ── Helper ────────────────────────────────────────────────────────────────
 
-    /// Approve feeSplitter for FEE_PAYER and return the approved amount.
-    function _approveFeeSplitter(uint256 amount) internal {
+    /// Approve feeDistributor for FEE_PAYER and return the approved amount.
+    function _approveFeeDistributor(uint256 amount) internal {
         vm.prank(FEE_PAYER);
-        usdc.approve(address(feeSplitter), amount);
+        usdc.approve(address(feeDistributor), amount);
     }
 
     // =========================================================================
@@ -141,48 +141,48 @@ contract FeeSplitterTest is Test {
 
     function testPayFeeZeroFeePayerReverts() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
-        vm.expectRevert(FeeSplitter.ZeroFeePayerAddress.selector);
-        feeSplitter.payFee(address(0), usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        vm.expectRevert(FeeDistributor.ZeroFeePayerAddress.selector);
+        feeDistributor.payFee(address(0), usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
     }
 
     function testPayFeeZeroCurrencyReverts() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
         vm.expectRevert(ZeroCurrencyAddress.selector);
-        feeSplitter.payFee(FEE_PAYER, IERC20(address(0)), FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, IERC20(address(0)), FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
     }
 
     function testPayFeeZeroAmountReverts() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
         vm.expectRevert(ZeroAmount.selector);
-        feeSplitter.payFee(FEE_PAYER, usdc, 0, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, 0, CoinvestedPosition(address(mockPosition)));
     }
 
     function testPayFeeZeroCoinvestedPositionReverts() public {
-        vm.expectRevert(FeeSplitter.ZeroCoinvestedPositionAddress.selector);
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(0)));
+        vm.expectRevert(FeeDistributor.ZeroCoinvestedPositionAddress.selector);
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(0)));
     }
 
     function testPayFeeNoLeadInvestorsReverts() public {
         // mockPosition has zero investors (never called addLeadInvestor)
-        _approveFeeSplitter(FEE_AMOUNT);
+        _approveFeeDistributor(FEE_AMOUNT);
         vm.expectRevert(NoLeadInvestors.selector);
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
     }
 
     function testPayFeeInsufficientAllowanceReverts() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
         // No approval → transferFrom fails
         vm.expectRevert("ERC20: insufficient allowance");
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
     }
 
     function testPayFeeInsufficientBalanceReverts() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
         uint256 tooMuch = usdc.balanceOf(FEE_PAYER) + 1;
         vm.prank(FEE_PAYER);
-        usdc.approve(address(feeSplitter), tooMuch);
+        usdc.approve(address(feeDistributor), tooMuch);
         vm.expectRevert("ERC20: transfer amount exceeds balance");
-        feeSplitter.payFee(FEE_PAYER, usdc, tooMuch, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, tooMuch, CoinvestedPosition(address(mockPosition)));
     }
 
     // =========================================================================
@@ -191,22 +191,22 @@ contract FeeSplitterTest is Test {
 
     function testSingleLeadInvestorReceivesFullFee() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
-        _approveFeeSplitter(FEE_AMOUNT);
+        _approveFeeDistributor(FEE_AMOUNT);
 
         uint256 balanceBefore = usdc.balanceOf(LEAD_A);
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
 
         // Single investor is always the "last" investor and absorbs all remaining fee.
         assertEq(usdc.balanceOf(LEAD_A), balanceBefore + FEE_AMOUNT, "single investor should receive full fee");
-        assertEq(usdc.balanceOf(address(feeSplitter)), 0, "feeSplitter should hold no residual balance");
+        assertEq(usdc.balanceOf(address(feeDistributor)), 0, "feeDistributor should hold no residual balance");
     }
 
     function testSingleLeadInvestorFeePayerBalanceDecreases() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
-        _approveFeeSplitter(FEE_AMOUNT);
+        _approveFeeDistributor(FEE_AMOUNT);
 
         uint256 payerBefore = usdc.balanceOf(FEE_PAYER);
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
 
         assertEq(usdc.balanceOf(FEE_PAYER), payerBefore - FEE_AMOUNT, "feePayer balance should decrease by feeAmount");
     }
@@ -219,9 +219,9 @@ contract FeeSplitterTest is Test {
         // Both have equal carry → each should get FEE_AMOUNT / 2 (last absorbs dust)
         mockPosition.addLeadInvestor(LEAD_A, CARRY_HALF);
         mockPosition.addLeadInvestor(LEAD_B, CARRY_HALF);
-        _approveFeeSplitter(FEE_AMOUNT);
+        _approveFeeDistributor(FEE_AMOUNT);
 
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
 
         uint256 shareA = usdc.balanceOf(LEAD_A);
         uint256 shareB = usdc.balanceOf(LEAD_B);
@@ -235,9 +235,9 @@ contract FeeSplitterTest is Test {
         // LEAD_A: 10%, LEAD_B: 5% → LEAD_A gets 2/3, LEAD_B gets 1/3 of the fee
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
         mockPosition.addLeadInvestor(LEAD_B, CARRY_5PCT);
-        _approveFeeSplitter(FEE_AMOUNT);
+        _approveFeeDistributor(FEE_AMOUNT);
 
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
 
         uint256 shareA = usdc.balanceOf(LEAD_A);
         uint256 shareB = usdc.balanceOf(LEAD_B);
@@ -252,9 +252,9 @@ contract FeeSplitterTest is Test {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
         mockPosition.addLeadInvestor(LEAD_B, CARRY_5PCT);
         mockPosition.addLeadInvestor(LEAD_C, CARRY_5PCT);
-        _approveFeeSplitter(FEE_AMOUNT);
+        _approveFeeDistributor(FEE_AMOUNT);
 
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
 
         uint256 shareA = usdc.balanceOf(LEAD_A);
         uint256 shareB = usdc.balanceOf(LEAD_B);
@@ -278,9 +278,9 @@ contract FeeSplitterTest is Test {
         uint256 tinyFee = 1;
         usdc.mint(FEE_PAYER, tinyFee);
         vm.prank(FEE_PAYER);
-        usdc.approve(address(feeSplitter), tinyFee);
+        usdc.approve(address(feeDistributor), tinyFee);
 
-        feeSplitter.payFee(FEE_PAYER, usdc, tinyFee, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, tinyFee, CoinvestedPosition(address(mockPosition)));
 
         // First investor: share = (CARRY_HALF * 1) / (CARRY_HALF + CARRY_HALF)
         //                       = CARRY_HALF / (2 * CARRY_HALF) = 0 (integer division)
@@ -298,15 +298,15 @@ contract FeeSplitterTest is Test {
 
         usdc.mint(FEE_PAYER, feeAmount);
         vm.prank(FEE_PAYER);
-        usdc.approve(address(feeSplitter), feeAmount);
+        usdc.approve(address(feeDistributor), feeAmount);
 
         uint256 payerBefore = usdc.balanceOf(FEE_PAYER);
-        feeSplitter.payFee(FEE_PAYER, usdc, feeAmount, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, feeAmount, CoinvestedPosition(address(mockPosition)));
 
         uint256 totalReceived = usdc.balanceOf(LEAD_A) + usdc.balanceOf(LEAD_B);
         assertEq(usdc.balanceOf(FEE_PAYER), payerBefore - feeAmount, "feePayer should lose exactly feeAmount");
         assertEq(totalReceived, feeAmount, "sum of shares must equal feeAmount");
-        assertEq(usdc.balanceOf(address(feeSplitter)), 0, "feeSplitter must hold no residual balance");
+        assertEq(usdc.balanceOf(address(feeDistributor)), 0, "feeDistributor must hold no residual balance");
     }
 
     // =========================================================================
@@ -315,26 +315,26 @@ contract FeeSplitterTest is Test {
 
     function testFeeDistributedEventEmitted() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
-        _approveFeeSplitter(FEE_AMOUNT);
+        _approveFeeDistributor(FEE_AMOUNT);
 
         vm.expectEmit(true, true, false, true);
         emit FeeDistributed(FEE_PAYER, address(usdc), FEE_AMOUNT);
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
     }
 
     // =========================================================================
     // Section 6 – Integration with real CoinvestedPosition
     // =========================================================================
 
-    /// Verifies FeeSplitter works end-to-end against a live CoinvestedPosition clone,
+    /// Verifies FeeDistributor works end-to-end against a live CoinvestedPosition clone,
     /// reading actual carry fractions and distributing accordingly.
     function testIntegrationWithRealCoinvestedPosition() public {
-        _approveFeeSplitter(FEE_AMOUNT);
+        _approveFeeDistributor(FEE_AMOUNT);
 
         uint256 leadABefore = usdc.balanceOf(LEAD_A);
         uint256 leadBBefore = usdc.balanceOf(LEAD_B);
 
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, realPosition);
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, realPosition);
 
         uint256 shareA = usdc.balanceOf(LEAD_A) - leadABefore;
         uint256 shareB = usdc.balanceOf(LEAD_B) - leadBBefore;
@@ -346,14 +346,14 @@ contract FeeSplitterTest is Test {
         assertApproxEqAbs(shareA, 2 * shareB, 1, "LEAD_A (10pct carry) should receive ~2x LEAD_B (5pct carry)");
     }
 
-    /// Verifies that FeeSplitter reads the live lead-investor list from the position
+    /// Verifies that FeeDistributor reads the live lead-investor list from the position
     /// contract and not from any cached state — calling payFee twice with the same mock
     /// (after mutating it between calls) should reflect the updated investor list.
     function testDistributionReflectsCurrentLeadInvestorList() public {
         // Round 1: only LEAD_A
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
-        _approveFeeSplitter(FEE_AMOUNT);
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        _approveFeeDistributor(FEE_AMOUNT);
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
         uint256 firstRoundLeadA = usdc.balanceOf(LEAD_A);
         uint256 firstRoundLeadB = usdc.balanceOf(LEAD_B);
 
@@ -363,9 +363,9 @@ contract FeeSplitterTest is Test {
         // Mutate the mock to add LEAD_B
         mockPosition.addLeadInvestor(LEAD_B, CARRY_10PCT);
         vm.prank(FEE_PAYER);
-        usdc.approve(address(feeSplitter), FEE_AMOUNT);
+        usdc.approve(address(feeDistributor), FEE_AMOUNT);
 
-        feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
+        feeDistributor.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
         uint256 secondRoundLeadA = usdc.balanceOf(LEAD_A) - firstRoundLeadA;
         uint256 secondRoundLeadB = usdc.balanceOf(LEAD_B) - firstRoundLeadB;
 

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -397,7 +397,7 @@ contract FeeSettingsTest is Test {
     }
 
     function testOwner0FailsInInitializer() public {
-        vm.expectRevert(FeeSettings.ZeroOwnerAddress.selector);
+        vm.expectRevert(ZeroOwnerAddress.selector);
         feeSettingsCloneFactory.createFeeSettingsClone("salt", TRUSTED_FORWARDER, address(0), _buildFeeTypes(ADMIN));
     }
 
@@ -675,7 +675,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_rando != ADMIN);
         vm.assume(_rando != TRUSTED_FORWARDER);
 
-        vm.expectRevert(FeeSettings.OnlyManagers.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vm.prank(_rando);
         feeSettings.setCustomFee(FeeTypes.TOKEN, someTokenAddress, 1, uint64(block.timestamp + 100));
     }
@@ -781,7 +781,7 @@ contract FeeSettingsTest is Test {
         address someTokenAddress = address(74);
         vm.assume(feeSettings.managers(_rando) == false);
         vm.assume(_rando != TRUSTED_FORWARDER);
-        vm.expectRevert(FeeSettings.OnlyManagers.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vm.prank(_rando);
         feeSettings.removeCustomFee(FeeTypes.TOKEN, someTokenAddress);
     }
@@ -1092,27 +1092,27 @@ contract FeeSettingsTest is Test {
         vm.assume(_customFeeCollector != address(0));
         vm.assume(_customFeeCollector != ADMIN);
 
-        vm.expectRevert(FeeSettings.OnlyManagers.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vm.prank(_rando);
         feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, EXAMPLE_TOKEN_ADDRESS, _customFeeCollector);
 
-        vm.expectRevert(FeeSettings.OnlyManagers.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vm.prank(_rando);
         feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, EXAMPLE_TOKEN_ADDRESS, _customFeeCollector);
 
-        vm.expectRevert(FeeSettings.OnlyManagers.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vm.prank(_rando);
         feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, EXAMPLE_TOKEN_ADDRESS, _customFeeCollector);
 
-        vm.expectRevert(FeeSettings.OnlyManagers.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vm.prank(_rando);
         feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN, EXAMPLE_TOKEN_ADDRESS);
 
-        vm.expectRevert(FeeSettings.OnlyManagers.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vm.prank(_rando);
         feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING, EXAMPLE_TOKEN_ADDRESS);
 
-        vm.expectRevert(FeeSettings.OnlyManagers.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vm.prank(_rando);
         feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER, EXAMPLE_TOKEN_ADDRESS);
     }
@@ -1132,7 +1132,7 @@ contract FeeSettingsTest is Test {
     }
 
     function testSettingCustomFeesFor0AddressReverts() public {
-        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
+        vm.expectRevert(ZeroTokenAddress.selector);
         vm.prank(ADMIN);
         feeSettings.setCustomFee(FeeTypes.TOKEN, address(0), 1, uint64(block.timestamp + 100));
     }
@@ -1218,21 +1218,21 @@ contract FeeSettingsTest is Test {
     }
 
     function testRemovingCustomFeeFor0AddressReverts() public {
-        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
+        vm.expectRevert(ZeroTokenAddress.selector);
         vm.prank(ADMIN);
         feeSettings.removeCustomFee(FeeTypes.TOKEN, address(0));
     }
 
     function testRemovingCustomFeeCollectorsFor0AddressReverts() public {
-        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
+        vm.expectRevert(ZeroTokenAddress.selector);
         vm.prank(ADMIN);
         feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN, address(0));
 
-        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
+        vm.expectRevert(ZeroTokenAddress.selector);
         vm.prank(ADMIN);
         feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING, address(0));
 
-        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
+        vm.expectRevert(ZeroTokenAddress.selector);
         vm.prank(ADMIN);
         feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER, address(0));
     }
@@ -1345,25 +1345,25 @@ contract FeeSettingsTest is Test {
 
     function testRegisterFeeTypeRevertsIfAlreadyRegistered() public {
         vm.prank(ADMIN);
-        vm.expectRevert(abi.encodeWithSelector(FeeSettings.FeeTypeAlreadyRegistered.selector, FeeTypes.TOKEN));
+        vm.expectRevert(FeeSettings.FeeTypeAlreadyRegistered.selector);
         feeSettings.registerFeeType(FeeTypes.TOKEN, 100, 50, ADMIN);
     }
 
     function testPlanFeeChangeRevertsIfUnknownFeeType() public {
         vm.prank(ADMIN);
-        vm.expectRevert(abi.encodeWithSelector(FeeSettings.UnknownFeeType.selector, keccak256("UNKNOWN_FEE_TYPE")));
+        vm.expectRevert(FeeSettings.UnknownFeeType.selector);
         feeSettings.planFeeChange(keccak256("UNKNOWN_FEE_TYPE"), 1, uint64(block.timestamp + 1));
     }
 
     function testExecuteFeeChangeRevertsIfNoPendingChange() public {
         vm.prank(ADMIN);
-        vm.expectRevert(abi.encodeWithSelector(FeeSettings.NoProposedFeeChange.selector, FeeTypes.TOKEN));
+        vm.expectRevert(FeeSettings.NoProposedFeeChange.selector);
         feeSettings.executeFeeChange(FeeTypes.TOKEN);
     }
 
     function testSetCustomFeeRevertsIfUnknownFeeType() public {
         vm.prank(ADMIN);
-        vm.expectRevert(abi.encodeWithSelector(FeeSettings.UnknownFeeType.selector, keccak256("UNKNOWN_FEE_TYPE")));
+        vm.expectRevert(FeeSettings.UnknownFeeType.selector);
         feeSettings.setCustomFee(
             keccak256("UNKNOWN_FEE_TYPE"),
             EXAMPLE_TOKEN_ADDRESS,
@@ -1386,19 +1386,19 @@ contract FeeSettingsTest is Test {
 
     function testSetDefaultFeeCollectorRevertsIfUnknownFeeType() public {
         vm.prank(ADMIN);
-        vm.expectRevert(abi.encodeWithSelector(FeeSettings.UnknownFeeType.selector, keccak256("UNKNOWN_FEE_TYPE")));
+        vm.expectRevert(FeeSettings.UnknownFeeType.selector);
         feeSettings.setDefaultFeeCollector(keccak256("UNKNOWN_FEE_TYPE"), ADMIN);
     }
 
     function testSetCustomFeeCollectorRevertsIfUnknownFeeType() public {
         vm.prank(ADMIN);
-        vm.expectRevert(abi.encodeWithSelector(FeeSettings.UnknownFeeType.selector, keccak256("UNKNOWN_FEE_TYPE")));
+        vm.expectRevert(FeeSettings.UnknownFeeType.selector);
         feeSettings.setCustomFeeCollector(keccak256("UNKNOWN_FEE_TYPE"), EXAMPLE_TOKEN_ADDRESS, ADMIN);
     }
 
     function testSetCustomFeeCollectorRevertsIfTokenZero() public {
         vm.prank(ADMIN);
-        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
+        vm.expectRevert(ZeroTokenAddress.selector);
         feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, address(0), ADMIN);
     }
 }

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/FeeSettings.t.sol
+++ b/test/FeeSettings.t.sol
@@ -79,7 +79,7 @@ contract FeeSettingsTest is Test {
         {
             FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
             feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, numerator, ADMIN);
-            vm.expectRevert("default exceeds max");
+            vm.expectRevert(FeeSettings.DefaultNumeratorExceedsMax.selector);
             feeSettingsCloneFactory.createFeeSettingsClone("salt", TRUSTED_FORWARDER, ADMIN, feeType);
         }
 
@@ -88,7 +88,7 @@ contract FeeSettingsTest is Test {
             FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
             feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, numerator, ADMIN);
             if (!crowdinvestingFeeInValidRange(numerator)) {
-                vm.expectRevert("default exceeds max");
+                vm.expectRevert(FeeSettings.DefaultNumeratorExceedsMax.selector);
                 feeSettingsCloneFactory.createFeeSettingsClone("salt", TRUSTED_FORWARDER, ADMIN, feeType);
             } else {
                 // this should not revert, as the fee is in valid range for crowdinvesting
@@ -100,7 +100,7 @@ contract FeeSettingsTest is Test {
         {
             FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
             feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, numerator, ADMIN);
-            vm.expectRevert("default exceeds max");
+            vm.expectRevert(FeeSettings.DefaultNumeratorExceedsMax.selector);
             feeSettingsCloneFactory.createFeeSettingsClone("salt", TRUSTED_FORWARDER, ADMIN, feeType);
         }
     }
@@ -109,7 +109,7 @@ contract FeeSettingsTest is Test {
         vm.assume(denominator > 0);
         vm.assume(!tokenOrPrivateOfferFeeInValidRange(numerator));
 
-        vm.expectRevert("exceeds max numerator");
+        vm.expectRevert(FeeSettings.NumeratorExceedsMax.selector);
         vm.prank(ADMIN);
         feeSettings.planFeeChange(FeeTypes.TOKEN, numerator, uint64(block.timestamp + 7884001));
     }
@@ -118,7 +118,7 @@ contract FeeSettingsTest is Test {
         vm.assume(denominator > 0);
         vm.assume(!crowdinvestingFeeInValidRange(numerator));
 
-        vm.expectRevert("exceeds max numerator");
+        vm.expectRevert(FeeSettings.NumeratorExceedsMax.selector);
         vm.prank(ADMIN);
         feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, numerator, uint64(block.timestamp + 7884001));
     }
@@ -127,7 +127,7 @@ contract FeeSettingsTest is Test {
         vm.assume(denominator > 0);
         vm.assume(!tokenOrPrivateOfferFeeInValidRange(numerator));
 
-        vm.expectRevert("exceeds max numerator");
+        vm.expectRevert(FeeSettings.NumeratorExceedsMax.selector);
         vm.prank(ADMIN);
         feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, numerator, uint64(block.timestamp + 7884001));
     }
@@ -146,15 +146,15 @@ contract FeeSettingsTest is Test {
         );
 
         vm.prank(ADMIN);
-        vm.expectRevert("fee increase needs 12 week delay");
+        vm.expectRevert(FeeSettings.FeeIncreaseNeedsDelay.selector);
         _feeSettings.planFeeChange(FeeTypes.TOKEN, newNumerator, uint64(block.timestamp + delay));
 
         vm.prank(ADMIN);
-        vm.expectRevert("fee increase needs 12 week delay");
+        vm.expectRevert(FeeSettings.FeeIncreaseNeedsDelay.selector);
         _feeSettings.planFeeChange(FeeTypes.CROWDINVESTING, newNumerator, uint64(block.timestamp + delay));
 
         vm.prank(ADMIN);
-        vm.expectRevert("fee increase needs 12 week delay");
+        vm.expectRevert(FeeSettings.FeeIncreaseNeedsDelay.selector);
         _feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, newNumerator, uint64(block.timestamp + delay));
     }
 
@@ -176,7 +176,7 @@ contract FeeSettingsTest is Test {
         feeSettings.planFeeChange(FeeTypes.PRIVATE_OFFER, investmentFeeNumerator, activationDate);
 
         vm.prank(ADMIN);
-        vm.expectRevert("activation date not reached");
+        vm.expectRevert(FeeSettings.ActivationDateNotReached.selector);
         vm.warp(activationDate - 1);
         feeSettings.executeFeeChange(FeeTypes.TOKEN);
     }
@@ -279,7 +279,7 @@ contract FeeSettingsTest is Test {
         assertEq(_privateOfferFeeNumerator, 0, "PrivateOffer fee numerator mismatch");
 
         vm.prank(ADMIN);
-        vm.expectRevert("fee increase needs 12 week delay");
+        vm.expectRevert(FeeSettings.FeeIncreaseNeedsDelay.selector);
         _feeSettings.planFeeChange(FeeTypes.TOKEN, 1, 0);
     }
 
@@ -371,7 +371,7 @@ contract FeeSettingsTest is Test {
         {
             FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
             feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.TOKEN, 500, 1, address(0));
-            vm.expectRevert("Fee collector cannot be 0x0");
+            vm.expectRevert(FeeSettings.ZeroCollectorAddress.selector);
             _feeSettings = FeeSettings(
                 feeSettingsCloneFactory.createFeeSettingsClone("salt", TRUSTED_FORWARDER, ADMIN, feeType)
             );
@@ -380,7 +380,7 @@ contract FeeSettingsTest is Test {
         {
             FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
             feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.CROWDINVESTING, 1000, 2, address(0));
-            vm.expectRevert("Fee collector cannot be 0x0");
+            vm.expectRevert(FeeSettings.ZeroCollectorAddress.selector);
             _feeSettings = FeeSettings(
                 feeSettingsCloneFactory.createFeeSettingsClone("salt", TRUSTED_FORWARDER, ADMIN, feeType)
             );
@@ -389,7 +389,7 @@ contract FeeSettingsTest is Test {
         {
             FeeSettings.FeeTypeInit[] memory feeType = new FeeSettings.FeeTypeInit[](1);
             feeType[0] = FeeSettings.FeeTypeInit(FeeTypes.PRIVATE_OFFER, 500, 3, address(0));
-            vm.expectRevert("Fee collector cannot be 0x0");
+            vm.expectRevert(FeeSettings.ZeroCollectorAddress.selector);
             _feeSettings = FeeSettings(
                 feeSettingsCloneFactory.createFeeSettingsClone("salt", TRUSTED_FORWARDER, ADMIN, feeType)
             );
@@ -397,18 +397,18 @@ contract FeeSettingsTest is Test {
     }
 
     function testOwner0FailsInInitializer() public {
-        vm.expectRevert("owner can not be zero address");
+        vm.expectRevert(FeeSettings.ZeroOwnerAddress.selector);
         feeSettingsCloneFactory.createFeeSettingsClone("salt", TRUSTED_FORWARDER, address(0), _buildFeeTypes(ADMIN));
     }
 
     function testFeeCollector0FailsInSetter() public {
-        vm.expectRevert("collector cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroCollectorAddress.selector);
         vm.prank(ADMIN);
         feeSettings.setDefaultFeeCollector(FeeTypes.TOKEN, address(0));
-        vm.expectRevert("collector cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroCollectorAddress.selector);
         vm.prank(ADMIN);
         feeSettings.setDefaultFeeCollector(FeeTypes.CROWDINVESTING, address(0));
-        vm.expectRevert("collector cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroCollectorAddress.selector);
         vm.prank(ADMIN);
         feeSettings.setDefaultFeeCollector(FeeTypes.PRIVATE_OFFER, address(0));
     }
@@ -675,7 +675,7 @@ contract FeeSettingsTest is Test {
         vm.assume(_rando != ADMIN);
         vm.assume(_rando != TRUSTED_FORWARDER);
 
-        vm.expectRevert("Only managers can call this function");
+        vm.expectRevert(FeeSettings.OnlyManagers.selector);
         vm.prank(_rando);
         feeSettings.setCustomFee(FeeTypes.TOKEN, someTokenAddress, 1, uint64(block.timestamp + 100));
     }
@@ -781,7 +781,7 @@ contract FeeSettingsTest is Test {
         address someTokenAddress = address(74);
         vm.assume(feeSettings.managers(_rando) == false);
         vm.assume(_rando != TRUSTED_FORWARDER);
-        vm.expectRevert("Only managers can call this function");
+        vm.expectRevert(FeeSettings.OnlyManagers.selector);
         vm.prank(_rando);
         feeSettings.removeCustomFee(FeeTypes.TOKEN, someTokenAddress);
     }
@@ -1092,47 +1092,47 @@ contract FeeSettingsTest is Test {
         vm.assume(_customFeeCollector != address(0));
         vm.assume(_customFeeCollector != ADMIN);
 
-        vm.expectRevert("Only managers can call this function");
+        vm.expectRevert(FeeSettings.OnlyManagers.selector);
         vm.prank(_rando);
         feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, EXAMPLE_TOKEN_ADDRESS, _customFeeCollector);
 
-        vm.expectRevert("Only managers can call this function");
+        vm.expectRevert(FeeSettings.OnlyManagers.selector);
         vm.prank(_rando);
         feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, EXAMPLE_TOKEN_ADDRESS, _customFeeCollector);
 
-        vm.expectRevert("Only managers can call this function");
+        vm.expectRevert(FeeSettings.OnlyManagers.selector);
         vm.prank(_rando);
         feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, EXAMPLE_TOKEN_ADDRESS, _customFeeCollector);
 
-        vm.expectRevert("Only managers can call this function");
+        vm.expectRevert(FeeSettings.OnlyManagers.selector);
         vm.prank(_rando);
         feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN, EXAMPLE_TOKEN_ADDRESS);
 
-        vm.expectRevert("Only managers can call this function");
+        vm.expectRevert(FeeSettings.OnlyManagers.selector);
         vm.prank(_rando);
         feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING, EXAMPLE_TOKEN_ADDRESS);
 
-        vm.expectRevert("Only managers can call this function");
+        vm.expectRevert(FeeSettings.OnlyManagers.selector);
         vm.prank(_rando);
         feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER, EXAMPLE_TOKEN_ADDRESS);
     }
 
     function testSettingCustomFeeCollectorFor0AddressReverts() public {
-        vm.expectRevert("collector cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroCollectorAddress.selector);
         vm.prank(ADMIN);
         feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, EXAMPLE_TOKEN_ADDRESS, address(0));
 
-        vm.expectRevert("collector cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroCollectorAddress.selector);
         vm.prank(ADMIN);
         feeSettings.setCustomFeeCollector(FeeTypes.CROWDINVESTING, EXAMPLE_TOKEN_ADDRESS, address(0));
 
-        vm.expectRevert("collector cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroCollectorAddress.selector);
         vm.prank(ADMIN);
         feeSettings.setCustomFeeCollector(FeeTypes.PRIVATE_OFFER, EXAMPLE_TOKEN_ADDRESS, address(0));
     }
 
     function testSettingCustomFeesFor0AddressReverts() public {
-        vm.expectRevert("token cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
         vm.prank(ADMIN);
         feeSettings.setCustomFee(FeeTypes.TOKEN, address(0), 1, uint64(block.timestamp + 100));
     }
@@ -1218,21 +1218,21 @@ contract FeeSettingsTest is Test {
     }
 
     function testRemovingCustomFeeFor0AddressReverts() public {
-        vm.expectRevert("token cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
         vm.prank(ADMIN);
         feeSettings.removeCustomFee(FeeTypes.TOKEN, address(0));
     }
 
     function testRemovingCustomFeeCollectorsFor0AddressReverts() public {
-        vm.expectRevert("token cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
         vm.prank(ADMIN);
         feeSettings.removeCustomFeeCollector(FeeTypes.TOKEN, address(0));
 
-        vm.expectRevert("token cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
         vm.prank(ADMIN);
         feeSettings.removeCustomFeeCollector(FeeTypes.CROWDINVESTING, address(0));
 
-        vm.expectRevert("token cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
         vm.prank(ADMIN);
         feeSettings.removeCustomFeeCollector(FeeTypes.PRIVATE_OFFER, address(0));
     }
@@ -1276,7 +1276,7 @@ contract FeeSettingsTest is Test {
         vm.assume(feeType != bytes32(0));
         vm.assume(maxNumerator >= feeSettings.FEE_DENOMINATOR());
 
-        vm.expectRevert("maxNumerator too large");
+        vm.expectRevert(FeeSettings.MaxNumeratorTooLarge.selector);
         vm.prank(ADMIN);
         feeSettings.registerFeeType(feeType, maxNumerator, 0, ADMIN);
     }
@@ -1333,37 +1333,37 @@ contract FeeSettingsTest is Test {
 
     function testRegisterFeeTypeRevertsIfFeeTypeZero() public {
         vm.prank(ADMIN);
-        vm.expectRevert("feeType cannot be 0");
+        vm.expectRevert(FeeSettings.ZeroFeeType.selector);
         feeSettings.registerFeeType(bytes32(0), 100, 50, ADMIN);
     }
 
     function testRegisterFeeTypeRevertsIfMaxNumeratorZero() public {
         vm.prank(ADMIN);
-        vm.expectRevert("maxNumerator cannot be 0");
+        vm.expectRevert(FeeSettings.ZeroMaxNumerator.selector);
         feeSettings.registerFeeType(keccak256("NEW_FEE_TYPE"), 0, 0, ADMIN);
     }
 
     function testRegisterFeeTypeRevertsIfAlreadyRegistered() public {
         vm.prank(ADMIN);
-        vm.expectRevert("fee type already registered");
+        vm.expectRevert(abi.encodeWithSelector(FeeSettings.FeeTypeAlreadyRegistered.selector, FeeTypes.TOKEN));
         feeSettings.registerFeeType(FeeTypes.TOKEN, 100, 50, ADMIN);
     }
 
     function testPlanFeeChangeRevertsIfUnknownFeeType() public {
         vm.prank(ADMIN);
-        vm.expectRevert("unknown fee type");
+        vm.expectRevert(abi.encodeWithSelector(FeeSettings.UnknownFeeType.selector, keccak256("UNKNOWN_FEE_TYPE")));
         feeSettings.planFeeChange(keccak256("UNKNOWN_FEE_TYPE"), 1, uint64(block.timestamp + 1));
     }
 
     function testExecuteFeeChangeRevertsIfNoPendingChange() public {
         vm.prank(ADMIN);
-        vm.expectRevert("no proposed fee change");
+        vm.expectRevert(abi.encodeWithSelector(FeeSettings.NoProposedFeeChange.selector, FeeTypes.TOKEN));
         feeSettings.executeFeeChange(FeeTypes.TOKEN);
     }
 
     function testSetCustomFeeRevertsIfUnknownFeeType() public {
         vm.prank(ADMIN);
-        vm.expectRevert("unknown fee type");
+        vm.expectRevert(abi.encodeWithSelector(FeeSettings.UnknownFeeType.selector, keccak256("UNKNOWN_FEE_TYPE")));
         feeSettings.setCustomFee(
             keccak256("UNKNOWN_FEE_TYPE"),
             EXAMPLE_TOKEN_ADDRESS,
@@ -1374,31 +1374,31 @@ contract FeeSettingsTest is Test {
 
     function testSetCustomFeeRevertsIfNumeratorExceedsMax() public {
         vm.prank(ADMIN);
-        vm.expectRevert("numerator exceeds max");
+        vm.expectRevert(FeeSettings.NumeratorExceedsMax.selector);
         feeSettings.setCustomFee(FeeTypes.TOKEN, EXAMPLE_TOKEN_ADDRESS, 501, uint64(block.timestamp + 1 days));
     }
 
     function testSetCustomFeeRevertsIfValidityDateInPast() public {
         vm.prank(ADMIN);
-        vm.expectRevert("validity date must be in the future");
+        vm.expectRevert(FeeSettings.ValidityDateNotInFuture.selector);
         feeSettings.setCustomFee(FeeTypes.TOKEN, EXAMPLE_TOKEN_ADDRESS, 1, uint64(block.timestamp));
     }
 
     function testSetDefaultFeeCollectorRevertsIfUnknownFeeType() public {
         vm.prank(ADMIN);
-        vm.expectRevert("unknown fee type");
+        vm.expectRevert(abi.encodeWithSelector(FeeSettings.UnknownFeeType.selector, keccak256("UNKNOWN_FEE_TYPE")));
         feeSettings.setDefaultFeeCollector(keccak256("UNKNOWN_FEE_TYPE"), ADMIN);
     }
 
     function testSetCustomFeeCollectorRevertsIfUnknownFeeType() public {
         vm.prank(ADMIN);
-        vm.expectRevert("unknown fee type");
+        vm.expectRevert(abi.encodeWithSelector(FeeSettings.UnknownFeeType.selector, keccak256("UNKNOWN_FEE_TYPE")));
         feeSettings.setCustomFeeCollector(keccak256("UNKNOWN_FEE_TYPE"), EXAMPLE_TOKEN_ADDRESS, ADMIN);
     }
 
     function testSetCustomFeeCollectorRevertsIfTokenZero() public {
         vm.prank(ADMIN);
-        vm.expectRevert("token cannot be 0x0");
+        vm.expectRevert(FeeSettings.ZeroTokenAddress.selector);
         feeSettings.setCustomFeeCollector(FeeTypes.TOKEN, address(0), ADMIN);
     }
 }

--- a/test/FeeSettingsCloneFactory.t.sol
+++ b/test/FeeSettingsCloneFactory.t.sol
@@ -278,7 +278,7 @@ contract tokenTest is Test {
     }
 
     function testPrivateOfferFactoryRevertsIfTimeLockFactoryZero() public {
-        vm.expectRevert("TimeLockCloneFactory must not be 0");
+        vm.expectRevert(PrivateOfferFactory.ZeroTimeLockCloneFactoryAddress.selector);
         new PrivateOfferFactory(TimeLockCloneFactory(address(0)), CoinvestedPositionCloneFactory(address(1)));
     }
 }

--- a/test/FeeSettingsCloneFactory.t.sol
+++ b/test/FeeSettingsCloneFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/FeeSettingsCloneFactory.t.sol
+++ b/test/FeeSettingsCloneFactory.t.sol
@@ -273,7 +273,7 @@ contract tokenTest is Test {
 
         FeeSettings.FeeTypeInit[] memory feeTypes = _buildFeeTypesAllSame(1, 2, 3, EXAMPLE_TOKEN_FEE_COLLECTOR);
 
-        vm.expectRevert("FeeSettingsCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         factory.createFeeSettingsClone(bytes32(0), _wrongTrustedForwarder, EXAMPLE_OWNER, feeTypes);
     }
 

--- a/test/FeeSettingsERC2771.t.sol
+++ b/test/FeeSettingsERC2771.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/FeeSettingsIntegration.t.sol
+++ b/test/FeeSettingsIntegration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/FeeSplitter.t.sol
+++ b/test/FeeSplitter.t.sol
@@ -141,13 +141,13 @@ contract FeeSplitterTest is Test {
 
     function testPayFeeZeroFeePayerReverts() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
-        vm.expectRevert(ZeroAddress.selector);
+        vm.expectRevert(FeeSplitter.ZeroFeePayerAddress.selector);
         feeSplitter.payFee(address(0), usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
     }
 
     function testPayFeeZeroCurrencyReverts() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
-        vm.expectRevert(ZeroAddress.selector);
+        vm.expectRevert(ZeroCurrencyAddress.selector);
         feeSplitter.payFee(FEE_PAYER, IERC20(address(0)), FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
     }
 
@@ -158,7 +158,7 @@ contract FeeSplitterTest is Test {
     }
 
     function testPayFeeZeroCoinvestedPositionReverts() public {
-        vm.expectRevert(ZeroAddress.selector);
+        vm.expectRevert(FeeSplitter.ZeroCoinvestedPositionAddress.selector);
         feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(0)));
     }
 

--- a/test/FeeSplitter.t.sol
+++ b/test/FeeSplitter.t.sol
@@ -5,6 +5,7 @@ import "../lib/forge-std/src/Test.sol";
 
 import "../contracts/FeeSplitter.sol";
 import "../contracts/CoinvestedPosition.sol";
+import "../contracts/common/Errors.sol";
 import "../contracts/factories/TokenProxyFactory.sol";
 import "../contracts/factories/CoinvestedPositionCloneFactory.sol";
 import "../contracts/FeeSettings.sol";
@@ -140,31 +141,31 @@ contract FeeSplitterTest is Test {
 
     function testPayFeeZeroFeePayerReverts() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
-        vm.expectRevert("feePayer can not be zero address");
+        vm.expectRevert(ZeroAddress.selector);
         feeSplitter.payFee(address(0), usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
     }
 
     function testPayFeeZeroCurrencyReverts() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
-        vm.expectRevert("currency can not be zero address");
+        vm.expectRevert(ZeroAddress.selector);
         feeSplitter.payFee(FEE_PAYER, IERC20(address(0)), FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
     }
 
     function testPayFeeZeroAmountReverts() public {
         mockPosition.addLeadInvestor(LEAD_A, CARRY_10PCT);
-        vm.expectRevert("feeAmount can not be zero");
+        vm.expectRevert(ZeroAmount.selector);
         feeSplitter.payFee(FEE_PAYER, usdc, 0, CoinvestedPosition(address(mockPosition)));
     }
 
     function testPayFeeZeroCoinvestedPositionReverts() public {
-        vm.expectRevert("coinvestedPosition can not be zero address");
+        vm.expectRevert(ZeroAddress.selector);
         feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(0)));
     }
 
     function testPayFeeNoLeadInvestorsReverts() public {
         // mockPosition has zero investors (never called addLeadInvestor)
         _approveFeeSplitter(FEE_AMOUNT);
-        vm.expectRevert("no lead investors");
+        vm.expectRevert(FeeSplitter.NoLeadInvestors.selector);
         feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
     }
 

--- a/test/FeeSplitter.t.sol
+++ b/test/FeeSplitter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 

--- a/test/FeeSplitter.t.sol
+++ b/test/FeeSplitter.t.sol
@@ -165,7 +165,7 @@ contract FeeSplitterTest is Test {
     function testPayFeeNoLeadInvestorsReverts() public {
         // mockPosition has zero investors (never called addLeadInvestor)
         _approveFeeSplitter(FEE_AMOUNT);
-        vm.expectRevert(FeeSplitter.NoLeadInvestors.selector);
+        vm.expectRevert(NoLeadInvestors.selector);
         feeSplitter.payFee(FEE_PAYER, usdc, FEE_AMOUNT, CoinvestedPosition(address(mockPosition)));
     }
 

--- a/test/GlobalTokenExitRegistry.t.sol
+++ b/test/GlobalTokenExitRegistry.t.sol
@@ -94,7 +94,7 @@ contract GlobalTokenExitRegistryTest is Test {
         address fakeExit = makeAddr("fakeExit");
 
         vm.prank(NON_ADMIN);
-        vm.expectRevert("caller is not token admin or owner");
+        vm.expectRevert(GlobalTokenExitRegistry.NotTokenAdminOrOwner.selector);
         registry.setExit(token, Exit(address(fakeExit)));
     }
 
@@ -102,13 +102,13 @@ contract GlobalTokenExitRegistryTest is Test {
         address fakeExit = makeAddr("fakeExit");
 
         vm.prank(ADMIN);
-        vm.expectRevert("token can not be zero address");
+        vm.expectRevert(ZeroTokenAddress.selector);
         registry.setExit(Token(address(0)), Exit(address(fakeExit)));
     }
 
     function testSetExitRevertsIfExitIsZeroAddress() public {
         vm.prank(ADMIN);
-        vm.expectRevert("exit can not be zero address");
+        vm.expectRevert(GlobalTokenExitRegistry.ZeroExitAddress.selector);
         registry.setExit(token, Exit(address(0)));
     }
 
@@ -120,7 +120,7 @@ contract GlobalTokenExitRegistryTest is Test {
         registry.setExit(token, Exit(address(fakeExit1)));
 
         vm.prank(ADMIN);
-        vm.expectRevert("exit has already been set");
+        vm.expectRevert(GlobalTokenExitRegistry.ExitAlreadySet.selector);
         registry.setExit(token, Exit(address(fakeExit2)));
     }
 
@@ -155,7 +155,7 @@ contract GlobalTokenExitRegistryTest is Test {
         address fakeExit = makeAddr("fakeExit");
 
         vm.prank(NON_ADMIN);
-        vm.expectRevert("caller is not token admin or owner");
+        vm.expectRevert(GlobalTokenExitRegistry.NotTokenAdminOrOwner.selector);
         registry.setExit(Token(address(ownableToken)), Exit(address(fakeExit)));
     }
 
@@ -194,7 +194,7 @@ contract GlobalTokenExitRegistryTest is Test {
         vm.assume(!token.hasRole(token.DEFAULT_ADMIN_ROLE(), caller));
         address fakeExit = makeAddr("fakeExit");
         vm.prank(caller);
-        vm.expectRevert("caller is not token admin or owner");
+        vm.expectRevert(GlobalTokenExitRegistry.NotTokenAdminOrOwner.selector);
         registry.setExit(token, Exit(address(fakeExit)));
     }
 

--- a/test/GlobalTokenExitRegistry.t.sol
+++ b/test/GlobalTokenExitRegistry.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 

--- a/test/IFeeSettings.t.sol
+++ b/test/IFeeSettings.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/MainnetCurrenciesInvest.t.sol
+++ b/test/MainnetCurrenciesInvest.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/MainnetCurrenciesPermit.t.sol
+++ b/test/MainnetCurrenciesPermit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/PaymentSplitter.t.sol
+++ b/test/PaymentSplitter.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/PriceLinear.t.sol
+++ b/test/PriceLinear.t.sol
@@ -281,7 +281,7 @@ contract PriceLinearTest is Test {
         oracle.updateParameters(1, 1, uint64(block.timestamp + 1), 1, false, true);
 
         vm.warp(block.timestamp + testDelay);
-        vm.expectRevert("PriceLinear: cool down period not over yet");
+        vm.expectRevert(PriceLinear.CoolDownNotOver.selector);
         oracle.getPrice(7e18);
 
         vm.warp(block.timestamp + testDelay + 1 hours + 1); // this is definitely after the cool down period
@@ -290,7 +290,7 @@ contract PriceLinearTest is Test {
 
     function testCreateWithParameters0() public {
         // owner 0
-        vm.expectRevert("owner can not be zero address");
+        vm.expectRevert(ZeroOwnerAddress.selector);
         PriceLinear(
             priceLinearCloneFactory.createPriceLinearClone(
                 bytes32(uint256(0)),
@@ -306,7 +306,7 @@ contract PriceLinearTest is Test {
         );
 
         // slopeEnumerator 0
-        vm.expectRevert("slopeEnumerator can not be zero");
+        vm.expectRevert(PriceLinear.ZeroSlopeEnumerator.selector);
         PriceLinear(
             priceLinearCloneFactory.createPriceLinearClone(
                 bytes32(uint256(0)),
@@ -322,7 +322,7 @@ contract PriceLinearTest is Test {
         );
 
         // slopeDenominator 0
-        vm.expectRevert("slopeDenominator can not be zero");
+        vm.expectRevert(PriceLinear.ZeroSlopeDenominator.selector);
         PriceLinear(
             priceLinearCloneFactory.createPriceLinearClone(
                 bytes32(uint256(0)),
@@ -338,7 +338,7 @@ contract PriceLinearTest is Test {
         );
 
         // stepDuration 0
-        vm.expectRevert("stepDuration can not be zero");
+        vm.expectRevert(PriceLinear.ZeroStepDuration.selector);
         PriceLinear(
             priceLinearCloneFactory.createPriceLinearClone(
                 bytes32(uint256(0)),
@@ -361,7 +361,7 @@ contract PriceLinearTest is Test {
         // check time-based start
         if (_start <= _currentTime) {
             console.log("time based start must revert");
-            vm.expectRevert("start must be in the future");
+            vm.expectRevert(PriceLinear.StartNotInFuture.selector);
             PriceLinear(
                 priceLinearCloneFactory.createPriceLinearClone(
                     bytes32(uint256(734)),
@@ -395,7 +395,7 @@ contract PriceLinearTest is Test {
         // check block-based start
         if (_start <= _currentBlock) {
             console.log("block based start must revert");
-            vm.expectRevert("start must be in the future");
+            vm.expectRevert(PriceLinear.StartNotInFuture.selector);
             PriceLinear(
                 priceLinearCloneFactory.createPriceLinearClone(
                     bytes32(uint256(734)),

--- a/test/PriceLinear.t.sol
+++ b/test/PriceLinear.t.sol
@@ -281,7 +281,7 @@ contract PriceLinearTest is Test {
         oracle.updateParameters(1, 1, uint64(block.timestamp + 1), 1, false, true);
 
         vm.warp(block.timestamp + testDelay);
-        vm.expectRevert(PriceLinear.CoolDownNotOver.selector);
+        vm.expectRevert(CoolDownNotOver.selector);
         oracle.getPrice(7e18);
 
         vm.warp(block.timestamp + testDelay + 1 hours + 1); // this is definitely after the cool down period

--- a/test/PriceLinear.t.sol
+++ b/test/PriceLinear.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/PriceLinearCloneFactory.t.sol
+++ b/test/PriceLinearCloneFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/PriceLinearCloneFactory.t.sol
+++ b/test/PriceLinearCloneFactory.t.sol
@@ -81,7 +81,7 @@ contract PriceLinearCloneFactoryTest is Test {
         vm.assume(_wrongTrustedForwarder != address(0));
 
         // using a different trustedForwarder should fail
-        vm.expectRevert("PriceLinearCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         factory.createPriceLinearClone(
             bytes32(uint256(0)),
             _wrongTrustedForwarder,

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -305,28 +305,28 @@ contract PrivateOfferTest is Test {
     function testRevertZeroCurrencyPayer() public {
         PrivateOfferArguments memory args = _buildBaseArguments();
         args.currencyPayer = address(0);
-        vm.expectRevert("_arguments.currencyPayer can not be zero address");
+        vm.expectRevert(PrivateOffer.ZeroCurrencyPayerAddress.selector);
         new PrivateOffer(args);
     }
 
     function testRevertZeroTokenReceiver() public {
         PrivateOfferArguments memory args = _buildBaseArguments();
         args.tokenReceiver = address(0);
-        vm.expectRevert("_arguments.tokenReceiver can not be zero address");
+        vm.expectRevert(PrivateOffer.ZeroTokenReceiverAddress.selector);
         new PrivateOffer(args);
     }
 
     function testRevertZeroCurrencyReceiver() public {
         PrivateOfferArguments memory args = _buildBaseArguments();
         args.currencyReceiver = address(0);
-        vm.expectRevert("_arguments.currencyReceiver can not be zero address");
+        vm.expectRevert(PrivateOffer.ZeroCurrencyReceiverAddress.selector);
         new PrivateOffer(args);
     }
 
     function testRevertZeroTokenPrice() public {
         PrivateOfferArguments memory args = _buildBaseArguments();
         args.tokenPrice = 0;
-        vm.expectRevert("_arguments.tokenPrice can not be zero");
+        vm.expectRevert(ZeroPrice.selector);
         new PrivateOffer(args);
     }
 
@@ -334,28 +334,28 @@ contract PrivateOfferTest is Test {
         vm.warp(1000);
         PrivateOfferArguments memory args = _buildBaseArguments();
         args.expiration = block.timestamp - 1;
-        vm.expectRevert("Deal expired");
+        vm.expectRevert(PrivateOffer.DealExpired.selector);
         new PrivateOffer(args);
     }
 
     function testRevertZeroToken() public {
         PrivateOfferArguments memory args = _buildBaseArguments();
         args.token = Token(address(0));
-        vm.expectRevert("_arguments.token can not be zero address");
+        vm.expectRevert(ZeroTokenAddress.selector);
         new PrivateOffer(args);
     }
 
     function testRevertZeroCurrency() public {
         PrivateOfferArguments memory args = _buildBaseArguments();
         args.currency = IERC20(address(0));
-        vm.expectRevert("_arguments.currency can not be zero address");
+        vm.expectRevert(ZeroCurrencyAddress.selector);
         new PrivateOffer(args);
     }
 
     function testRevertZeroTokenAmount() public {
         PrivateOfferArguments memory args = _buildBaseArguments();
         args.tokenAmount = 0;
-        vm.expectRevert("_arguments.tokenAmount can not be zero");
+        vm.expectRevert(ZeroAmount.selector);
         new PrivateOffer(args);
     }
 

--- a/test/PrivateOffer.t.sol
+++ b/test/PrivateOffer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/PrivateOfferFactory.t.sol
+++ b/test/PrivateOfferFactory.t.sol
@@ -200,7 +200,7 @@ contract PrivateOfferFactoryTest is Test {
 
         // try to drain before lock expires — must revert
         vm.prank(timeLockOwner);
-        vm.expectRevert("timelock has not expired");
+        vm.expectRevert(TimeLock.TimeLockNotExpired.selector);
         timeLockContract.drain(IERC20(address(token)), tokenReceiver);
 
         // drain after lock expires

--- a/test/PrivateOfferFactory.t.sol
+++ b/test/PrivateOfferFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/PrivateOfferFactory.t.sol
+++ b/test/PrivateOfferFactory.t.sol
@@ -200,7 +200,7 @@ contract PrivateOfferFactoryTest is Test {
 
         // try to drain before lock expires — must revert
         vm.prank(timeLockOwner);
-        vm.expectRevert(TimeLock.TimeLockNotExpired.selector);
+        vm.expectRevert(TimeLockNotExpired.selector);
         timeLockContract.drain(IERC20(address(token)), tokenReceiver);
 
         // drain after lock expires

--- a/test/PrivateOfferOffchainPaymentTimeLock.t.sol
+++ b/test/PrivateOfferOffchainPaymentTimeLock.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/PrivateOfferTimeLock.t.sol
+++ b/test/PrivateOfferTimeLock.t.sol
@@ -188,13 +188,13 @@ contract PrivateOfferTimeLockTest is Test {
         // drain before lock expires should revert
         assertEq(token.balanceOf(TOKEN_RECEIVER), 0, "investor vault should have no tokens");
         vm.prank(ADMIN);
-        vm.expectRevert(TimeLock.TimeLockNotExpired.selector);
+        vm.expectRevert(TimeLockNotExpired.selector);
         timeLock.drain(IERC20(address(token)), TOKEN_RECEIVER);
 
         // drain at attemptTime (still before lockedUntil) should also revert
         vm.warp(attemptTime);
         vm.prank(ADMIN);
-        vm.expectRevert(TimeLock.TimeLockNotExpired.selector);
+        vm.expectRevert(TimeLockNotExpired.selector);
         timeLock.drain(IERC20(address(token)), TOKEN_RECEIVER);
 
         // drain after lock expires transfers all tokens to recipient

--- a/test/PrivateOfferTimeLock.t.sol
+++ b/test/PrivateOfferTimeLock.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/PrivateOfferTimeLock.t.sol
+++ b/test/PrivateOfferTimeLock.t.sol
@@ -188,13 +188,13 @@ contract PrivateOfferTimeLockTest is Test {
         // drain before lock expires should revert
         assertEq(token.balanceOf(TOKEN_RECEIVER), 0, "investor vault should have no tokens");
         vm.prank(ADMIN);
-        vm.expectRevert("timelock has not expired");
+        vm.expectRevert(TimeLock.TimeLockNotExpired.selector);
         timeLock.drain(IERC20(address(token)), TOKEN_RECEIVER);
 
         // drain at attemptTime (still before lockedUntil) should also revert
         vm.warp(attemptTime);
         vm.prank(ADMIN);
-        vm.expectRevert("timelock has not expired");
+        vm.expectRevert(TimeLock.TimeLockNotExpired.selector);
         timeLock.drain(IERC20(address(token)), TOKEN_RECEIVER);
 
         // drain after lock expires transfers all tokens to recipient

--- a/test/SetUpExampleCompany.t.sol
+++ b/test/SetUpExampleCompany.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/TimeLockDistributeExit.t.sol
+++ b/test/TimeLockDistributeExit.t.sol
@@ -151,7 +151,7 @@ contract TimeLockDistributeExitTest is Test {
     function testDrainStillBlockedBeforeLockedUntil() public {
         // No exit is set — drain must be blocked
         vm.prank(OWNER);
-        vm.expectRevert("timelock has not expired");
+        vm.expectRevert(TimeLock.TimeLockNotExpired.selector);
         timeLock.drain(IERC20(address(token)), RECIPIENT);
     }
 
@@ -163,7 +163,7 @@ contract TimeLockDistributeExitTest is Test {
         tokenExitRegistry.setExit(token, Exit(address(exitContract)));
 
         vm.prank(OWNER);
-        vm.expectRevert("timelock has not expired");
+        vm.expectRevert(TimeLock.TimeLockNotExpired.selector);
         timeLock.drain(IERC20(address(token)), RECIPIENT);
     }
 
@@ -172,7 +172,7 @@ contract TimeLockDistributeExitTest is Test {
     /// Reverts when no exit is set in tokenExitRegistry
     function testDistributeExitRevertsIfNoExitRegistered() public {
         vm.prank(OWNER);
-        vm.expectRevert("no exit set in tokenExitRegistry");
+        vm.expectRevert(TimeLock.NoExitSet.selector);
         timeLock.claimExit(token, RECIPIENT, 0);
     }
 
@@ -183,7 +183,7 @@ contract TimeLockDistributeExitTest is Test {
         tokenExitRegistry.setExit(token, Exit(address(exitContract)));
 
         vm.prank(OWNER);
-        vm.expectRevert("recipient can not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         timeLock.claimExit(token, address(0), 0);
     }
 
@@ -214,7 +214,7 @@ contract TimeLockDistributeExitTest is Test {
 
         vm.warp(timeLockExpiry + 1 days);
         vm.prank(OWNER);
-        vm.expectRevert("no tokens to exit");
+        vm.expectRevert(TimeLock.NoTokensToExit.selector);
         timeLock.claimExit(token, RECIPIENT, 0);
     }
 
@@ -281,14 +281,14 @@ contract TimeLockDistributeExitTest is Test {
     function testInitializeRevertsIfOwnerZero() public {
         TimeLock logic = new TimeLock(TRUSTED_FORWARDER);
         TimeLockCloneFactory cloneFactory = new TimeLockCloneFactory(address(logic));
-        vm.expectRevert("owner can not be zero address");
+        vm.expectRevert(ZeroOwnerAddress.selector);
         cloneFactory.createTimeLockClone(bytes32(0), TRUSTED_FORWARDER, address(0), timeLockExpiry, tokenExitRegistry);
     }
 
     function testInitializeRevertsIfLockedUntilNotInFuture() public {
         TimeLock logic = new TimeLock(TRUSTED_FORWARDER);
         TimeLockCloneFactory cloneFactory = new TimeLockCloneFactory(address(logic));
-        vm.expectRevert("lockedUntil must be in the future");
+        vm.expectRevert(LockedUntilNotInFuture.selector);
         cloneFactory.createTimeLockClone(
             bytes32(0),
             TRUSTED_FORWARDER,
@@ -301,7 +301,7 @@ contract TimeLockDistributeExitTest is Test {
     function testInitializeRevertsIfRegistryZero() public {
         TimeLock logic = new TimeLock(TRUSTED_FORWARDER);
         TimeLockCloneFactory cloneFactory = new TimeLockCloneFactory(address(logic));
-        vm.expectRevert("tokenExitRegistry can not be zero address");
+        vm.expectRevert(TimeLock.ZeroTokenExitRegistryAddress.selector);
         cloneFactory.createTimeLockClone(
             bytes32(0),
             TRUSTED_FORWARDER,
@@ -324,7 +324,7 @@ contract TimeLockDistributeExitTest is Test {
     function testDrainRevertsIfRecipientZero() public {
         vm.warp(timeLockExpiry);
         vm.prank(OWNER);
-        vm.expectRevert("recipient can not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         timeLock.drain(IERC20(address(token)), address(0));
     }
 
@@ -334,14 +334,14 @@ contract TimeLockDistributeExitTest is Test {
         timeLock.drain(IERC20(address(token)), RECIPIENT);
 
         vm.prank(OWNER);
-        vm.expectRevert("no tokens to drain");
+        vm.expectRevert(TimeLock.NoTokensToDrain.selector);
         timeLock.drain(IERC20(address(token)), RECIPIENT);
     }
 
     function testClaimDistributionRevertsIfRecipientZero() public {
         FixedPayoutDistribution stub = new FixedPayoutDistribution(IERC20(address(eurc)), 0);
         vm.prank(OWNER);
-        vm.expectRevert("recipient can not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         timeLock.claimDistribution(Distribution(address(stub)), address(0), 0);
     }
 }

--- a/test/TimeLockDistributeExit.t.sol
+++ b/test/TimeLockDistributeExit.t.sol
@@ -315,7 +315,7 @@ contract TimeLockDistributeExitTest is Test {
         address wrongForwarder = address(99);
         TimeLock logic = new TimeLock(TRUSTED_FORWARDER);
         TimeLockCloneFactory cloneFactory = new TimeLockCloneFactory(address(logic));
-        vm.expectRevert("TimeLockCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         cloneFactory.createTimeLockClone(bytes32(0), wrongForwarder, OWNER, timeLockExpiry, tokenExitRegistry);
     }
 

--- a/test/TimeLockDistributeExit.t.sol
+++ b/test/TimeLockDistributeExit.t.sol
@@ -151,7 +151,7 @@ contract TimeLockDistributeExitTest is Test {
     function testDrainStillBlockedBeforeLockedUntil() public {
         // No exit is set — drain must be blocked
         vm.prank(OWNER);
-        vm.expectRevert(TimeLock.TimeLockNotExpired.selector);
+        vm.expectRevert(TimeLockNotExpired.selector);
         timeLock.drain(IERC20(address(token)), RECIPIENT);
     }
 
@@ -163,7 +163,7 @@ contract TimeLockDistributeExitTest is Test {
         tokenExitRegistry.setExit(token, Exit(address(exitContract)));
 
         vm.prank(OWNER);
-        vm.expectRevert(TimeLock.TimeLockNotExpired.selector);
+        vm.expectRevert(TimeLockNotExpired.selector);
         timeLock.drain(IERC20(address(token)), RECIPIENT);
     }
 
@@ -172,7 +172,7 @@ contract TimeLockDistributeExitTest is Test {
     /// Reverts when no exit is set in tokenExitRegistry
     function testDistributeExitRevertsIfNoExitRegistered() public {
         vm.prank(OWNER);
-        vm.expectRevert(TimeLock.NoExitSet.selector);
+        vm.expectRevert(NoExitSet.selector);
         timeLock.claimExit(token, RECIPIENT, 0);
     }
 
@@ -301,7 +301,7 @@ contract TimeLockDistributeExitTest is Test {
     function testInitializeRevertsIfRegistryZero() public {
         TimeLock logic = new TimeLock(TRUSTED_FORWARDER);
         TimeLockCloneFactory cloneFactory = new TimeLockCloneFactory(address(logic));
-        vm.expectRevert(TimeLock.ZeroTokenExitRegistryAddress.selector);
+        vm.expectRevert(ZeroTokenExitRegistryAddress.selector);
         cloneFactory.createTimeLockClone(
             bytes32(0),
             TRUSTED_FORWARDER,

--- a/test/TimeLockDistributeExit.t.sol
+++ b/test/TimeLockDistributeExit.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/Token.t.sol
+++ b/test/Token.t.sol
@@ -98,7 +98,7 @@ contract tokenTest is Test {
 
     function testAllowList0() public {
         AllowList _noList = AllowList(address(0));
-        vm.expectRevert("AllowList must not be zero address");
+        vm.expectRevert(Token.ZeroAllowListAddress.selector);
         tokenCloneFactory.createTokenProxy(0, TRUSTED_FORWARDER, feeSettings, ADMIN, _noList, 0x0, "testToken", "TEST");
     }
 
@@ -401,7 +401,7 @@ contract tokenTest is Test {
         assertTrue(token.mintingAllowance(MINTER) == 0);
 
         vm.prank(MINTER);
-        vm.expectRevert("MintingAllowance too low");
+        vm.expectRevert(Token.MintingAllowanceTooLow.selector);
         token.mint(PAUSER, 1);
     }
 
@@ -444,7 +444,7 @@ contract tokenTest is Test {
         assertTrue(token.mintingAllowance(MINTER) == 0); // check allowance is 0
 
         vm.prank(MINTER);
-        vm.expectRevert("MintingAllowance too low");
+        vm.expectRevert(Token.MintingAllowanceTooLow.selector);
         token.mint(PAUSER, x); // try to mint -> must fail!
     }
 
@@ -620,9 +620,7 @@ contract tokenTest is Test {
 
         // move tokens around
         vm.prank(TRANSFERER);
-        vm.expectRevert(
-            "Sender or Receiver is not allowed to transact. Either locally issue the role as a TRANSFERER or they must meet requirements as defined in the allowList"
-        );
+        vm.expectRevert(Token.NotAllowedToTransact.selector);
         token.transfer(BURNER, 50);
         assertTrue(token.balanceOf(BURNER) == 0);
     }
@@ -671,9 +669,7 @@ contract tokenTest is Test {
         vm.prank(ADMIN);
         allowList.set(PAUSER, 4); // only one bit set, but bit 1 and 2 (=3) should be set
         vm.prank(MINTER);
-        vm.expectRevert(
-            "Sender or Receiver is not allowed to transact. Either locally issue the role as a TRANSFERER or they must meet requirements as defined in the allowList"
-        );
+        vm.expectRevert(Token.NotAllowedToTransact.selector);
         token.mint(PAUSER, 50);
 
         assertTrue(token.balanceOf(PAUSER) == 0);
@@ -934,17 +930,13 @@ contract tokenTest is Test {
         console.log("person1: ", person1);
 
         vm.prank(person1);
-        vm.expectRevert(
-            "Sender or Receiver is not allowed to transact. Either locally issue the role as a TRANSFERER or they must meet requirements as defined in the allowList"
-        );
+        vm.expectRevert(Token.NotAllowedToTransact.selector);
         token.transfer(person2, 20);
         assertTrue(token.balanceOf(person2) == 20);
         assertTrue(token.balanceOf(person1) == 30);
 
         vm.prank(person2);
-        vm.expectRevert(
-            "Sender or Receiver is not allowed to transact. Either locally issue the role as a TRANSFERER or they must meet requirements as defined in the allowList"
-        );
+        vm.expectRevert(Token.NotAllowedToTransact.selector);
         token.transfer(person1, 10);
         assertTrue(token.balanceOf(person2) == 20);
         assertTrue(token.balanceOf(person1) == 30);

--- a/test/TokenERC2612.t.sol
+++ b/test/TokenERC2612.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/TokenERC2771.t.sol
+++ b/test/TokenERC2771.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/TokenGasConsumption.t.sol
+++ b/test/TokenGasConsumption.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/TokenIntegration.t.sol
+++ b/test/TokenIntegration.t.sol
@@ -84,7 +84,7 @@ contract tokenTest is Test {
     }
 
     function testUpdateAllowList0() public {
-        vm.expectRevert("AllowList must not be zero address");
+        vm.expectRevert(Token.ZeroAllowListAddress.selector);
         vm.prank(ADMIN);
         token.setAllowList(AllowList(address(0)));
     }
@@ -97,7 +97,7 @@ contract tokenTest is Test {
             buildFeeTypes(0, 0, 0, PAUSER, PAUSER, PAUSER)
         );
         vm.prank(wrongUpdater);
-        vm.expectRevert("Only fee settings owner can suggest fee settings update");
+        vm.expectRevert(Token.OnlyFeeSettingsOwner.selector);
         token.suggestNewFeeSettings(newFeeSettings);
     }
 
@@ -108,7 +108,7 @@ contract tokenTest is Test {
             buildFeeTypes(0, 0, 0, PAUSER, PAUSER, PAUSER)
         );
         vm.prank(feeSettings.feeCollector());
-        vm.expectRevert("Only fee settings owner can suggest fee settings update");
+        vm.expectRevert(Token.OnlyFeeSettingsOwner.selector);
         token.suggestNewFeeSettings(newFeeSettings);
     }
 
@@ -256,7 +256,7 @@ contract tokenTest is Test {
             console.log("Suggested fee settings: ", address(realNewFeeSettings));
 
             // ADMIN thinks he is accepting a, but suggestion is b
-            vm.expectRevert("Only suggested fee settings can be accepted");
+            vm.expectRevert(Token.OnlySuggestedFeeSettings.selector);
             vm.prank(ADMIN);
             token.acceptNewFeeSettings(fakeNewFeeSettings);
         }
@@ -346,9 +346,7 @@ contract tokenTest is Test {
 
         // mint tokens for feeCollector
         vm.startPrank(localMinter);
-        vm.expectRevert(
-            "Sender or Receiver is not allowed to transact. Either locally issue the role as a TRANSFERER or they must meet requirements as defined in the allowList"
-        );
+        vm.expectRevert(Token.NotAllowedToTransact.selector);
         token.mint(feeCollector, _amount);
         vm.stopPrank();
     }
@@ -362,7 +360,7 @@ contract tokenTest is Test {
         vm.startPrank(feeSettings.owner());
         // cycle through the fake contracts and make sure each one triggers a revert
         for (uint i = 0; i < feeSettingsArray.length; i++) {
-            vm.expectRevert("FeeSettings must implement IFeeSettingsV2");
+            vm.expectRevert(Token.FeeSettingsInterfaceNotSupported.selector);
             token.suggestNewFeeSettings(feeSettingsArray[i]);
         }
         vm.stopPrank();

--- a/test/TokenProxyFactory.t.sol
+++ b/test/TokenProxyFactory.t.sol
@@ -136,7 +136,7 @@ contract tokenProxyFactoryTest is Test {
         vm.assume(_wrongForwarder != address(0));
 
         // using a different TRUSTED_FORWARDER should fail
-        vm.expectRevert("TokenProxyFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         factory.createTokenProxy(
             bytes32(uint256(0)),
             _wrongForwarder,

--- a/test/TokenProxyFactory.t.sol
+++ b/test/TokenProxyFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/TokenProxyUpgrade.t.sol
+++ b/test/TokenProxyUpgrade.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/TokenSnapshots.t.sol
+++ b/test/TokenSnapshots.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/TokenSwap.t.sol
+++ b/test/TokenSwap.t.sol
@@ -229,37 +229,37 @@ contract TokenSwapTest is Test {
         // OWNER 0
         TokenSwapInitializerArguments memory tempArgs = cloneTokenSwapInitializerArguments(arguments);
         tempArgs.owner = address(0);
-        vm.expectRevert("owner can not be zero address");
+        vm.expectRevert(ZeroOwnerAddress.selector);
         factory.createTokenSwapClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // RECEIVER 0
         tempArgs = cloneTokenSwapInitializerArguments(arguments);
         tempArgs.receiver = address(0);
-        vm.expectRevert("receiver can not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         factory.createTokenSwapClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // HOLDER 0
         tempArgs = cloneTokenSwapInitializerArguments(arguments);
         tempArgs.holder = address(0);
-        vm.expectRevert("holder can not be zero address");
+        vm.expectRevert(TokenSwap.ZeroHolderAddress.selector);
         factory.createTokenSwapClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // PRICE 0
         tempArgs = cloneTokenSwapInitializerArguments(arguments);
         tempArgs.tokenPrice = 0;
-        vm.expectRevert("_tokenPrice needs to be a non-zero amount");
+        vm.expectRevert(ZeroPrice.selector);
         factory.createTokenSwapClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // currency 0
         tempArgs = cloneTokenSwapInitializerArguments(arguments);
         tempArgs.currency = IERC20(address(0));
-        vm.expectRevert("currency can not be zero address");
+        vm.expectRevert(ZeroCurrencyAddress.selector);
         factory.createTokenSwapClone(0, TRUSTED_FORWARDER, tempArgs);
 
         // token 0
         tempArgs = cloneTokenSwapInitializerArguments(arguments);
         tempArgs.token = Token(address(0));
-        vm.expectRevert("token can not be zero address");
+        vm.expectRevert(ZeroTokenAddress.selector);
         factory.createTokenSwapClone(0, TRUSTED_FORWARDER, tempArgs);
     }
 
@@ -574,7 +574,7 @@ contract TokenSwapTest is Test {
             );
         } else {
             vm.prank(BUYER);
-            vm.expectRevert("Purchase more expensive than _maxCurrencyAmount");
+            vm.expectRevert(TokenSwap.PurchaseTooExpensive.selector);
             tokenSwap.buy(tokenBuyAmount, maxCurrencyAmount, BUYER);
         }
     }
@@ -603,7 +603,7 @@ contract TokenSwapTest is Test {
             );
         } else {
             vm.prank(BUYER);
-            vm.expectRevert("Payout too low");
+            vm.expectRevert(TokenSwap.PayoutTooLow.selector);
             tokenSwap.sell(tokenSellAmount, minCurrencyAmount, BUYER);
         }
     }
@@ -776,7 +776,7 @@ contract TokenSwapTest is Test {
         assertTrue(tokenSwap.receiver() == address(BUYER));
 
         vm.prank(OWNER);
-        vm.expectRevert("receiver can not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         tokenSwap.setReceiver(address(0));
     }
 
@@ -792,7 +792,7 @@ contract TokenSwapTest is Test {
         assertTrue(tokenSwap.tokenPrice() == newPrice);
 
         vm.prank(OWNER);
-        vm.expectRevert("_tokenPrice needs to be a non-zero amount");
+        vm.expectRevert(ZeroPrice.selector);
         tokenSwap.setTokenPrice(0);
     }
 

--- a/test/TokenSwap.t.sol
+++ b/test/TokenSwap.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/TokenSwap.t.sol
+++ b/test/TokenSwap.t.sol
@@ -574,7 +574,7 @@ contract TokenSwapTest is Test {
             );
         } else {
             vm.prank(BUYER);
-            vm.expectRevert(TokenSwap.PurchaseTooExpensive.selector);
+            vm.expectRevert(PurchaseTooExpensive.selector);
             tokenSwap.buy(tokenBuyAmount, maxCurrencyAmount, BUYER);
         }
     }

--- a/test/TokenSwap.t.sol
+++ b/test/TokenSwap.t.sol
@@ -223,7 +223,7 @@ contract TokenSwapTest is Test {
             token
         );
 
-        vm.expectRevert("TokenSwapCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         TokenSwap(factory.createTokenSwapClone(0, address(0), arguments));
 
         // OWNER 0

--- a/test/TokenSwapCloneFactory.t.sol
+++ b/test/TokenSwapCloneFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/TokenSwapCloneFactory.t.sol
+++ b/test/TokenSwapCloneFactory.t.sol
@@ -350,7 +350,7 @@ contract TokenSwapCloneFactoryTest is Test {
             exampleToken
         );
 
-        vm.expectRevert("currency needs to be on the allowlist with TRUSTED_CURRENCY attribute");
+        vm.expectRevert(UntrustedCurrency.selector);
         tokenSwapFactory.createTokenSwapClone("salt", TRUSTED_FORWARDER, arguments);
 
         // test deployment succeeds with trusted currency

--- a/test/Vesting.t.sol
+++ b/test/Vesting.t.sol
@@ -80,7 +80,7 @@ contract VestingTest is Test {
 
         // rando cannot commit
         vm.prank(rando);
-        vm.expectRevert(Vesting.CallerNotManager.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vest.commit(hash);
 
         // owner can commit
@@ -103,7 +103,7 @@ contract VestingTest is Test {
 
         // rando cannot create
         vm.prank(_rando);
-        vm.expectRevert(Vesting.CallerNotManager.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vest.createVesting(100, address(7), 1, 20 days, 40 days, false);
 
         // owner can create
@@ -581,7 +581,7 @@ contract VestingTest is Test {
 
         address rando = address(99);
         vm.prank(rando);
-        vm.expectRevert(Vesting.CallerNotManager.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vesting.stopVesting(vestingId, uint64(exampleStart + 1));
     }
 }

--- a/test/Vesting.t.sol
+++ b/test/Vesting.t.sol
@@ -80,7 +80,7 @@ contract VestingTest is Test {
 
         // rando cannot commit
         vm.prank(rando);
-        vm.expectRevert("Caller is not a manager");
+        vm.expectRevert(Vesting.CallerNotManager.selector);
         vest.commit(hash);
 
         // owner can commit
@@ -103,7 +103,7 @@ contract VestingTest is Test {
 
         // rando cannot create
         vm.prank(_rando);
-        vm.expectRevert("Caller is not a manager");
+        vm.expectRevert(Vesting.CallerNotManager.selector);
         vest.createVesting(100, address(7), 1, 20 days, 40 days, false);
 
         // owner can create
@@ -136,7 +136,7 @@ contract VestingTest is Test {
         // rando can not release tokens
         vm.warp(10 days);
         vm.prank(rando);
-        vm.expectRevert("Only beneficiary can release tokens");
+        vm.expectRevert(Vesting.OnlyBeneficiary.selector);
         vesting.release(id);
 
         // beneficiary can release tokens
@@ -178,7 +178,7 @@ contract VestingTest is Test {
         // rando can not release tokens
         vm.warp(10 days);
         vm.prank(rando);
-        vm.expectRevert("Only beneficiary can release tokens");
+        vm.expectRevert(Vesting.OnlyBeneficiary.selector);
         vesting.release(id);
 
         // beneficiary can release tokens
@@ -395,13 +395,13 @@ contract VestingTest is Test {
         vm.warp(exampleStart + changeAfter);
         // rando can never change beneficiary
         vm.prank(rando);
-        vm.expectRevert("Only beneficiary can change beneficiary, or owner 1 year after vesting end");
+        vm.expectRevert(Vesting.NotAllowedToChangeBeneficiary.selector);
         vesting.changeBeneficiary(id, rando);
         assertEq(vesting.beneficiary(id), beneficiary, "rando changed beneficiary");
 
         // even beneficiary can never set beneficiary to 0
         vm.prank(beneficiary);
-        vm.expectRevert("Beneficiary must not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         vesting.changeBeneficiary(id, address(0));
         assertEq(vesting.beneficiary(id), beneficiary, "beneficiary should not have changed!");
 
@@ -420,7 +420,7 @@ contract VestingTest is Test {
         } else {
             // owner can not change beneficiary before 1 year
             vm.prank(owner);
-            vm.expectRevert("Only beneficiary can change beneficiary, or owner 1 year after vesting end");
+            vm.expectRevert(Vesting.NotAllowedToChangeBeneficiary.selector);
             vesting.changeBeneficiary(id, beneficiary);
             assertEq(vesting.beneficiary(id), rando, "owner changed beneficiary too early");
         }
@@ -445,28 +445,28 @@ contract VestingTest is Test {
 
     function testInitializingWith0() public {
         // owner 0
-        vm.expectRevert("Owner must not be zero address");
+        vm.expectRevert(ZeroOwnerAddress.selector);
         Vesting vest = Vesting(factory.createVestingClone(0, trustedForwarder, address(0), address(token)));
 
         // token 0
-        vm.expectRevert("Token must not be zero address");
+        vm.expectRevert(ZeroTokenAddress.selector);
         vest = Vesting(factory.createVestingClone(0, trustedForwarder, owner, address(0)));
     }
 
     function testCommit0() public {
-        vm.expectRevert("hash must not be zero");
+        vm.expectRevert(Vesting.ZeroHash.selector);
         vm.prank(owner);
         vesting.commit(bytes32(0));
     }
 
     function testRevoke0() public {
-        vm.expectRevert("invalid-hash");
+        vm.expectRevert(Vesting.InvalidHash.selector);
         vm.prank(owner);
         vesting.revoke(bytes32(0), 20 days);
     }
 
     function testBeneficiary0() public {
-        vm.expectRevert("Beneficiary must not be zero address");
+        vm.expectRevert(ZeroReceiverAddress.selector);
         vm.prank(owner);
         vesting.createVesting(100, address(0), 1, 20 days, 40 days, false);
     }
@@ -484,7 +484,7 @@ contract VestingTest is Test {
         vm.stopPrank();
 
         vm.prank(owner);
-        vm.expectRevert("endTime must be before vesting end");
+        vm.expectRevert(Vesting.EndTimeAfterVestingEnd.selector);
         vesting.stopVesting(id, exampleStart + exampleDuration + 1);
     }
 
@@ -502,15 +502,15 @@ contract VestingTest is Test {
         vm.warp(exampleStart + exampleCliff);
 
         // end time in past
-        vm.expectRevert("endTime must be in the future");
+        vm.expectRevert(Vesting.EndTimeNotInFuture.selector);
         vesting.pauseVesting(id, exampleStart, exampleStart + 2 * exampleDuration);
 
         // end time is vesting end
-        vm.expectRevert("endTime must be before vesting end");
+        vm.expectRevert(Vesting.EndTimeAfterVestingEnd.selector);
         vesting.pauseVesting(id, exampleStart + exampleDuration, exampleStart + 2 * exampleDuration);
 
         // new start before end
-        vm.expectRevert("newStartTime must be after endTime");
+        vm.expectRevert(Vesting.NewStartTimeNotAfterEndTime.selector);
         vesting.pauseVesting(id, exampleStart + exampleCliff + 1, exampleStart + exampleCliff / 2);
     }
 
@@ -581,7 +581,7 @@ contract VestingTest is Test {
 
         address rando = address(99);
         vm.prank(rando);
-        vm.expectRevert("Caller is not a manager");
+        vm.expectRevert(Vesting.CallerNotManager.selector);
         vesting.stopVesting(vestingId, uint64(exampleStart + 1));
     }
 }

--- a/test/Vesting.t.sol
+++ b/test/Vesting.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/VestingBlind.t.sol
+++ b/test/VestingBlind.t.sol
@@ -48,7 +48,7 @@ contract VestingBlindTest is Test {
         vm.assume(noOwner != trustedForwarder);
         vm.assume(vesting.managers(noOwner) == false);
         vm.assume(hash != bytes32(0));
-        vm.expectRevert("Caller is not a manager");
+        vm.expectRevert(Vesting.CallerNotManager.selector);
         vm.prank(noOwner);
         vesting.commit(hash);
     }
@@ -84,7 +84,7 @@ contract VestingBlindTest is Test {
 
         assertTrue(vesting.commitments(hash) == type(uint64).max, "commitment does not exist");
         vm.prank(noOwner);
-        vm.expectRevert("Caller is not a manager");
+        vm.expectRevert(Vesting.CallerNotManager.selector);
         vesting.revoke(hash, uint64(block.timestamp));
         assertEq(vesting.commitments(hash), type(uint64).max, "commitment has been revoked");
     }
@@ -128,7 +128,7 @@ contract VestingBlindTest is Test {
         assertTrue(vesting.commitments(hash) == 0, "commitment still exists");
 
         // make sure a second creation fails
-        vm.expectRevert("invalid-hash");
+        vm.expectRevert(Vesting.InvalidHash.selector);
         vm.prank(_rando);
         vesting.reveal(hash, _allocation, _beneficiary, _start, _cliff, _duration, _isMintable, _salt);
     }
@@ -187,7 +187,7 @@ contract VestingBlindTest is Test {
         assertTrue(vesting.commitments(hash) == 0, "commitment still exists");
 
         // make sure a second creation fails
-        vm.expectRevert("invalid-hash");
+        vm.expectRevert(Vesting.InvalidHash.selector);
         vm.prank(_rando);
         vesting.reveal(hash, _allocation, _beneficiary, _start, _cliff, _duration, _isMintable, _salt);
     }
@@ -242,7 +242,7 @@ contract VestingBlindTest is Test {
         assertTrue(vesting.commitments(hash) == 0, "commitment still exists");
 
         // make sure a second creation fails
-        vm.expectRevert("invalid-hash");
+        vm.expectRevert(Vesting.InvalidHash.selector);
         vesting.reveal(hash, commitmentAllocation, beneficiary, _start, _cliff, _duration, _isMintable, _salt);
 
         // vest everything
@@ -287,7 +287,7 @@ contract VestingBlindTest is Test {
         vesting.revoke(hash, uint64(end));
 
         // claim
-        vm.expectRevert("commitment revoked before cliff ended");
+        vm.expectRevert(Vesting.CommitmentRevokedBeforeCliff.selector);
         vesting.reveal(hash, _allocation, _beneficiary, _start, _cliff, _duration, isMintable, _salt);
 
         // make sure nothing changed
@@ -567,10 +567,10 @@ contract VestingBlindTest is Test {
         assertTrue(vesting.commitments(hash) == type(uint64).max, "commitment does not exist");
 
         // claim
-        vm.expectRevert("invalid-hash");
+        vm.expectRevert(Vesting.InvalidHash.selector);
         vesting.reveal(hash, _allocation, _beneficiary2, _start, _cliff, _duration, isMintable, _salt);
 
-        vm.expectRevert("invalid-hash");
+        vm.expectRevert(Vesting.InvalidHash.selector);
         vesting.reveal(hash, _allocation2, _beneficiary, _start, _cliff, _duration, isMintable, _salt);
     }
 

--- a/test/VestingBlind.t.sol
+++ b/test/VestingBlind.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/VestingBlind.t.sol
+++ b/test/VestingBlind.t.sol
@@ -48,7 +48,7 @@ contract VestingBlindTest is Test {
         vm.assume(noOwner != trustedForwarder);
         vm.assume(vesting.managers(noOwner) == false);
         vm.assume(hash != bytes32(0));
-        vm.expectRevert(Vesting.CallerNotManager.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vm.prank(noOwner);
         vesting.commit(hash);
     }
@@ -84,7 +84,7 @@ contract VestingBlindTest is Test {
 
         assertTrue(vesting.commitments(hash) == type(uint64).max, "commitment does not exist");
         vm.prank(noOwner);
-        vm.expectRevert(Vesting.CallerNotManager.selector);
+        vm.expectRevert(CallerNotManager.selector);
         vesting.revoke(hash, uint64(block.timestamp));
         assertEq(vesting.commitments(hash), type(uint64).max, "commitment has been revoked");
     }

--- a/test/VestingCloneFactory.t.sol
+++ b/test/VestingCloneFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/VestingCloneFactory.t.sol
+++ b/test/VestingCloneFactory.t.sol
@@ -106,7 +106,7 @@ contract VestingCloneFactoryTest is Test {
         assertNotEq(actual, changedAddress, "address prediction failed: salt");
 
         // ensure changing the trustedForwarder reverts
-        vm.expectRevert("VestingCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         _factory.predictCloneAddressWithLockupPlan(
             _rawSalt,
             address(1),
@@ -227,10 +227,10 @@ contract VestingCloneFactoryTest is Test {
         address _token = address(3);
 
         // test wrong trustedForwarder reverts
-        vm.expectRevert("VestingCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         factory.predictCloneAddress(_salt, _wrongTrustedForwarder, _owner, _token);
 
-        vm.expectRevert("VestingCloneFactory: Unexpected trustedForwarder");
+        vm.expectRevert(Factory.UnexpectedTrustedForwarder.selector);
         factory.createVestingClone(_salt, _wrongTrustedForwarder, _owner, _token);
     }
 

--- a/test/VestingDemo.t.sol
+++ b/test/VestingDemo.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/VestingERC2771.t.sol
+++ b/test/VestingERC2771.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../lib/forge-std/src/Test.sol";
 import "../lib/forge-std/src/console.sol";

--- a/test/backwards-compatibility/BackwardsCompatibilityV4_2_0_beta_0.t.sol
+++ b/test/backwards-compatibility/BackwardsCompatibilityV4_2_0_beta_0.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/test/backwards-compatibility/BackwardsCompatibilityV5_0_1.t.sol
+++ b/test/backwards-compatibility/BackwardsCompatibilityV5_0_1.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/test/backwards-compatibility/BackwardsCompatibilityV6_1_0.t.sol
+++ b/test/backwards-compatibility/BackwardsCompatibilityV6_1_0.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";

--- a/test/resources/CloneCreators.sol
+++ b/test/resources/CloneCreators.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "../../contracts/factories/FeeSettingsCloneFactory.sol";

--- a/test/resources/CoinvestedPositionTestBase.sol
+++ b/test/resources/CoinvestedPositionTestBase.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "../../contracts/factories/TokenProxyFactory.sol";

--- a/test/resources/CrowdinvestingArgumentHelper.sol
+++ b/test/resources/CrowdinvestingArgumentHelper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "../../contracts/Crowdinvesting.sol";

--- a/test/resources/ERC20Helper.sol
+++ b/test/resources/ERC20Helper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "../../lib/forge-std/src/Test.sol";

--- a/test/resources/ERC20MintableByAnyone.sol
+++ b/test/resources/ERC20MintableByAnyone.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/test/resources/ERC2771Helper.sol
+++ b/test/resources/ERC2771Helper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "@opengsn/contracts/src/forwarder/Forwarder.sol"; // chose specific version to avoid import error: yarn add @opengsn/contracts@2.2.5

--- a/test/resources/FakeCrowdinvestingAndToken.sol
+++ b/test/resources/FakeCrowdinvestingAndToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "../../contracts/Token.sol";

--- a/test/resources/FakePaymentToken.sol
+++ b/test/resources/FakePaymentToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Permit.sol";

--- a/test/resources/FeeSettingsCreator.sol
+++ b/test/resources/FeeSettingsCreator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "../../contracts/factories/FeeSettingsCloneFactory.sol";

--- a/test/resources/FeeSettingsMissingV2.sol
+++ b/test/resources/FeeSettingsMissingV2.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 /**
  * @notice Stub FeeSettings that passes Token's 3-step ERC165 check for IFeeSettingsV2

--- a/test/resources/FixedPayoutExit.sol
+++ b/test/resources/FixedPayoutExit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 

--- a/test/resources/MaliciousDistributionCurrency.sol
+++ b/test/resources/MaliciousDistributionCurrency.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "../../contracts/Distribution.sol";

--- a/test/resources/MaliciousExitCurrency.sol
+++ b/test/resources/MaliciousExitCurrency.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "../../contracts/Exit.sol";

--- a/test/resources/MaliciousPaymentToken.sol
+++ b/test/resources/MaliciousPaymentToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";

--- a/test/resources/WrongFeeSettings.sol
+++ b/test/resources/WrongFeeSettings.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-pragma solidity 0.8.23;
+pragma solidity 0.8.34;
 
 import "../../lib/forge-std/src/Test.sol";
 import "../../contracts/FeeSettings.sol";


### PR DESCRIPTION


# Changes
- updates solidity from v0.8.23 to v0.8.34
- switched to custom error reverts instead of string reverts, which has been the recommended approach for a while
- using safe transfer everywhere, even with our own token, where it is not strictly necessary. The gas overhead is negligible, it makes auditors happy (this has been mentioned a lot), makes the codebase more unified, and it might come in handy one day.
- renames FeeSplitter to FeeDistributor to avoid misunderstandings, because FeeSplitter abbreviates to FS just like FeeSettings
- extends documentation of FeeDistributor with how it and can't be used properly

# Notes

- Using solidity v0.8.34 because it is the latest stable version and fixes a bug in the IR-pipeline that many versions before had. We use IR, so that information is relevant, even though the bug itself doesn't apply to us (our v0.8.23 didn't have it yet, and it only applies to transient storage, which we don't use).
- Using foundry nightly build because stable doesn't support solidity v0.8.34 yet. Once it IS supported, we should switch back to stable.

I had a blast doing this!