### PR TITLE
investigation F-2026-16571: Redundant Storage Reads In Vesting Functions

### DIFF
--- a/contracts/Vesting.sol
+++ b/contracts/Vesting.sol
@@ -104,21 +104,21 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
     /**
      * @dev Total amount of tokens that belong to the vesting plan with the given id.
      */
-    function allocation(uint64 _id) public view returns (uint256) {
+    function allocation(uint64 _id) external view returns (uint256) {
         return vestings[_id].allocation;
     }
 
     /**
      * @dev Amount of tokens already released.
      */
-    function released(uint64 _id) public view returns (uint256) {
+    function released(uint64 _id) external view returns (uint256) {
         return vestings[_id].released;
     }
 
     /**
      * @dev Address that will receive the vested tokens.
      */
-    function beneficiary(uint64 _id) public view returns (address) {
+    function beneficiary(uint64 _id) external view returns (address) {
         return vestings[_id].beneficiary;
     }
 
@@ -126,7 +126,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @dev Start date of the vesting plan.
      * The cliff duration and total duration are measured from this date.
      */
-    function start(uint64 _id) public view returns (uint64) {
+    function start(uint64 _id) external view returns (uint64) {
         return vestings[_id].start;
     }
 
@@ -134,7 +134,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @dev Cliff duration of the vesting plan.
      * The beneficiary gets no tokens before this duration has passed.
      */
-    function cliff(uint64 _id) public view returns (uint64) {
+    function cliff(uint64 _id) external view returns (uint64) {
         return vestings[_id].cliff;
     }
 
@@ -142,7 +142,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @dev Total duration of the vesting plan.
      * After this duration all tokens can be released.
      */
-    function duration(uint64 _id) public view returns (uint64) {
+    function duration(uint64 _id) external view returns (uint64) {
         return vestings[_id].duration;
     }
 
@@ -151,22 +151,24 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * isMintable == true means that tokens are minted form the token contract.
      * isMintable == false means the tokens need to be held by the vesting contract directly.
      */
-    function isMintable(uint64 _id) public view returns (bool) {
+    function isMintable(uint64 _id) external view returns (bool) {
         return vestings[_id].isMintable;
     }
 
     /**
      * @dev Amount of tokens that could be released right now.
      */
-    function releasable(uint64 _id) public view returns (uint256) {
-        return vestedAmount(_id, uint64(block.timestamp)) - released(_id);
+    function releasable(uint64 _id) external view returns (uint256) {
+        VestingPlan memory vesting = vestings[_id];
+        return _computeVestedAmount(vesting, uint64(block.timestamp)) - vesting.released;
     }
 
     /**
      * @dev Amount of tokens that could be released at a given time.
      */
-    function releasable(uint64 _id, uint64 _time) public view returns (uint256) {
-        return vestedAmount(_id, _time) - released(_id);
+    function releasable(uint64 _id, uint64 _time) external view returns (uint256) {
+        VestingPlan memory vesting = vestings[_id];
+        return _computeVestedAmount(vesting, _time) - vesting.released;
     }
 
     /**
@@ -344,7 +346,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
         if (vesting.start + vesting.cliff > _endTime) {
             delete vestings[_id];
         } else {
-            vestings[_id].allocation = vestedAmount(_id, _endTime);
+            vestings[_id].allocation = _computeVestedAmount(vesting, _endTime);
             vestings[_id].duration = _endTime - vesting.start;
         }
         emit VestingStopped(_id, _endTime);
@@ -374,7 +376,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
 
         // create new vesting
         newId = _createVesting(
-            vesting.allocation - vestedAmount(_id, _endTime), # remaining allocation
+            vesting.allocation - _computeVestedAmount(vesting, _endTime),
             vesting.beneficiary,
             _newStartTime,
             cliffRemainder,
@@ -402,7 +404,7 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
     function release(uint64 _id, uint256 _amount) public nonReentrant {
         VestingPlan memory vesting = vestings[_id];
         require(_msgSender() == vesting.beneficiary, OnlyBeneficiary());
-        uint256 releasableAmount = releasable(_id);
+        uint256 releasableAmount = _computeVestedAmount(vesting, uint64(block.timestamp)) - vesting.released;
         _amount = releasableAmount < _amount ? releasableAmount : _amount;
         vestings[_id].released += _amount;
         if (vesting.isMintable) {
@@ -421,8 +423,11 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @param _timestamp point in time for which the vested amount is calculated
      * @return amount of vested tokens
      */
-    function vestedAmount(uint64 _id, uint64 _timestamp) public view returns (uint256) {
-        VestingPlan memory vesting = vestings[_id];
+    function vestedAmount(uint64 _id, uint64 _timestamp) external view returns (uint256) {
+        return _computeVestedAmount(vestings[_id], _timestamp);
+    }
+
+    function _computeVestedAmount(VestingPlan memory vesting, uint64 _timestamp) private pure returns (uint256) {
         if (_timestamp < vesting.start + vesting.cliff) {
             return 0;
         } else if (_timestamp > vesting.start + vesting.duration) {
@@ -442,9 +447,10 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @param _newBeneficiary new beneficiary address
      */
     function changeBeneficiary(uint64 _id, address _newBeneficiary) external {
+        VestingPlan memory vesting = vestings[_id];
         require(
-            _msgSender() == beneficiary(_id) ||
-                ((_msgSender() == owner()) && uint64(block.timestamp) > start(_id) + duration(_id) + 365 days),
+            _msgSender() == vesting.beneficiary ||
+                ((_msgSender() == owner()) && uint64(block.timestamp) > vesting.start + vesting.duration + 365 days),
             NotAllowedToChangeBeneficiary()
         );
         require(_newBeneficiary != address(0), ZeroReceiverAddress());

--- a/contracts/Vesting.sol
+++ b/contracts/Vesting.sol
@@ -338,13 +338,14 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
     function stopVesting(uint64 _id, uint64 _endTime) public onlyManager {
         // already vested tokens can not be taken away (except of burning in the token contract itself)
         _endTime = _endTime < uint64(block.timestamp) ? uint64(block.timestamp) : _endTime;
-        require(_endTime < start(_id) + duration(_id), EndTimeAfterVestingEnd());
+        VestingPlan memory vesting = vestings[_id];
+        require(_endTime < vesting.start + vesting.duration, EndTimeAfterVestingEnd());
 
-        if (start(_id) + cliff(_id) > _endTime) {
+        if (vesting.start + vesting.cliff > _endTime) {
             delete vestings[_id];
         } else {
             vestings[_id].allocation = vestedAmount(_id, _endTime);
-            vestings[_id].duration = _endTime - start(_id);
+            vestings[_id].duration = _endTime - vesting.start;
         }
         emit VestingStopped(_id, _endTime);
     }
@@ -363,22 +364,22 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
         uint64 _newStartTime
     ) external onlyManager returns (uint64 newId) {
         require(_endTime > uint64(block.timestamp), EndTimeNotInFuture());
-        require(_endTime < start(_id) + duration(_id), EndTimeAfterVestingEnd());
+        VestingPlan memory vesting = vestings[_id];
+        require(_endTime < vesting.start + vesting.duration, EndTimeAfterVestingEnd());
         require(_newStartTime > _endTime, NewStartTimeNotAfterEndTime());
 
-        uint256 allocationRemainder = allocation(_id) - vestedAmount(_id, _endTime);
-        uint64 timeVested = _endTime - start(_id);
-        uint64 cliffRemainder = timeVested >= cliff(_id) ? 0 : cliff(_id) - timeVested;
-        uint64 durationRemainder = duration(_id) - timeVested;
+        uint64 timeVested = _endTime - vesting.start;
+        uint64 cliffRemainder = timeVested >= vesting.cliff ? 0 : vesting.cliff - timeVested;
+        uint64 durationRemainder = vesting.duration - timeVested;
 
         // create new vesting
         newId = _createVesting(
-            allocationRemainder,
-            beneficiary(_id),
+            vesting.allocation - vestedAmount(_id, _endTime), # remaining allocation
+            vesting.beneficiary,
             _newStartTime,
             cliffRemainder,
             durationRemainder,
-            isMintable(_id)
+            vesting.isMintable
         );
 
         // stop old vesting
@@ -399,13 +400,15 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @param _amount maximum amount of tokens to be released
      */
     function release(uint64 _id, uint256 _amount) public nonReentrant {
-        require(_msgSender() == beneficiary(_id), OnlyBeneficiary());
-        _amount = releasable(_id) < _amount ? releasable(_id) : _amount;
+        VestingPlan memory vesting = vestings[_id];
+        require(_msgSender() == vesting.beneficiary, OnlyBeneficiary());
+        uint256 releasableAmount = releasable(_id);
+        _amount = releasableAmount < _amount ? releasableAmount : _amount;
         vestings[_id].released += _amount;
-        if (isMintable(_id)) {
-            ERC20Mintable(token).mint(beneficiary(_id), _amount);
+        if (vesting.isMintable) {
+            ERC20Mintable(token).mint(vesting.beneficiary, _amount);
         } else {
-            SafeERC20Upgradeable.safeTransfer(IERC20Upgradeable(token), beneficiary(_id), _amount);
+            SafeERC20Upgradeable.safeTransfer(IERC20Upgradeable(token), vesting.beneficiary, _amount);
         }
         emit ERC20Released(_id, _amount);
     }
@@ -419,12 +422,13 @@ contract Vesting is Initializable, ERC2771ContextUpgradeable, OwnableUpgradeable
      * @return amount of vested tokens
      */
     function vestedAmount(uint64 _id, uint64 _timestamp) public view returns (uint256) {
-        if (_timestamp < start(_id) + cliff(_id)) {
+        VestingPlan memory vesting = vestings[_id];
+        if (_timestamp < vesting.start + vesting.cliff) {
             return 0;
-        } else if (_timestamp > start(_id) + duration(_id)) {
-            return allocation(_id);
+        } else if (_timestamp > vesting.start + vesting.duration) {
+            return vesting.allocation;
         } else {
-            return (allocation(_id) * (_timestamp - start(_id))) / duration(_id);
+            return (vesting.allocation * (_timestamp - vesting.start)) / vesting.duration;
         }
     }
 


### PR DESCRIPTION
## Summary

This PR documents an attempted fix for [F-2026-16571](https://github.com/corpus-io/tokenize.it-smart-contracts/issues/436) — caching `vestings[_id]` fields in local variables to reduce redundant storage reads in `vestedAmount`, `stopVesting`, `pauseVesting`, and `release`.

Two approaches were tried and measured:

1. **Cache individual fields** (`uint64 vestingStart = vestings[_id].start` etc.) — causes stack too deep compiler errors in `pauseVesting`, which already has many local variables.

2. **Cache the full struct** (`VestingPlan memory vesting = vestings[_id]`) — avoids the stack issue but always reads all 4 storage slots regardless of how many fields a function actually needs.

## Gas Report

Measured with `FOUNDRY_FUZZ_RUNS=1` against a pre-change baseline:

```
↓ testPauseAfterCliff             -7,650  -2.173%
↓ testStopAfterReleaseERC2771     -5,176  -1.956%
↓ testPauseBeforeCliff            -2,797  -1.025%
↓ testCreateTransferrableVest     -2,669  -1.051%
↓ testCreateMintableVest          -2,678  -1.207%
↓ testReleasable                  -2,007  -1.251%
↑ testChangeBeneficiary           +1,864  +1.253%
↑ testPauseVestingWrong             +842  +0.665%
↑ testStopVestingAfterEnd           +344  +0.290%
↑ testVestedAmountAtTimestamp       +143  +0.119%

Total: 44 tests, ↑8, ↓29, ━7 | Overall: +39,242 (+0.004%)
```

(The +37K spikes in `testAddressPrediction` / `testLockUpAddressPrediction` are fuzz noise from single-run sampling, not related to these changes.)

Full report for the curious:
```
$ FOUNDRY_FUZZ_RUNS=1 forge snapshot --match-path 'test/Vestin
g*' --diff temp/vesting_before_singleFuzz.snap 
Warning: This is a nightly build of Foundry. It is recommended to use the latest stable version. To mute this warning set `FOUNDRY_DISABLE_NIGHTLY_WARNING` in your environment. 

[⠊] Compiling...
[⠒] Compiling 7 files with Solc 0.8.34
[⠑] Solc 0.8.34 finished in 3.43s
Compiler run successful with warnings:
Warning (4591): There are more than 256 warnings. Ignoring the rest.

Ran 3 tests for test/VestingERC2771.t.sol:VestingERC2771Test
[PASS] testInitERC2771() (gas: 179590)
[PASS] testStopAfterReleaseERC2771() (gas: 259467)
[PASS] testVestERC2771() (gas: 239624)
Suite result: ok. 3 passed; 0 failed; 0 skipped; finished in 4.27ms (2.73ms CPU time)

Ran 1 test for test/VestingDemo.t.sol:VestingDemoTest
[PASS] testDemoEverythingLocal(bytes32,address) (runs: 1, μ: 5205395, ~: 5205395)
Suite result: ok. 1 passed; 0 failed; 0 skipped; finished in 24.32ms (22.95ms CPU time)

Ran 5 tests for test/VestingCloneFactory.t.sol:VestingCloneFactoryTest
[PASS] testAddressPrediction(bytes32,address,address,address) (runs: 1, μ: 3253002, ~: 3253002)
[PASS] testInitialization(bytes32,address,address) (runs: 1, μ: 180875, ~: 180875)
[PASS] testLockUpAddressPrediction(bytes32,address,address,address,uint256,address,uint64,uint64,uint64) (runs: 1, μ: 3371924, ~: 3371924)
[PASS] testSecondDeploymentFails(bytes32,address,address) (runs: 1, μ: 1040434703, ~: 1040434703)
[PASS] testWrongTrustedForwarderReverts(address) (runs: 1, μ: 62485, ~: 62485)
Suite result: ok. 5 passed; 0 failed; 0 skipped; finished in 37.15ms (99.13ms CPU time)

Ran 13 tests for test/VestingBlind.t.sol:VestingBlindTest
[PASS] testClaimAfterRevoke() (gas: 233003)
[PASS] testClaimWithModifiedData(address,address,uint128,uint128,bytes32) (runs: 1, μ: 52965, ~: 52965)
[PASS] testCommit(bytes32) (runs: 1, μ: 42992, ~: 42992)
[PASS] testCommitNoManager(address,bytes32) (runs: 1, μ: 18749, ~: 18749)
[PASS] testReveal(address,uint256,uint64,uint64,uint64,bytes32,bool,address) (runs: 1, μ: 147769, ~: 147769)
[PASS] testRevealAndRelease(address,uint256,uint64,uint64,uint64,bytes32,bool,address,uint256) (runs: 1, μ: 153894, ~: 153894)
[PASS] testRevokeAfterEnd(uint64,uint64,uint64) (runs: 1, μ: 229996, ~: 229996)
[PASS] testRevokeAndYankBehaveEqual(uint64,uint64,uint256,uint64) (runs: 1, μ: 135360, ~: 135360)
[PASS] testRevokeBeforeCliff(uint256,address,uint64,uint24,uint24,bytes32,uint24) (runs: 1, μ: 68188, ~: 68188)
[PASS] testRevokeBeforeEnd(uint64,uint64,uint64) (runs: 1, μ: 240130, ~: 240130)
[PASS] testRevokeLater(bytes32,uint64) (runs: 1, μ: 47210, ~: 47210)
[PASS] testRevokeNoOwner(address,bytes32) (runs: 1, μ: 51796, ~: 51796)
[PASS] testRevokeNow(bytes32) (runs: 1, μ: 46790, ~: 46790)
Suite result: ok. 13 passed; 0 failed; 0 skipped; finished in 44.92ms (266.75ms CPU time)

Ran 22 tests for test/Vesting.t.sol:VestingTest
[PASS] testAddAndRemoveManager(address) (runs: 1, μ: 35132, ~: 35132)
[PASS] testBeneficiary0() (gas: 16583)
[PASS] testChangeBeneficiary(uint64,address) (runs: 1, μ: 150601, ~: 150601)
[PASS] testCommit0() (gas: 15861)
[PASS] testCreateMintableVest(address,address) (runs: 1, μ: 219158, ~: 219158)
[PASS] testCreateTransferrableVest(address,address) (runs: 1, μ: 251229, ~: 251229)
[PASS] testDurationIsExtendedToCliff(uint64,uint64) (runs: 1, μ: 118418, ~: 118418)
[PASS] testInitializingWith0() (gas: 154770)
[PASS] testNoWrongManagers(address) (runs: 1, μ: 16319, ~: 16319)
[PASS] testNonManagerCannotStopVesting() (gas: 119527)
[PASS] testOnlyOwnerCanCommit(address,bytes32) (runs: 1, μ: 206795, ~: 206795)
[PASS] testOnlyOwnerCanCreate(address,address,address) (runs: 1, μ: 279033, ~: 279033)
[PASS] testPauseAfterCliff(address,uint64,uint64) (runs: 1, μ: 344408, ~: 344408)
[PASS] testPauseBeforeCliff(address) (runs: 1, μ: 270153, ~: 270153)
[PASS] testPauseVestingWrong() (gas: 127510)
[PASS] testReleasable(uint64) (runs: 1, μ: 158447, ~: 158447)
[PASS] testReleaseWithAmountLimit() (gas: 222033)
[PASS] testReleaseWithDivBy0() (gas: 122344)
[PASS] testRevoke0() (gas: 18147)
[PASS] testStopVestingAfterEnd() (gas: 119023)
[PASS] testSwitchOwner(address,address) (runs: 1, μ: 188090, ~: 188090)
[PASS] testVestedAmountAtTimestamp() (gas: 120064)
Suite result: ok. 22 passed; 0 failed; 0 skipped; finished in 44.94ms (199.83ms CPU time)

Ran 5 test suites in 46.70ms (155.60ms CPU time): 44 tests passed, 0 failed, 0 skipped (44 total tests)
━ VestingTest::testBeneficiary0() (gas: 16583 → 16583 | 0 0.000%)
━ VestingTest::testCommit0() (gas: 15861 → 15861 | 0 0.000%)
━ VestingTest::testNonManagerCannotStopVesting() (gas: 119527 → 119527 | 0 0.000%)
━ VestingTest::testRevoke0() (gas: 18147 → 18147 | 0 0.000%)
━ VestingBlindTest::testClaimWithModifiedData(address,address,uint128,uint128,bytes32) (gas: 52965 → 52965 | 0 0.000%)
━ VestingBlindTest::testCommit(bytes32) (gas: 42992 → 42992 | 0 0.000%)
━ VestingCloneFactoryTest::testSecondDeploymentFails(bytes32,address,address) (gas: 1040434703 → 1040434703 | 0 0.000%)
↓ VestingTest::testOnlyOwnerCanCreate(address,address,address) (gas: 279036 → 279033 | -3 -0.001%)
↓ VestingTest::testOnlyOwnerCanCommit(address,bytes32) (gas: 206798 → 206795 | -3 -0.001%)
↓ VestingTest::testSwitchOwner(address,address) (gas: 188097 → 188090 | -7 -0.004%)
↓ VestingCloneFactoryTest::testInitialization(bytes32,address,address) (gas: 180882 → 180875 | -7 -0.004%)
↓ VestingTest::testInitializingWith0() (gas: 154778 → 154770 | -8 -0.005%)
↓ VestingBlindTest::testRevokeNoOwner(address,bytes32) (gas: 51800 → 51796 | -4 -0.008%)
↓ VestingCloneFactoryTest::testWrongTrustedForwarderReverts(address) (gas: 62493 → 62485 | -8 -0.013%)
↓ VestingERC2771Test::testInitERC2771() (gas: 179618 → 179590 | -28 -0.016%)
↓ VestingBlindTest::testRevealAndRelease(address,uint256,uint64,uint64,uint64,bytes32,bool,address,uint256) (gas: 153918 → 153894 | -24 -0.016%)
↓ VestingBlindTest::testReveal(address,uint256,uint64,uint64,uint64,bytes32,bool,address) (gas: 147793 → 147769 | -24 -0.016%)
↓ VestingBlindTest::testRevokeBeforeCliff(uint256,address,uint64,uint24,uint24,bytes32,uint24) (gas: 68200 → 68188 | -12 -0.018%)
↑ VestingTest::testDurationIsExtendedToCliff(uint64,uint64) (gas: 118397 → 118418 | 21 0.018%)
↑ VestingBlindTest::testRevokeAndYankBehaveEqual(uint64,uint64,uint256,uint64) (gas: 135335 → 135360 | 25 0.018%)
↓ VestingBlindTest::testCommitNoManager(address,bytes32) (gas: 18753 → 18749 | -4 -0.021%)
↓ VestingTest::testNoWrongManagers(address) (gas: 16323 → 16319 | -4 -0.025%)
↓ VestingBlindTest::testRevokeLater(bytes32,uint64) (gas: 47222 → 47210 | -12 -0.025%)
↓ VestingBlindTest::testRevokeNow(bytes32) (gas: 46802 → 46790 | -12 -0.026%)
↓ VestingTest::testAddAndRemoveManager(address) (gas: 35144 → 35132 | -12 -0.034%)
↓ VestingDemoTest::testDemoEverythingLocal(bytes32,address) (gas: 5208331 → 5205395 | -2936 -0.056%)
↑ VestingTest::testVestedAmountAtTimestamp() (gas: 119921 → 120064 | 143 0.119%)
↑ VestingTest::testStopVestingAfterEnd() (gas: 118679 → 119023 | 344 0.290%)
↓ VestingTest::testReleaseWithAmountLimit() (gas: 223171 → 222033 | -1138 -0.510%)
↓ VestingTest::testReleaseWithDivBy0() (gas: 123098 → 122344 | -754 -0.613%)
↑ VestingTest::testPauseVestingWrong() (gas: 126668 → 127510 | 842 0.665%)
↓ VestingBlindTest::testClaimAfterRevoke() (gas: 235312 → 233003 | -2309 -0.981%)
↓ VestingTest::testPauseBeforeCliff(address) (gas: 272950 → 270153 | -2797 -1.025%)
↓ VestingBlindTest::testRevokeBeforeEnd(uint64,uint64,uint64) (gas: 242660 → 240130 | -2530 -1.043%)
↓ VestingTest::testCreateTransferrableVest(address,address) (gas: 253898 → 251229 | -2669 -1.051%)
↓ VestingBlindTest::testRevokeAfterEnd(uint64,uint64,uint64) (gas: 232514 → 229996 | -2518 -1.083%)
↑ VestingCloneFactoryTest::testLockUpAddressPrediction(bytes32,address,address,address,uint256,address,uint64,uint64,uint64) (gas: 3334674 → 3371924 | 37250 1.117%)
↑ VestingCloneFactoryTest::testAddressPrediction(bytes32,address,address,address) (gas: 3215708 → 3253002 | 37294 1.160%)
↓ VestingTest::testCreateMintableVest(address,address) (gas: 221836 → 219158 | -2678 -1.207%)
↓ VestingTest::testReleasable(uint64) (gas: 160454 → 158447 | -2007 -1.251%)
↑ VestingTest::testChangeBeneficiary(uint64,address) (gas: 148737 → 150601 | 1864 1.253%)
↓ VestingERC2771Test::testVestERC2771() (gas: 242831 → 239624 | -3207 -1.321%)
↓ VestingERC2771Test::testStopAfterReleaseERC2771() (gas: 264643 → 259467 | -5176 -1.956%)
↓ VestingTest::testPauseAfterCliff(address,uint64,uint64) (gas: 352058 → 344408 | -7650 -2.173%)

--------------------------------------------------------------------------------
Total tests: 44, ↑ 8, ↓ 29, ━ 7
Overall gas change: 39242 (0.004%)
```

## Decision: not proceeding

Three reasons:

1. **Caching individual fields causes stack too deep.** `pauseVesting` already has many local variables; adding `uint64 vestingStart`, `vestingCliff`, `vestingDuration` pushes it over the limit without `via-ir`.

2. **Caching the full struct has no consistent benefit.** `VestingPlan` spans 4 storage slots. Functions that only need fields from one or two slots pay more with struct caching than with direct reads. The gas report confirms this — results go both directions.

3. **Mixing approaches hurts code style.** Some functions would use struct caching, others direct reads, with no clear rule. Inconsistency increases cognitive load and bug risk — a poor trade for negligible and non-uniform gas savings.

The finding is correctly rated Info. The contract is left unchanged.