### PR TITLE
F-2026-16606: Lack of Exit Token Validation Allows Mismatched Contract Binding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ broadcast/
 .npmignore
 .VSCodeCounter/
 *.code-workspace
+.claude/

--- a/contracts/GlobalTokenExitRegistry.sol
+++ b/contracts/GlobalTokenExitRegistry.sol
@@ -28,6 +28,9 @@ contract GlobalTokenExitRegistry is ERC2771ContextUpgradeable {
     /// @notice Reverted when an exit has already been set for the token and a second set is attempted.
     error ExitAlreadySet();
 
+    /// @notice Reverted when the exit's token() does not match the token being registered.
+    error ExitTokenMismatch();
+
     /// @notice The authorized exit contract per token.
     mapping(Token => Exit) public exits;
 
@@ -51,6 +54,7 @@ contract GlobalTokenExitRegistry is ERC2771ContextUpgradeable {
         require(address(_exit) != address(0), ZeroExitAddress());
         require(address(exits[_token]) == address(0), ExitAlreadySet());
         require(_isTokenAdminOrOwner(_token, _msgSender()), NotTokenAdminOrOwner());
+        require(address(_exit.token()) == address(_token), ExitTokenMismatch());
         exits[_token] = _exit;
         emit ExitSet(_token, _exit);
     }

--- a/test/CoinvestedPositionExit.t.sol
+++ b/test/CoinvestedPositionExit.t.sol
@@ -16,9 +16,11 @@ import "./resources/FixedPayoutExit.sol";
 
 /// @dev Minimal IExit stub: claim() does nothing. Currency is configurable at construction.
 contract NoOpExit {
+    address public token;
     IERC20 private _currency;
 
-    constructor(IERC20 currency_) {
+    constructor(address token_, IERC20 currency_) {
+        token = token_;
         _currency = currency_;
     }
 
@@ -1062,7 +1064,7 @@ contract CoinvestedPositionExitTest is Test {
         vm.prank(ADMIN);
         allowList.set(address(token), TRUSTED_CURRENCY);
 
-        NoOpExit noOpExit = new NoOpExit(IERC20(address(token)));
+        NoOpExit noOpExit = new NoOpExit(address(token), IERC20(address(token)));
 
         vm.prank(ADMIN);
         tokenExitRegistry.setExit(token, Exit(address(noOpExit)));
@@ -1106,7 +1108,7 @@ contract CoinvestedPositionExitTest is Test {
     function testXIII_BalanceDiffAcceptsExactMinimum() public {
         uint256 minCurrencyAmount = 1e6;
         eurc.mint(address(this), minCurrencyAmount);
-        FixedPayoutExit stub = new FixedPayoutExit(IERC20(address(eurc)), minCurrencyAmount);
+        FixedPayoutExit stub = new FixedPayoutExit(address(token), IERC20(address(eurc)), minCurrencyAmount);
         IERC20(address(eurc)).transfer(address(stub), minCurrencyAmount);
         vm.prank(ADMIN);
         tokenExitRegistry.setExit(token, Exit(address(stub)));

--- a/test/GlobalTokenExitRegistry.t.sol
+++ b/test/GlobalTokenExitRegistry.t.sol
@@ -170,11 +170,7 @@ contract GlobalTokenExitRegistryTest is Test {
         vm.prank(ADMIN);
         registry.setExit(Token(address(ownableToken)), Exit(address(exitStub)));
 
-        assertEq(
-            address(registry.exits(Token(address(ownableToken)))),
-            address(exitStub),
-            "exit not set via owner()"
-        );
+        assertEq(address(registry.exits(Token(address(ownableToken)))), address(exitStub), "exit not set via owner()");
     }
 
     function testSetExitRevertsForNonOwnerOfOwnableToken() public {

--- a/test/GlobalTokenExitRegistry.t.sol
+++ b/test/GlobalTokenExitRegistry.t.sol
@@ -4,11 +4,13 @@ pragma solidity 0.8.34;
 import "../lib/forge-std/src/Test.sol";
 
 import "../contracts/factories/TokenProxyFactory.sol";
+import "../contracts/factories/ExitCloneFactory.sol";
 import "../contracts/GlobalTokenExitRegistry.sol";
 import "../contracts/Exit.sol";
 import "../contracts/Token.sol";
 import "./resources/CloneCreators.sol";
 import "./resources/FakePaymentToken.sol";
+import "./resources/FixedPayoutExit.sol";
 
 /// @dev Minimal Ownable token stub — has owner() but no AccessControl
 contract FakeOwnableToken {
@@ -36,6 +38,8 @@ contract GlobalTokenExitRegistryTest is Test {
     IFeeSettingsV2 feeSettings;
     Token token;
     TokenProxyFactory tokenFactory;
+    FakePaymentToken currency;
+    ExitCloneFactory exitFactory;
     GlobalTokenExitRegistry registry;
 
     function setUp() public {
@@ -48,7 +52,27 @@ contract GlobalTokenExitRegistryTest is Test {
             tokenFactory.createTokenProxy(0, TRUSTED_FORWARDER, feeSettings, ADMIN, allowList, 0, "TestToken", "TTK")
         );
 
+        currency = new FakePaymentToken(0, 6);
+        vm.prank(ADMIN);
+        allowList.set(address(currency), TRUSTED_CURRENCY);
+
+        exitFactory = new ExitCloneFactory(address(new Exit(TRUSTED_FORWARDER)));
+
         registry = new GlobalTokenExitRegistry(TRUSTED_FORWARDER);
+    }
+
+    /// @dev Deploys a real Exit clone for `_exitToken` using a zero initial funding amount.
+    function _createExit(Token _exitToken, bytes32 salt) internal returns (Exit) {
+        ExitInitializerArguments memory args = ExitInitializerArguments({
+            owner: ADMIN,
+            token: _exitToken,
+            currency: IERC20(address(currency)),
+            pricePerToken: 2e6,
+            lockedUntil: uint64(block.timestamp + 1),
+            referenceCurrencies: new IERC20[](0),
+            referenceToExitRates: new uint256[](0)
+        });
+        return Exit(exitFactory.createExitClone(salt, TRUSTED_FORWARDER, address(this), args, 0));
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -80,14 +104,14 @@ contract GlobalTokenExitRegistryTest is Test {
     // ─────────────────────────────────────────────────────────────────────────
 
     function testSetExitHappyPath() public {
-        address fakeExit = makeAddr("fakeExit");
+        Exit realExit = _createExit(token, 0);
 
         vm.prank(ADMIN);
         vm.expectEmit(true, true, false, false, address(registry));
-        emit GlobalTokenExitRegistry.ExitSet(token, Exit(address(fakeExit)));
-        registry.setExit(token, Exit(address(fakeExit)));
+        emit GlobalTokenExitRegistry.ExitSet(token, realExit);
+        registry.setExit(token, realExit);
 
-        assertEq(address(registry.exits(token)), address(fakeExit), "exit not set correctly");
+        assertEq(address(registry.exits(token)), address(realExit), "exit not set correctly");
     }
 
     function testSetExitRevertsIfCallerIsNotTokenAdmin() public {
@@ -113,11 +137,11 @@ contract GlobalTokenExitRegistryTest is Test {
     }
 
     function testSetExitRevertsIfAlreadySet() public {
-        address fakeExit1 = makeAddr("fakeExit1");
+        Exit realExit = _createExit(token, 0);
         address fakeExit2 = makeAddr("fakeExit2");
 
         vm.prank(ADMIN);
-        registry.setExit(token, Exit(address(fakeExit1)));
+        registry.setExit(token, realExit);
 
         vm.prank(ADMIN);
         vm.expectRevert(GlobalTokenExitRegistry.ExitAlreadySet.selector);
@@ -125,7 +149,7 @@ contract GlobalTokenExitRegistryTest is Test {
     }
 
     function testSetExitOnlyCallableByRoleHolder() public {
-        address fakeExit = makeAddr("fakeExit");
+        Exit realExit = _createExit(token, 0);
 
         // Grant DEFAULT_ADMIN_ROLE to NON_ADMIN
         bytes32 defaultAdminRole = token.DEFAULT_ADMIN_ROLE();
@@ -134,29 +158,32 @@ contract GlobalTokenExitRegistryTest is Test {
 
         // Now NON_ADMIN can set exit
         vm.prank(NON_ADMIN);
-        registry.setExit(token, Exit(address(fakeExit)));
+        registry.setExit(token, realExit);
 
-        assertEq(address(registry.exits(token)), address(fakeExit), "exit not set by new ADMIN");
+        assertEq(address(registry.exits(token)), address(realExit), "exit not set by new ADMIN");
     }
 
     function testSetExitViaTokenOwner() public {
         FakeOwnableToken ownableToken = new FakeOwnableToken(ADMIN);
-        address fakeExit = makeAddr("fakeExit");
+        FixedPayoutExit exitStub = new FixedPayoutExit(address(ownableToken), IERC20(address(currency)), 0);
 
-        // ADMIN is the owner() of ownableToken — should be allowed
         vm.prank(ADMIN);
-        registry.setExit(Token(address(ownableToken)), Exit(address(fakeExit)));
+        registry.setExit(Token(address(ownableToken)), Exit(address(exitStub)));
 
-        assertEq(address(registry.exits(Token(address(ownableToken)))), address(fakeExit), "exit not set via owner()");
+        assertEq(
+            address(registry.exits(Token(address(ownableToken)))),
+            address(exitStub),
+            "exit not set via owner()"
+        );
     }
 
     function testSetExitRevertsForNonOwnerOfOwnableToken() public {
         FakeOwnableToken ownableToken = new FakeOwnableToken(ADMIN);
-        address fakeExit = makeAddr("fakeExit");
+        FixedPayoutExit exitStub = new FixedPayoutExit(address(ownableToken), IERC20(address(currency)), 0);
 
         vm.prank(NON_ADMIN);
         vm.expectRevert(GlobalTokenExitRegistry.NotTokenAdminOrOwner.selector);
-        registry.setExit(Token(address(ownableToken)), Exit(address(fakeExit)));
+        registry.setExit(Token(address(ownableToken)), Exit(address(exitStub)));
     }
 
     function testSetExitIndependentPerToken() public {
@@ -172,17 +199,42 @@ contract GlobalTokenExitRegistryTest is Test {
                 "TT2"
             )
         );
-        address fakeExit1 = makeAddr("fakeExit1");
-        address fakeExit2 = makeAddr("fakeExit2");
+        Exit exit1 = _createExit(token, 0);
+        Exit exit2 = _createExit(token2, 0);
 
         vm.prank(ADMIN);
-        registry.setExit(token, Exit(address(fakeExit1)));
+        registry.setExit(token, exit1);
 
         vm.prank(ADMIN);
-        registry.setExit(token2, Exit(address(fakeExit2)));
+        registry.setExit(token2, exit2);
 
-        assertEq(address(registry.exits(token)), address(fakeExit1), "token1 exit wrong");
-        assertEq(address(registry.exits(token2)), address(fakeExit2), "token2 exit wrong");
+        assertEq(address(registry.exits(token)), address(exit1), "token1 exit wrong");
+        assertEq(address(registry.exits(token2)), address(exit2), "token2 exit wrong");
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // ── Token mismatch validation ─────────────────────────────────────────────
+    // ─────────────────────────────────────────────────────────────────────────
+
+    function testSetExitRevertsIfExitTokenMismatch() public {
+        Token otherToken = Token(
+            tokenFactory.createTokenProxy(
+                bytes32(uint256(1)),
+                TRUSTED_FORWARDER,
+                feeSettings,
+                ADMIN,
+                allowList,
+                0,
+                "OtherToken",
+                "OTK"
+            )
+        );
+        // Exit is initialized for otherToken, not for `token`
+        Exit exitForOtherToken = _createExit(otherToken, 0);
+
+        vm.prank(ADMIN);
+        vm.expectRevert(GlobalTokenExitRegistry.ExitTokenMismatch.selector);
+        registry.setExit(token, exitForOtherToken);
     }
 
     // ─────────────────────────────────────────────────────────────────────────
@@ -205,15 +257,15 @@ contract GlobalTokenExitRegistryTest is Test {
     /// Admin calling setExit through the trusted forwarder (ADMIN address appended to calldata)
     /// must succeed: _msgSender() resolves to ADMIN, not the forwarder.
     function testSetExitViaERC2771TrustedForwarder() public {
-        address fakeExit = makeAddr("fakeExit");
+        Exit realExit = _createExit(token, 0);
         bytes memory callData = abi.encodePacked(
-            abi.encodeWithSelector(GlobalTokenExitRegistry.setExit.selector, token, Exit(address(fakeExit))),
+            abi.encodeWithSelector(GlobalTokenExitRegistry.setExit.selector, token, realExit),
             ADMIN
         );
         vm.prank(TRUSTED_FORWARDER);
         (bool success, ) = address(registry).call(callData);
         assertTrue(success, "setExit via trusted forwarder failed");
-        assertEq(address(registry.exits(token)), address(fakeExit), "exit not set via ERC2771");
+        assertEq(address(registry.exits(token)), address(realExit), "exit not set via ERC2771");
     }
 
     /// An untrusted forwarder appending ADMIN's address must NOT be treated as ADMIN:

--- a/test/TimeLockDistributeExit.t.sol
+++ b/test/TimeLockDistributeExit.t.sol
@@ -224,7 +224,7 @@ contract TimeLockDistributeExitTest is Test {
     function testClaimExitSucceedsWhenReceivedEqualsMinPayout() public {
         uint256 minPayout = 1e6;
         eurc.mint(address(this), minPayout);
-        FixedPayoutExit stub = new FixedPayoutExit(IERC20(address(eurc)), minPayout);
+        FixedPayoutExit stub = new FixedPayoutExit(address(token), IERC20(address(eurc)), minPayout);
         IERC20(address(eurc)).transfer(address(stub), minPayout);
         vm.prank(ADMIN);
         tokenExitRegistry.setExit(token, Exit(address(stub)));

--- a/test/resources/FixedPayoutExit.sol
+++ b/test/resources/FixedPayoutExit.sol
@@ -6,10 +6,12 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 /// @dev Stub IExit: claim() pays a fixed amount to _recipient, ignoring _minPayout.
 /// Lets tests trigger the caller's own balance-diff check independently of Exit's.
 contract FixedPayoutExit {
+    address public token;
     IERC20 public currency;
     uint256 public payout;
 
-    constructor(IERC20 _currency, uint256 _payout) {
+    constructor(address _token, IERC20 _currency, uint256 _payout) {
+        token = _token;
         currency = _currency;
         payout = _payout;
     }


### PR DESCRIPTION
## Finding

**ID:** F-2026-16606  
**Severity:** Low  
**Contract:** `GlobalTokenExitRegistry.sol`

## Description

`GlobalTokenExitRegistry.setExit()` registered an `Exit` contract for a given `Token` without verifying that `_exit.token() == _token`. An `Exit` instance initialized for a different token could be permanently registered for the wrong token entry. Since the registry mapping is immutable after the first assignment (`ExitAlreadySet` guard), a misregistration permanently breaks the exit-claim path for `TimeLock.claimExit()` and `CoinvestedPosition.claimExit()`.

## Remediation applied

Added `require(address(_exit.token()) == address(_token), ExitTokenMismatch())` in `setExit()` before persisting the registry entry.

## Changes

- `contracts/GlobalTokenExitRegistry.sol` — new `ExitTokenMismatch` error + validation require
- `test/GlobalTokenExitRegistry.t.sol` — replaced fake-address exits with real `Exit` clones; added `testSetExitRevertsIfExitTokenMismatch`; updated ownable-token tests to use `FixedPayoutExit`
- `test/resources/FixedPayoutExit.sol` — added `address public token` field and constructor param so the stub satisfies the new validation
- `test/CoinvestedPositionExit.t.sol` — updated `NoOpExit` stub and its constructor call site
- `test/TimeLockDistributeExit.t.sol` — updated `FixedPayoutExit` constructor call site

Closes https://github.com/corpus-io/tokenize.it-smart-contracts/issues/428