### PR TITLE
allow leadInvestor to update account

### DIFF
--- a/contracts/CoinvestedPosition.sol
+++ b/contracts/CoinvestedPosition.sol
@@ -53,6 +53,9 @@ contract CoinvestedPosition is TokenSwapBase {
 
     error ZeroLeadInvestorAddress();
     error ZeroLeadInvestorProfitFraction();
+    error NotLeadInvestor();
+
+    event LeadInvestorAccountUpdated(address indexed oldAccount, address indexed newAccount);
 
     /// lead investors and their carry fractions
     LeadInvestor[] public leadInvestors;
@@ -235,6 +238,24 @@ contract CoinvestedPosition is TokenSwapBase {
         uint256 received = exitCurrency.balanceOf(address(this)) - before;
         uint256 profit = basePayout < received ? received - basePayout : 0;
         _settle(profit, exitCurrency);
+    }
+
+    /**
+     * @notice Update the caller's lead investor account address. Allows a lead investor to migrate
+     *      to a new address, e.g. if the current address is blacklisted by the currency.
+     * @param newAccount new address to receive carry; must not be zero
+     */
+    function updateLeadInvestorAccount(address newAccount) external {
+        require(newAccount != address(0), ZeroLeadInvestorAddress());
+        address caller = _msgSender();
+        for (uint256 i = 0; i < leadInvestors.length; i++) {
+            if (leadInvestors[i].account == caller) {
+                leadInvestors[i].account = newAccount;
+                emit LeadInvestorAccountUpdated(caller, newAccount);
+                return;
+            }
+        }
+        revert NotLeadInvestor();
     }
 
     /**

--- a/test/CoinvestedPosition.t.sol
+++ b/test/CoinvestedPosition.t.sol
@@ -1468,4 +1468,77 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         vm.expectRevert(NoExitSet.selector);
         coinvestedPosition.claimExit(0, 0);
     }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // ── Section 14: updateLeadInvestorAccount() ───────────────────────────────
+    // ─────────────────────────────────────────────────────────────────────────
+
+    function testUpdateLeadInvestorAccountUpdatesAddress() public {
+        address newAddress = address(0xBEEF);
+        vm.prank(LEAD_A);
+        coinvestedPosition.updateLeadInvestorAccount(newAddress);
+        (address acc,) = coinvestedPosition.leadInvestors(0);
+        assertEq(acc, newAddress, "LEAD_A address not updated");
+    }
+
+    function testUpdateLeadInvestorAccountEmitsEvent() public {
+        address newAddress = address(0xBEEF);
+        vm.prank(LEAD_A);
+        vm.expectEmit(true, true, false, false);
+        emit CoinvestedPosition.LeadInvestorAccountUpdated(LEAD_A, newAddress);
+        coinvestedPosition.updateLeadInvestorAccount(newAddress);
+    }
+
+    function testUpdateLeadInvestorAccountNonLeadReverts() public {
+        vm.prank(BUYER);
+        vm.expectRevert(CoinvestedPosition.NotLeadInvestor.selector);
+        coinvestedPosition.updateLeadInvestorAccount(address(0xBEEF));
+    }
+
+    function testUpdateLeadInvestorAccountZeroAddressReverts() public {
+        vm.prank(LEAD_A);
+        vm.expectRevert(CoinvestedPosition.ZeroLeadInvestorAddress.selector);
+        coinvestedPosition.updateLeadInvestorAccount(address(0));
+    }
+
+    function testUpdateLeadInvestorAccountOwnerIsNotLeadReverts() public {
+        vm.prank(OWNER);
+        vm.expectRevert(CoinvestedPosition.NotLeadInvestor.selector);
+        coinvestedPosition.updateLeadInvestorAccount(address(0xBEEF));
+    }
+
+    function testUpdateLeadInvestorAccountNewAddressReceivesCarry() public {
+        address newAddress = address(0xBEEF);
+        vm.prank(LEAD_A);
+        coinvestedPosition.updateLeadInvestorAccount(newAddress);
+
+        _setupBuy(10e18, 200e6);
+        _fundBuyer(eurc, 400e6);
+
+        vm.prank(BUYER);
+        coinvestedPosition.buy(2e18, 400e6, TOKEN_RECEIVER);
+
+        uint256 carry = 200e6;
+        uint256 expectedNewAddress = (uint256(CARRY_10PCT) * carry) / type(uint64).max;
+        assertEq(eurc.balanceOf(newAddress), expectedNewAddress, "new address did not receive carry");
+        assertEq(eurc.balanceOf(LEAD_A), 0, "old address received carry");
+    }
+
+    function testUpdateLeadInvestorAccountSecondLeadUpdates() public {
+        address newB = address(0xCAFE);
+        vm.prank(LEAD_B);
+        coinvestedPosition.updateLeadInvestorAccount(newB);
+        (address acc,) = coinvestedPosition.leadInvestors(1);
+        assertEq(acc, newB, "LEAD_B address not updated");
+        // first lead unchanged
+        (address acc0,) = coinvestedPosition.leadInvestors(0);
+        assertEq(acc0, LEAD_A, "LEAD_A address changed unexpectedly");
+    }
+
+    function testFuzz_UpdateLeadInvestorAccountOnlyLeadCanUpdate(address caller) public {
+        vm.assume(caller != LEAD_A && caller != LEAD_B && caller != address(0) && caller != TRUSTED_FORWARDER);
+        vm.prank(caller);
+        vm.expectRevert(CoinvestedPosition.NotLeadInvestor.selector);
+        coinvestedPosition.updateLeadInvestorAccount(address(0xBEEF));
+    }
 }

--- a/test/CoinvestedPosition.t.sol
+++ b/test/CoinvestedPosition.t.sol
@@ -1475,10 +1475,12 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
 
     function testUpdateLeadInvestorAccountUpdatesAddress() public {
         address newAddress = address(0xBEEF);
+        (address oldAccount, ) = coinvestedPosition.leadInvestors(0);
+        assertEq(oldAccount, LEAD_A, "LEAD_A address unexpected");
         vm.prank(LEAD_A);
         coinvestedPosition.updateLeadInvestorAccount(newAddress);
-        (address acc,) = coinvestedPosition.leadInvestors(0);
-        assertEq(acc, newAddress, "LEAD_A address not updated");
+        (address newAccount, ) = coinvestedPosition.leadInvestors(0);
+        assertEq(newAccount, newAddress, "LEAD_A address not updated");
     }
 
     function testUpdateLeadInvestorAccountEmitsEvent() public {
@@ -1528,10 +1530,10 @@ contract CoinvestedPositionTest is CoinvestedPositionTestBase {
         address newB = address(0xCAFE);
         vm.prank(LEAD_B);
         coinvestedPosition.updateLeadInvestorAccount(newB);
-        (address acc,) = coinvestedPosition.leadInvestors(1);
+        (address acc, ) = coinvestedPosition.leadInvestors(1);
         assertEq(acc, newB, "LEAD_B address not updated");
         // first lead unchanged
-        (address acc0,) = coinvestedPosition.leadInvestors(0);
+        (address acc0, ) = coinvestedPosition.leadInvestors(0);
         assertEq(acc0, LEAD_A, "LEAD_A address changed unexpectedly");
     }
 


### PR DESCRIPTION
### Problem

`CoinvestedPosition._settle()` uses a push-based model, iterating over `leadInvestors` and calling `safeTransfer` to each address. If any lead investor's address is blacklisted by the payment currency (e.g. USDC, EURc), the transfer reverts and the entire transaction fails. Since `_settle()` is called by `buy()`, `claimDistribution()`, and `claimExit()`, a single blacklisted address permanently blocks all three paths. The `leadInvestors` array has no mechanism to update entries after initialization, so the contract becomes permanently inoperable.

### Why a pull-based settlement doesn't solve this

The suggested mitigation — replacing push transfers with a claimable-balance mapping that each party withdraws from — only shifts where the failure occurs. For it to help, funds must first arrive in the contract: `buy()` pulls currency from the buyer into the contract, `claimDistribution()` has the distribution push currency into the contract, and `claimExit()` receives exit proceeds into the contract. If the contract address itself is blacklisted, none of these inbound transfers succeed either. Accepting that any address involved in the flow can be blacklisted means the contract is already exposed to a more fundamental DoS that no settlement pattern can fix. The pull model adds complexity without meaningfully reducing risk.

### Solution

The actual attack surface is narrow: a lead investor address that was valid at initialization later becomes non-transferable. The direct fix is to let each lead investor update their own address — `updateLeadInvestorAccount(address newAccount)` finds the caller in the `leadInvestors` array and replaces their entry. This requires no owner involvement, is ERC2771-compatible, and costs ~15 lines. If an address is blacklisted, the affected lead investor migrates to a fresh address before or after the fact, and settlement proceeds normally.

### Hard recovery
If a lead investor is not available anymore and can't change their address, only the Token admin can help through burn&mint.


fixes #422 