### PR TITLE
Automated npm releases via CI (trusted publishing)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency: release-${{ github.ref }}
+
+permissions:
+  contents: write # create the GitHub release
+  id-token: write # npm trusted publishing (OIDC)
+
+jobs:
+  release:
+    name: Publish to npm and create GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          registry-url: https://registry.npmjs.org
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Verify tag matches package.json version
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Tag $GITHUB_REF_NAME does not match package.json version $PACKAGE_VERSION"
+            exit 1
+          fi
+
+      - name: Determine dist-tag
+        id: dist-tag
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          case "$VERSION" in
+            *-alpha*) DIST_TAG=alpha ;;
+            *-beta*) DIST_TAG=beta ;;
+            *-*) DIST_TAG=next ;;
+            *) DIST_TAG=latest ;;
+          esac
+          echo "Publishing $VERSION with dist-tag $DIST_TAG"
+          echo "tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Run tests
+        run: yarn test
+
+      - name: Build
+        run: yarn build
+
+      - name: Publish to npm
+        run: npm publish --provenance --tag ${{ steps.dist-tag.outputs.tag }}
+
+      - name: Extract release notes from CHANGELOG.md
+        id: release-notes
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          awk -v version="$VERSION" '
+            $0 ~ "^## \\[" version "\\]" { found=1; next }
+            found && /^## \[/ { exit }
+            found { print }
+          ' CHANGELOG.md > release-notes.md
+          if [ -s release-notes.md ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No CHANGELOG.md section for $VERSION, falling back to generated notes"
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          PRERELEASE_FLAG=""
+          if [ "${{ steps.dist-tag.outputs.tag }}" != "latest" ]; then
+            PRERELEASE_FLAG="--prerelease"
+          fi
+          if [ "${{ steps.release-notes.outputs.found }}" = "true" ]; then
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --notes-file release-notes.md $PRERELEASE_FLAG
+          else
+            gh release create "$GITHUB_REF_NAME" --title "$GITHUB_REF_NAME" --generate-notes $PRERELEASE_FLAG
+          fi

--- a/docs/npm_publishing.md
+++ b/docs/npm_publishing.md
@@ -1,45 +1,46 @@
 # Publishing to npm
 
-The smart contracts are published to npm as a package. The package name is `@tokenizeit/contracts`. This makes it easy to use the contracts in other projects (e.g. in our web app).
+The smart contracts are published to npm as a package. The package name is `@tokenize.it/contracts`. This makes it easy to use the contracts in other projects (e.g. in our web app).
 
-Currently, no automated publishing is set up. Publishing is done manually. To publish a new version, follow these steps:
+Publishing is automated: pushing a version tag triggers the [release workflow](../.github/workflows/release.yml), which runs the tests, builds the artifacts from a fresh checkout, publishes to npm and creates a GitHub release with the notes from the matching `CHANGELOG.md` section.
 
-1. Update version in package.json and create git tag:
+## Releasing a new version
+
+1. Make sure `CHANGELOG.md` has a `## [<newversion>]` section — it becomes the GitHub release notes.
+2. Update the version in package.json and create the git tag:
 
    ```bash
    npm version <newversion>
    ```
 
-   The version number must be a valid semver version. The version number must be higher than the current version number.
+   The version number must be a valid semver version higher than the current one.
 
-2. Build the contracts:
-
-   ```bash
-   yarn build
-   ```
-
-3. Test without publishing:
+3. Push the branch and the tag:
 
    ```bash
-   npm publish [--tag <alpha/beta>] --dry-run
+   git push --follow-tags
    ```
 
-4. Check if all necessary files are contained and no secrets are leaked.
-5. Verify you are logged in to npm as a maintainer of the package:
+That's it. The release workflow takes care of the rest.
 
-   ```bash
-   npm whoami
-   ```
+## Prereleases
 
-   If you are not logged in or the wrong user, run:
+Versions with an `-alpha`/`-beta` suffix (e.g. `7.2.0-beta1`) are published under the `alpha`/`beta` dist-tag and marked as prereleases on GitHub; any other prerelease suffix goes to the `next` dist-tag. Only stable versions are published as `latest`, so `npm install @tokenize.it/contracts` never picks up a preview.
 
-   ```bash
-   npm login
-   ```
+## Authentication
 
-6. If everything is fine, publish:
-   ```bash
-   npm publish [--tag <alpha/beta>]
-   ```
+The workflow authenticates via [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC): npm is configured to accept publishes for this package from the `release.yml` workflow of this repository. There are no npm tokens stored in the repository, and no 2FA one-time passwords are involved. Each publish carries a `--provenance` attestation linking the tarball to the exact commit and workflow run.
 
-Sadly, `yarn publish` did not work at the time of writing. It appeared to have trouble with the 2FA.
+Changing the workflow's file name breaks the trusted-publisher registration — update the npm package settings if `release.yml` is ever renamed.
+
+## Manual publishing (fallback)
+
+If CI is unavailable, a package can still be published by a maintainer:
+
+```bash
+yarn test && yarn build                             # prepack no longer runs tests/build
+npm pack                                            # builds the tarball (verify its contents!)
+npm publish ./tokenize.it-contracts-<version>.tgz [--tag <alpha/beta>]
+```
+
+Run `npm publish` from an interactive terminal — the 2FA browser flow does not work in non-interactive shells. Note that the tarball is packed from the working directory, so untracked files inside `contracts/`, `docs/` etc. would be included: check the file list printed by `npm pack` before publishing.

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@openzeppelin/contracts-upgradeable": "4.9.6"
   },
   "scripts": {
-    "prepack": "yarn npmignore --auto && yarn test && yarn build ",
+    "prepack": "yarn npmignore --auto",
     "build": "yarn clean && yarn hardhat compile && yarn tsc --declaration",
     "test": "forge test --no-match-test Mainnet",
     "test-backwards-compatibility": "make test-backwards-compatibility",


### PR DESCRIPTION
Stacked on #454 (needs its Node 24 bump — trusted publishing requires npm ≥ 11.5, which ships with Node 24).

Implements the CI release flow: pushing a `v*` tag publishes `@tokenize.it/contracts` to npm and creates the GitHub release. A release becomes:

```bash
npm version <newversion>
git push --follow-tags
```

## How it works

- **Auth**: npm trusted publishing (OIDC). No tokens stored in the repo, no 2FA OTPs. Publishes carry `--provenance` attestations linking the tarball to the exact commit and workflow run.
- **Safety**: the workflow fails if the tag doesn't match `package.json`; tests and the full build run against a fresh checkout of the tag, so the tarball contains exactly what's committed — untracked working-directory files can never end up on npm again.
- **Prereleases**: `-alpha*`/`-beta*` versions publish under the `alpha`/`beta` dist-tag, other prerelease suffixes under `next`, and are marked prerelease on GitHub. Only stable versions get `latest`, so `npm install` never resolves to a preview.
- **Release notes** are extracted from the matching `## [x.y.z]` section of CHANGELOG.md (fallback: GitHub's generated notes).
- `prepack` is reduced to `npmignore --auto`; CI runs tests/build as explicit steps. `docs/npm_publishing.md` is rewritten accordingly, including the manual-fallback procedure.

## One-time setup before merging (npm account required)

On npmjs.com → `@tokenize.it/contracts` → Settings → Trusted Publisher: org `corpus-io`, repo `tokenize.it-smart-contracts`, workflow `release.yml` (no environment). Optionally restrict the package's publishing access to trusted publisher only, which revokes the ability of any token or laptop to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BmhG9gFVHiF1XL2AfdAHRr